### PR TITLE
feat(dashboard): settings page — system status + slack workspaces + email identities

### DIFF
--- a/packages/dashboard/app/(dashboard)/settings/page.tsx
+++ b/packages/dashboard/app/(dashboard)/settings/page.tsx
@@ -1,13 +1,22 @@
-import { Settings as SettingsIcon } from "lucide-react";
-
-import { ComingSoon } from "@/components/coming-soon";
+import { EmailIdentities } from "@/components/settings/email-identities";
+import { SlackWorkspaces } from "@/components/settings/slack-workspaces";
+import { SystemStatusCard } from "@/components/settings/system-status";
 
 export default function SettingsPage() {
 	return (
-		<ComingSoon
-			icon={SettingsIcon}
-			title="Settings"
-			body="Slack workspaces, email sender identities, encryption key status, and the admin API token."
-		/>
+		<div className="max-w-3xl">
+			<div className="mb-8">
+				<h1 className="text-2xl font-bold">Settings</h1>
+				<p className="text-white/45 text-sm mt-1">
+					Channel configuration and server state.
+				</p>
+			</div>
+
+			<div className="space-y-10">
+				<SystemStatusCard />
+				<SlackWorkspaces />
+				<EmailIdentities />
+			</div>
+		</div>
 	);
 }

--- a/packages/dashboard/components/settings/email-identities.tsx
+++ b/packages/dashboard/components/settings/email-identities.tsx
@@ -1,0 +1,326 @@
+"use client";
+
+import { Mail, Plus, Trash2, X } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+import {
+	createEmailIdentity,
+	deleteEmailIdentity,
+	fetchEmailIdentities,
+	type CreateEmailIdentityRequest,
+	type EmailIdentity,
+	type EmailTransport,
+} from "@/lib/server";
+import { cn } from "@/lib/utils";
+import { SettingsSection } from "./section";
+
+const TRANSPORTS: EmailTransport[] = ["resend", "smtp", "logging", "noop"];
+
+export function EmailIdentities() {
+	const [identities, setIdentities] = useState<EmailIdentity[] | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const [showForm, setShowForm] = useState(false);
+	const [deletingId, setDeletingId] = useState<string | null>(null);
+
+	const load = useCallback(async () => {
+		try {
+			const list = await fetchEmailIdentities();
+			setIdentities(list);
+			setError(null);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Failed to load");
+		}
+	}, []);
+
+	useEffect(() => {
+		load();
+	}, [load]);
+
+	const handleDelete = async (id: string) => {
+		if (!confirm(`Delete identity "${id}"?`)) return;
+		setDeletingId(id);
+		try {
+			await deleteEmailIdentity(id);
+			await load();
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Delete failed");
+		} finally {
+			setDeletingId(null);
+		}
+	};
+
+	return (
+		<SettingsSection
+			icon={Mail}
+			title="Email sender identities"
+			description={'Per-team sender profiles referenced as notify="email+<id>:user@example.com".'}
+			action={
+				!showForm && (
+					<button
+						type="button"
+						onClick={() => setShowForm(true)}
+						className="inline-flex items-center gap-1.5 px-3 py-1.5 border border-brand/30 text-brand hover:bg-brand/5 rounded-md text-xs font-medium transition-colors"
+					>
+						<Plus size={13} />
+						Add identity
+					</button>
+				)
+			}
+		>
+			{showForm && (
+				<IdentityForm
+					onCancel={() => setShowForm(false)}
+					onSaved={async () => {
+						setShowForm(false);
+						await load();
+					}}
+					onError={setError}
+				/>
+			)}
+
+			{error && (
+				<div className="px-5 py-3 text-red-400 text-xs border-b border-red-400/20 bg-red-400/5">
+					{error}
+				</div>
+			)}
+
+			{identities === null ? (
+				<div className="px-5 py-4 text-white/30 text-xs">Loading…</div>
+			) : identities.length === 0 && !showForm ? (
+				<div className="px-5 py-6 text-center text-white/35 text-sm">
+					No sender identities configured.
+				</div>
+			) : (
+				<ul className="divide-y divide-white/5">
+					{identities.map((i) => (
+						<li
+							key={i.id}
+							className="px-5 py-3 flex items-center justify-between gap-4"
+						>
+							<div className="min-w-0">
+								<div className="text-sm font-medium truncate">
+									{i.display_name}
+								</div>
+								<div className="text-white/40 text-xs truncate">
+									<span className="font-mono">{i.id}</span> ·{" "}
+									{i.from_name ? `${i.from_name} ` : ""}
+									{`<${i.from_email}>`}
+								</div>
+								<div className="flex items-center gap-2 mt-1">
+									<span className="text-[10px] font-mono uppercase tracking-wider text-brand">
+										{i.transport}
+									</span>
+									{i.verified ? (
+										<span className="text-[10px] font-mono text-white/40">
+											verified
+										</span>
+									) : (
+										<span className="text-[10px] font-mono text-yellow-400/70">
+											unverified
+										</span>
+									)}
+								</div>
+							</div>
+							<button
+								type="button"
+								onClick={() => handleDelete(i.id)}
+								disabled={deletingId === i.id}
+								className="flex items-center gap-1.5 text-xs text-red-400/80 hover:text-red-400 disabled:opacity-40 transition-colors px-2 py-1 rounded-md hover:bg-red-400/5"
+							>
+								<Trash2 size={13} />
+								{deletingId === i.id ? "Removing…" : "Delete"}
+							</button>
+						</li>
+					))}
+				</ul>
+			)}
+		</SettingsSection>
+	);
+}
+
+function IdentityForm({
+	onCancel,
+	onSaved,
+	onError,
+}: {
+	onCancel: () => void;
+	onSaved: () => Promise<void>;
+	onError: (msg: string) => void;
+}) {
+	const [id, setId] = useState("");
+	const [displayName, setDisplayName] = useState("");
+	const [fromEmail, setFromEmail] = useState("");
+	const [fromName, setFromName] = useState("");
+	const [replyTo, setReplyTo] = useState("");
+	const [transport, setTransport] = useState<EmailTransport>("logging");
+	const [transportConfigText, setTransportConfigText] = useState("{}");
+	const [submitting, setSubmitting] = useState(false);
+
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
+		setSubmitting(true);
+		try {
+			const config =
+				transportConfigText.trim() === ""
+					? {}
+					: (JSON.parse(transportConfigText) as Record<string, unknown>);
+			const body: CreateEmailIdentityRequest = {
+				id,
+				display_name: displayName,
+				from_email: fromEmail,
+				transport,
+				transport_config: config,
+				...(fromName ? { from_name: fromName } : {}),
+				...(replyTo ? { reply_to: replyTo } : {}),
+			};
+			await createEmailIdentity(body);
+			await onSaved();
+		} catch (err) {
+			onError(err instanceof Error ? err.message : "Create failed");
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
+	return (
+		<form
+			onSubmit={handleSubmit}
+			className="px-5 py-4 border-b border-white/5 bg-white/[0.02]"
+		>
+			<div className="flex items-center justify-between mb-3">
+				<h3 className="text-xs font-semibold text-white/70 uppercase tracking-wider">
+					New identity
+				</h3>
+				<button
+					type="button"
+					onClick={onCancel}
+					className="text-white/40 hover:text-white"
+					aria-label="Cancel"
+				>
+					<X size={14} />
+				</button>
+			</div>
+
+			<div className="grid grid-cols-2 gap-3">
+				<FormField label="ID" hint="URL-safe slug, e.g. acme-prod">
+					<input
+						required
+						value={id}
+						onChange={(e) => setId(e.target.value)}
+						className={inputClass}
+						placeholder="acme-prod"
+					/>
+				</FormField>
+				<FormField label="Display name">
+					<input
+						required
+						value={displayName}
+						onChange={(e) => setDisplayName(e.target.value)}
+						className={inputClass}
+						placeholder="Acme Notifications"
+					/>
+				</FormField>
+				<FormField label="From email">
+					<input
+						required
+						type="email"
+						value={fromEmail}
+						onChange={(e) => setFromEmail(e.target.value)}
+						className={inputClass}
+						placeholder="notifications@acme.com"
+					/>
+				</FormField>
+				<FormField label="From name (optional)">
+					<input
+						value={fromName}
+						onChange={(e) => setFromName(e.target.value)}
+						className={inputClass}
+						placeholder="Acme Tasks"
+					/>
+				</FormField>
+				<FormField label="Reply-to (optional)">
+					<input
+						type="email"
+						value={replyTo}
+						onChange={(e) => setReplyTo(e.target.value)}
+						className={inputClass}
+						placeholder="support@acme.com"
+					/>
+				</FormField>
+				<FormField label="Transport">
+					<select
+						value={transport}
+						onChange={(e) => setTransport(e.target.value as EmailTransport)}
+						className={inputClass}
+					>
+						{TRANSPORTS.map((t) => (
+							<option key={t} value={t}>
+								{t}
+							</option>
+						))}
+					</select>
+				</FormField>
+				<FormField
+					label="Transport config (JSON)"
+					hint={
+						transport === "resend"
+							? '{"api_key": "re_…"}'
+							: transport === "smtp"
+								? '{"host": "smtp.…", "port": 587, "user": "…", "password": "…"}'
+								: "{} for logging / noop"
+					}
+					wide
+				>
+					<textarea
+						value={transportConfigText}
+						onChange={(e) => setTransportConfigText(e.target.value)}
+						rows={3}
+						className={cn(inputClass, "font-mono")}
+					/>
+				</FormField>
+			</div>
+
+			<div className="flex justify-end gap-2 mt-4">
+				<button
+					type="button"
+					onClick={onCancel}
+					className="px-3 py-1.5 text-xs text-white/50 hover:text-white transition-colors"
+				>
+					Cancel
+				</button>
+				<button
+					type="submit"
+					disabled={submitting}
+					className="px-4 py-1.5 bg-brand text-black font-semibold text-xs rounded-md hover:bg-brand/90 disabled:opacity-40 transition-colors"
+				>
+					{submitting ? "Creating…" : "Create identity"}
+				</button>
+			</div>
+		</form>
+	);
+}
+
+const inputClass =
+	"w-full bg-white/5 border border-white/10 rounded-md px-2.5 py-1.5 text-xs placeholder:text-white/20 focus:outline-none focus:border-brand/40";
+
+function FormField({
+	label,
+	children,
+	hint,
+	wide,
+}: {
+	label: string;
+	children: React.ReactNode;
+	hint?: string;
+	wide?: boolean;
+}) {
+	return (
+		<label className={cn("block", wide && "col-span-2")}>
+			<span className="text-[10px] font-medium text-white/50 uppercase tracking-wider mb-1 block">
+				{label}
+			</span>
+			{children}
+			{hint && <span className="text-[10px] text-white/30 mt-1 block">{hint}</span>}
+		</label>
+	);
+}

--- a/packages/dashboard/components/settings/section.tsx
+++ b/packages/dashboard/components/settings/section.tsx
@@ -1,0 +1,57 @@
+import type { LucideIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export function SettingsSection({
+	icon: Icon,
+	title,
+	description,
+	action,
+	children,
+	className,
+}: {
+	icon: LucideIcon;
+	title: string;
+	description?: string;
+	action?: React.ReactNode;
+	children: React.ReactNode;
+	className?: string;
+}) {
+	return (
+		<section className={cn("space-y-3", className)}>
+			<div className="flex items-start justify-between gap-4">
+				<div className="flex items-start gap-3">
+					<div className="w-8 h-8 rounded-md border border-white/10 flex items-center justify-center text-white/50 shrink-0 mt-0.5">
+						<Icon size={16} />
+					</div>
+					<div>
+						<h2 className="text-sm font-semibold">{title}</h2>
+						{description && (
+							<p className="text-white/45 text-xs mt-0.5 max-w-xl">
+								{description}
+							</p>
+						)}
+					</div>
+				</div>
+				{action && <div className="shrink-0">{action}</div>}
+			</div>
+			<div className="border border-white/10 rounded-lg bg-white/[0.015]">
+				{children}
+			</div>
+		</section>
+	);
+}
+
+export function StatusDot({
+	state,
+}: {
+	state: "ok" | "warn" | "off";
+}) {
+	const color =
+		state === "ok"
+			? "bg-brand shadow-[0_0_8px_rgba(0,230,118,0.4)]"
+			: state === "warn"
+				? "bg-yellow-400"
+				: "bg-white/20";
+	return <span className={cn("inline-block w-1.5 h-1.5 rounded-full", color)} />;
+}

--- a/packages/dashboard/components/settings/slack-workspaces.tsx
+++ b/packages/dashboard/components/settings/slack-workspaces.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { ExternalLink, Slack, Trash2 } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+import {
+	fetchSlackInstallations,
+	fetchSystemStatus,
+	uninstallSlackWorkspace,
+	type SlackInstallation,
+	type SystemStatus,
+} from "@/lib/server";
+import { formatRelativeTime } from "@/lib/utils";
+import { SettingsSection } from "./section";
+
+export function SlackWorkspaces() {
+	const [installs, setInstalls] = useState<SlackInstallation[] | null>(null);
+	const [slackMode, setSlackMode] = useState<SystemStatus["slack_mode"] | null>(
+		null,
+	);
+	const [error, setError] = useState<string | null>(null);
+	const [deletingId, setDeletingId] = useState<string | null>(null);
+
+	const load = useCallback(async () => {
+		try {
+			const [list, status] = await Promise.all([
+				fetchSlackInstallations(),
+				fetchSystemStatus(),
+			]);
+			setInstalls(list);
+			setSlackMode(status.slack_mode);
+			setError(null);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Failed to load");
+		}
+	}, []);
+
+	useEffect(() => {
+		load();
+	}, [load]);
+
+	const handleUninstall = async (teamId: string) => {
+		if (!confirm(`Uninstall workspace ${teamId}?`)) return;
+		setDeletingId(teamId);
+		try {
+			await uninstallSlackWorkspace(teamId);
+			await load();
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Uninstall failed");
+		} finally {
+			setDeletingId(null);
+		}
+	};
+
+	const canInstall = slackMode === "multi-workspace";
+
+	return (
+		<SettingsSection
+			icon={Slack}
+			title="Slack workspaces"
+			description={
+				canInstall
+					? "Workspaces that have granted this server a bot token. Uninstall to revoke."
+					: "Multi-workspace OAuth isn't configured. Set SLACK_CLIENT_ID + SLACK_CLIENT_SECRET + SLACK_INSTALL_TOKEN to let teams install from the browser."
+			}
+			action={
+				canInstall ? (
+					<InstallButton />
+				) : slackMode === "single-workspace" ? (
+					<span className="text-xs text-white/40 px-3 py-1.5 border border-white/10 rounded-md">
+						Static bot token mode
+					</span>
+				) : null
+			}
+		>
+			{error ? (
+				<div className="px-5 py-4 text-red-400 text-xs">{error}</div>
+			) : installs === null ? (
+				<div className="px-5 py-4 text-white/30 text-xs">Loading…</div>
+			) : installs.length === 0 ? (
+				<div className="px-5 py-6 text-center text-white/35 text-sm">
+					No workspaces yet.
+				</div>
+			) : (
+				<ul className="divide-y divide-white/5">
+					{installs.map((i) => (
+						<li
+							key={i.team_id}
+							className="px-5 py-3 flex items-center justify-between gap-4"
+						>
+							<div className="min-w-0">
+								<div className="text-sm font-medium truncate">
+									{i.team_name || i.team_id}
+								</div>
+								<div className="text-white/35 text-xs font-mono truncate">
+									{i.team_id} · {i.scopes.split(",").length} scopes · installed{" "}
+									{formatRelativeTime(i.installed_at)}
+								</div>
+							</div>
+							<button
+								type="button"
+								onClick={() => handleUninstall(i.team_id)}
+								disabled={deletingId === i.team_id}
+								className="flex items-center gap-1.5 text-xs text-red-400/80 hover:text-red-400 disabled:opacity-40 transition-colors px-2 py-1 rounded-md hover:bg-red-400/5"
+							>
+								<Trash2 size={13} />
+								{deletingId === i.team_id ? "Removing…" : "Uninstall"}
+							</button>
+						</li>
+					))}
+				</ul>
+			)}
+		</SettingsSection>
+	);
+}
+
+function InstallButton() {
+	// The install endpoint requires ?install_token=X. We don't know the
+	// token (server-side secret), so we link the operator to a page
+	// they can paste the token into — or, more typically, they hit
+	// /api/channels/slack/oauth/start?install_token=… themselves from
+	// the terminal that sourced the env. The button here is a
+	// documentation affordance, not a direct deep link.
+	return (
+		<a
+			href="/api/channels/slack/oauth/start"
+			target="_blank"
+			rel="noopener noreferrer"
+			className="inline-flex items-center gap-1.5 px-3 py-1.5 border border-brand/30 text-brand hover:bg-brand/5 rounded-md text-xs font-medium transition-colors"
+		>
+			<ExternalLink size={13} />
+			Install workspace
+		</a>
+	);
+}

--- a/packages/dashboard/components/settings/system-status.tsx
+++ b/packages/dashboard/components/settings/system-status.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { Server } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { fetchSystemStatus, type SystemStatus } from "@/lib/server";
+import { SettingsSection, StatusDot } from "./section";
+
+export function SystemStatusCard() {
+	const [status, setStatus] = useState<SystemStatus | null>(null);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		fetchSystemStatus()
+			.then(setStatus)
+			.catch((err) =>
+				setError(err instanceof Error ? err.message : "Failed to load status"),
+			);
+	}, []);
+
+	return (
+		<SettingsSection
+			icon={Server}
+			title="System"
+			description="Snapshot of how the server is configured. No secrets — just what's on and what's off."
+		>
+			{error ? (
+				<div className="px-5 py-4 text-red-400 text-xs">{error}</div>
+			) : !status ? (
+				<div className="px-5 py-4 text-white/30 text-xs">Loading…</div>
+			) : (
+				<dl className="divide-y divide-white/5">
+					<Row label="Version" value={status.version} />
+					<Row
+						label="Environment"
+						value={
+							<span className="font-mono">{status.environment}</span>
+						}
+					/>
+					<Row
+						label="Public URL"
+						value={<code className="text-xs">{status.public_url}</code>}
+					/>
+					<Row
+						label="Dashboard auth"
+						value={
+							<ModeBadge
+								on={status.auth_enabled}
+								onText="Password enabled"
+								offText="No password (proxy mode)"
+							/>
+						}
+					/>
+					<Row
+						label="Payload encryption"
+						value={
+							<ModeBadge
+								on={status.payload_encryption_enabled}
+								onText="PAYLOAD_KEY configured"
+								offText="Not configured"
+								warnWhenOff
+							/>
+						}
+					/>
+					<Row
+						label="Admin API token"
+						value={
+							<ModeBadge
+								on={status.admin_token_enabled}
+								onText="Configured"
+								offText="Not configured"
+							/>
+						}
+					/>
+					<Row
+						label="Slack"
+						value={<SlackBadge mode={status.slack_mode} />}
+					/>
+					<Row
+						label="Email transport"
+						value={
+							status.email_transport ? (
+								<span className="font-mono text-brand">
+									{status.email_transport}
+									{status.email_from ? ` · ${status.email_from}` : null}
+								</span>
+							) : (
+								<ModeBadge on={false} onText="" offText="Not configured" />
+							)
+						}
+					/>
+				</dl>
+			)}
+		</SettingsSection>
+	);
+}
+
+function Row({
+	label,
+	value,
+}: {
+	label: string;
+	value: React.ReactNode;
+}) {
+	return (
+		<div className="flex items-center justify-between gap-4 px-5 py-3 text-sm">
+			<dt className="text-white/50 text-xs uppercase tracking-wider">{label}</dt>
+			<dd className="text-right">{value}</dd>
+		</div>
+	);
+}
+
+function ModeBadge({
+	on,
+	onText,
+	offText,
+	warnWhenOff,
+}: {
+	on: boolean;
+	onText: string;
+	offText: string;
+	warnWhenOff?: boolean;
+}) {
+	const state = on ? "ok" : warnWhenOff ? "warn" : "off";
+	return (
+		<span className="inline-flex items-center gap-2 text-xs">
+			<StatusDot state={state} />
+			<span className={on ? "text-fg" : "text-white/40"}>
+				{on ? onText : offText}
+			</span>
+		</span>
+	);
+}
+
+function SlackBadge({ mode }: { mode: string }) {
+	if (mode === "off") {
+		return <ModeBadge on={false} onText="" offText="Not configured" />;
+	}
+	const label =
+		mode === "single-workspace"
+			? "Single workspace (static bot token)"
+			: "Multi-workspace (OAuth)";
+	return (
+		<span className="inline-flex items-center gap-2 text-xs">
+			<StatusDot state="ok" />
+			<span>{label}</span>
+		</span>
+	);
+}

--- a/packages/dashboard/lib/server/email-identities.ts
+++ b/packages/dashboard/lib/server/email-identities.ts
@@ -1,0 +1,53 @@
+/**
+ * Email sender identities — list / create / delete.
+ *
+ * Admin-gated by AWAITHUMANS_ADMIN_API_TOKEN on the server. The
+ * dashboard only sees the public fields (`transport_config` is never
+ * echoed back after create — operators rotate by upserting, not
+ * reading back, to keep credentials out of the API surface).
+ */
+
+import { apiFetch } from "./client";
+
+export type EmailTransport = "resend" | "smtp" | "logging" | "noop";
+
+export interface EmailIdentity {
+	id: string;
+	display_name: string;
+	from_email: string;
+	from_name: string | null;
+	reply_to: string | null;
+	transport: EmailTransport | string;
+	verified: boolean;
+	verified_at: string | null;
+}
+
+export interface CreateEmailIdentityRequest {
+	id: string;
+	display_name: string;
+	from_email: string;
+	from_name?: string;
+	reply_to?: string;
+	transport: EmailTransport;
+	transport_config: Record<string, unknown>;
+}
+
+export async function fetchEmailIdentities(): Promise<EmailIdentity[]> {
+	return apiFetch<EmailIdentity[]>("/api/channels/email/identities");
+}
+
+export async function createEmailIdentity(
+	body: CreateEmailIdentityRequest,
+): Promise<EmailIdentity> {
+	return apiFetch<EmailIdentity>("/api/channels/email/identities", {
+		method: "POST",
+		body: JSON.stringify(body),
+	});
+}
+
+export async function deleteEmailIdentity(id: string): Promise<void> {
+	await apiFetch<void>(
+		`/api/channels/email/identities/${encodeURIComponent(id)}`,
+		{ method: "DELETE" },
+	);
+}

--- a/packages/dashboard/lib/server/index.ts
+++ b/packages/dashboard/lib/server/index.ts
@@ -16,5 +16,19 @@ export type {
 export { fetchAuditTrail } from "./audit";
 export { fetchMe, login, logout, type MeResponse } from "./auth";
 export { apiFetch, UnauthorizedError } from "./client";
+export {
+	createEmailIdentity,
+	deleteEmailIdentity,
+	fetchEmailIdentities,
+	type CreateEmailIdentityRequest,
+	type EmailIdentity,
+	type EmailTransport,
+} from "./email-identities";
 export { fetchHealth } from "./health";
+export {
+	fetchSlackInstallations,
+	uninstallSlackWorkspace,
+	type SlackInstallation,
+} from "./slack";
+export { fetchSystemStatus, type SystemStatus } from "./status";
 export { cancelTask, completeTask, fetchTask, fetchTasks } from "./tasks";

--- a/packages/dashboard/lib/server/slack.ts
+++ b/packages/dashboard/lib/server/slack.ts
@@ -1,0 +1,27 @@
+/**
+ * Slack installations — list + uninstall.
+ */
+
+import { apiFetch } from "./client";
+
+export interface SlackInstallation {
+	team_id: string;
+	team_name: string | null;
+	bot_user_id: string;
+	scopes: string;
+	enterprise_id: string | null;
+	installed_by_user_id: string | null;
+	installed_at: string;
+	updated_at: string;
+}
+
+export async function fetchSlackInstallations(): Promise<SlackInstallation[]> {
+	return apiFetch<SlackInstallation[]>("/api/channels/slack/installations");
+}
+
+export async function uninstallSlackWorkspace(teamId: string): Promise<void> {
+	await apiFetch<void>(
+		`/api/channels/slack/installations/${encodeURIComponent(teamId)}`,
+		{ method: "DELETE" },
+	);
+}

--- a/packages/dashboard/lib/server/status.ts
+++ b/packages/dashboard/lib/server/status.ts
@@ -1,0 +1,21 @@
+/**
+ * System status — diagnostic data for the Settings page.
+ */
+
+import { apiFetch } from "./client";
+
+export interface SystemStatus {
+	version: string;
+	environment: string;
+	public_url: string;
+	auth_enabled: boolean;
+	payload_encryption_enabled: boolean;
+	admin_token_enabled: boolean;
+	slack_mode: "off" | "single-workspace" | "multi-workspace";
+	email_transport: string | null;
+	email_from: string | null;
+}
+
+export async function fetchSystemStatus(): Promise<SystemStatus> {
+	return apiFetch<SystemStatus>("/api/status");
+}

--- a/packages/python/awaithumans/server/app.py
+++ b/packages/python/awaithumans/server/app.py
@@ -22,7 +22,7 @@ from awaithumans.server.core.exceptions import exception_handlers
 from awaithumans.server.core.logging_config import setup_logging
 from awaithumans.server.core.middleware import RequestIDMiddleware
 from awaithumans.server.db.connection import close_db, init_db
-from awaithumans.server.routes import auth, email, health, slack, tasks
+from awaithumans.server.routes import auth, email, health, slack, status, tasks
 from awaithumans.server.services.timeout_scheduler import run_timeout_scheduler
 
 logger = logging.getLogger("awaithumans.server")
@@ -117,6 +117,7 @@ def create_app(*, serve_dashboard: bool = True) -> FastAPI:
 
     # ── Routes ───────────────────────────────────────────────────────
     app.include_router(auth.router, prefix="/api")
+    app.include_router(status.router, prefix="/api")
     app.include_router(tasks.router, prefix="/api")
     app.include_router(health.router, prefix="/api")
     app.include_router(slack.router, prefix="/api")

--- a/packages/python/awaithumans/server/routes/slack/__init__.py
+++ b/packages/python/awaithumans/server/routes/slack/__init__.py
@@ -1,6 +1,6 @@
-"""Slack routes — interactivity webhook + OAuth install flow.
+"""Slack routes — interactivity webhook + OAuth install flow + installations CRUD.
 
-The two sub-routers register handlers on their own `APIRouter` instances
+Each sub-router registers handlers on its own `APIRouter` instance
 (no prefix). This module aggregates them under the shared
 `/channels/slack` prefix and exports the combined `router` for `app.py`.
 """
@@ -9,9 +9,11 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+from awaithumans.server.routes.slack.installations import router as _installations_router
 from awaithumans.server.routes.slack.interactions import router as _interactions_router
 from awaithumans.server.routes.slack.oauth import router as _oauth_router
 
 router = APIRouter(prefix="/channels/slack", tags=["channels"])
 router.include_router(_interactions_router)
 router.include_router(_oauth_router)
+router.include_router(_installations_router)

--- a/packages/python/awaithumans/server/routes/slack/installations.py
+++ b/packages/python/awaithumans/server/routes/slack/installations.py
@@ -1,0 +1,62 @@
+"""Slack installations CRUD — list + uninstall.
+
+Public shape never includes `bot_token` (encrypted, stays server-side).
+Dashboard Settings page lists these and offers per-row uninstall.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Path
+from fastapi.responses import Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from awaithumans.server.db.connection import get_session
+from awaithumans.server.schemas.slack import SlackInstallationResponse
+from awaithumans.server.services.slack_installation_service import (
+    delete_installation,
+    list_installations,
+)
+
+router = APIRouter()
+logger = logging.getLogger("awaithumans.server.routes.slack.installations")
+
+
+def _to_public(row) -> SlackInstallationResponse:
+    return SlackInstallationResponse(
+        team_id=row.team_id,
+        team_name=row.team_name,
+        bot_user_id=row.bot_user_id,
+        scopes=row.scopes,
+        enterprise_id=row.enterprise_id,
+        installed_by_user_id=row.installed_by_user_id,
+        installed_at=row.installed_at.isoformat(),
+        updated_at=row.updated_at.isoformat(),
+    )
+
+
+@router.get("/installations", response_model=list[SlackInstallationResponse])
+async def list_slack_installations(
+    session: AsyncSession = Depends(get_session),
+) -> list[SlackInstallationResponse]:
+    rows = await list_installations(session)
+    return [_to_public(r) for r in rows]
+
+
+@router.delete(
+    "/installations/{team_id}",
+    status_code=204,
+    # Override the default JSONResponse — 204 forbids a response body, and
+    # FastAPI's default response would try to emit one.
+    response_class=Response,
+)
+async def uninstall_slack_workspace(
+    team_id: str = Path(..., min_length=1, max_length=50),
+    session: AsyncSession = Depends(get_session),
+) -> Response:
+    ok = await delete_installation(session, team_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Installation not found.")
+    logger.info("Uninstalled Slack workspace team_id=%s", team_id)
+    return Response(status_code=204)

--- a/packages/python/awaithumans/server/routes/status.py
+++ b/packages/python/awaithumans/server/routes/status.py
@@ -1,0 +1,41 @@
+"""System status route — GET /api/status.
+
+Returns diagnostic data the operator wants visible on the Settings page:
+which channels are configured, whether encryption is on, which mode of
+Slack is active. No secrets, no keys, no passwords ever leave the server.
+
+Gated by the dashboard auth middleware — probes from the public internet
+return 401 when `DASHBOARD_PASSWORD` is set.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from awaithumans.server.core.config import settings
+from awaithumans.server.schemas.status import SystemStatus
+
+router = APIRouter(prefix="/status", tags=["status"])
+
+
+def _slack_mode() -> str:
+    if settings.SLACK_BOT_TOKEN:
+        return "single-workspace"
+    if settings.SLACK_CLIENT_ID and settings.SLACK_CLIENT_SECRET:
+        return "multi-workspace"
+    return "off"
+
+
+@router.get("", response_model=SystemStatus)
+async def get_status() -> SystemStatus:
+    return SystemStatus(
+        version="0.1.0",
+        environment=settings.ENVIRONMENT,
+        public_url=settings.PUBLIC_URL,
+        auth_enabled=bool(settings.DASHBOARD_PASSWORD),
+        payload_encryption_enabled=bool(settings.PAYLOAD_KEY),
+        admin_token_enabled=bool(settings.ADMIN_API_TOKEN),
+        slack_mode=_slack_mode(),
+        email_transport=settings.EMAIL_TRANSPORT,
+        email_from=settings.EMAIL_FROM,
+    )

--- a/packages/python/awaithumans/server/schemas/__init__.py
+++ b/packages/python/awaithumans/server/schemas/__init__.py
@@ -7,6 +7,8 @@ Import schemas from here, not from individual files:
 from awaithumans.server.schemas.audit import AuditEntryResponse
 from awaithumans.server.schemas.email import IdentityCreateRequest, IdentityResponse
 from awaithumans.server.schemas.health import HealthResponse
+from awaithumans.server.schemas.slack import SlackInstallationResponse
+from awaithumans.server.schemas.status import SystemStatus
 from awaithumans.server.schemas.task import (
     CompleteTaskRequest,
     CreateTaskRequest,
@@ -22,5 +24,7 @@ __all__ = [
     "IdentityCreateRequest",
     "IdentityResponse",
     "PollResponse",
+    "SlackInstallationResponse",
+    "SystemStatus",
     "TaskResponse",
 ]

--- a/packages/python/awaithumans/server/schemas/slack.py
+++ b/packages/python/awaithumans/server/schemas/slack.py
@@ -1,0 +1,23 @@
+"""Slack API request/response schemas.
+
+`bot_token` is NEVER part of a response model — it's stored encrypted
+and only read server-side by notifier.py. The public shape only
+carries enough to recognise which workspace an installation is.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class SlackInstallationResponse(BaseModel):
+    team_id: str
+    team_name: str | None
+    bot_user_id: str
+    scopes: str
+    enterprise_id: str | None
+    installed_by_user_id: str | None
+    installed_at: str
+    updated_at: str
+
+    model_config = {"from_attributes": True}

--- a/packages/python/awaithumans/server/schemas/status.py
+++ b/packages/python/awaithumans/server/schemas/status.py
@@ -1,0 +1,28 @@
+"""System status schema — safe-to-display diagnostic data."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class SystemStatus(BaseModel):
+    """Operator-facing server status. No secrets, no keys, no passwords.
+
+    Everything here is either "is X configured" (bool) or "what mode
+    are we in" (enum-like string). The exact values/paths/tokens stay
+    server-side.
+    """
+
+    version: str
+    environment: str
+    public_url: str
+
+    # Auth + crypto
+    auth_enabled: bool
+    payload_encryption_enabled: bool
+    admin_token_enabled: bool
+
+    # Channels — each value is a mode the operator picked. Not the keys.
+    slack_mode: str   # "off" | "single-workspace" | "multi-workspace"
+    email_transport: str | None   # "resend" | "smtp" | "logging" | "noop" | None
+    email_from: str | None

--- a/packages/python/tests/auth/test_status_and_installations.py
+++ b/packages/python/tests/auth/test_status_and_installations.py
@@ -1,0 +1,170 @@
+"""Status + slack installations routes — response shape + auth + secret leakage."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from awaithumans.server.app import create_app
+from awaithumans.server.services.slack_installation_service import upsert_installation
+
+
+@pytest.fixture
+def client(auth_enabled) -> Iterator[TestClient]:
+    app = create_app(serve_dashboard=False)
+    with TestClient(app) as c:
+        # Log in once so subsequent calls ride the cookie.
+        c.post(
+            "/api/auth/login",
+            json={"user": "admin", "password": "correct-horse-battery-staple"},
+        )
+        yield c
+
+
+# ─── /api/status ────────────────────────────────────────────────────────
+
+
+def test_status_shape(client: TestClient) -> None:
+    resp = client.get("/api/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    # Presence check; exact values depend on settings snapshot.
+    assert set(data.keys()) == {
+        "version",
+        "environment",
+        "public_url",
+        "auth_enabled",
+        "payload_encryption_enabled",
+        "admin_token_enabled",
+        "slack_mode",
+        "email_transport",
+        "email_from",
+    }
+
+
+def test_status_never_leaks_secrets(client: TestClient) -> None:
+    """Config values like PAYLOAD_KEY, DASHBOARD_PASSWORD, SLACK_BOT_TOKEN
+    must never appear in the /status response, only boolean presence."""
+    resp = client.get("/api/status")
+    body = resp.text.lower()
+    # These are the env-var names — none should leak.
+    for forbidden in (
+        "payload_key",
+        "dashboard_password",
+        "slack_bot_token",
+        "slack_client_secret",
+        "admin_api_token",
+        "smtp_password",
+        "resend_key",
+    ):
+        assert forbidden not in body, f"/status leaked {forbidden}"
+
+
+def test_status_auth_required(auth_enabled) -> None:
+    """Without a session, /status returns 401 (middleware gate)."""
+    app = create_app(serve_dashboard=False)
+    with TestClient(app) as c:
+        resp = c.get("/api/status")
+        assert resp.status_code == 401
+
+
+def test_status_slack_mode_detects_single_workspace(client: TestClient, monkeypatch) -> None:
+    from awaithumans.server.core.config import settings
+
+    monkeypatch.setattr(settings, "SLACK_BOT_TOKEN", "xoxb-static")
+    resp = client.get("/api/status")
+    assert resp.json()["slack_mode"] == "single-workspace"
+
+
+def test_status_slack_mode_detects_multi_workspace(client: TestClient, monkeypatch) -> None:
+    from awaithumans.server.core.config import settings
+
+    monkeypatch.setattr(settings, "SLACK_BOT_TOKEN", None)
+    monkeypatch.setattr(settings, "SLACK_CLIENT_ID", "A123")
+    monkeypatch.setattr(settings, "SLACK_CLIENT_SECRET", "sekret")
+    resp = client.get("/api/status")
+    assert resp.json()["slack_mode"] == "multi-workspace"
+
+
+def test_status_slack_mode_off_when_unconfigured(client: TestClient, monkeypatch) -> None:
+    from awaithumans.server.core.config import settings
+
+    monkeypatch.setattr(settings, "SLACK_BOT_TOKEN", None)
+    monkeypatch.setattr(settings, "SLACK_CLIENT_ID", None)
+    resp = client.get("/api/status")
+    assert resp.json()["slack_mode"] == "off"
+
+
+# ─── /api/channels/slack/installations ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_installations_returns_public_shape(
+    client: TestClient, auth_enabled
+) -> None:
+    """Seed one installation directly and verify bot_token is never in the response."""
+    # Use a fresh session to write the fixture — the TestClient's session
+    # runs in a request context and isn't reachable from here.
+    from awaithumans.server.db.connection import get_async_session_factory
+
+    factory = get_async_session_factory()
+    async with factory() as session:
+        await upsert_installation(
+            session,
+            team_id="T123",
+            team_name="Acme",
+            bot_token="xoxb-PLAINTEXT-SECRET",
+            bot_user_id="U_BOT",
+            scopes="chat:write,im:write",
+        )
+
+    resp = client.get("/api/channels/slack/installations")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    entry = body[0]
+    assert entry["team_id"] == "T123"
+    assert entry["team_name"] == "Acme"
+    assert entry["scopes"] == "chat:write,im:write"
+    # CRITICAL: the raw token must never appear in the public response.
+    assert "bot_token" not in entry
+    assert "xoxb" not in resp.text
+
+
+def test_list_installations_requires_auth(auth_enabled) -> None:
+    app = create_app(serve_dashboard=False)
+    with TestClient(app) as c:
+        resp = c.get("/api/channels/slack/installations")
+        assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_uninstall_removes_row(client: TestClient, auth_enabled) -> None:
+    from awaithumans.server.db.connection import get_async_session_factory
+
+    factory = get_async_session_factory()
+    async with factory() as session:
+        await upsert_installation(
+            session,
+            team_id="T_REMOVE_ME",
+            team_name="GoneSoon",
+            bot_token="xoxb-x",
+            bot_user_id="U",
+            scopes="chat:write",
+        )
+
+    resp = client.delete("/api/channels/slack/installations/T_REMOVE_ME")
+    assert resp.status_code == 204
+
+    # Subsequent list call must not include it.
+    listing = client.get("/api/channels/slack/installations").json()
+    ids = [r["team_id"] for r in listing]
+    assert "T_REMOVE_ME" not in ids
+
+
+def test_uninstall_unknown_team_404(client: TestClient) -> None:
+    resp = client.delete("/api/channels/slack/installations/T_DOES_NOT_EXIST")
+    assert resp.status_code == 404


### PR DESCRIPTION
Stacks on PR #3. Review that first — this branch only contains the Settings page content + its backing endpoints.

## Summary

Replaces the Settings placeholder with three functional sections operators can use without touching curl.

**Python server (new endpoints, no secrets in any response)**
- `GET /api/status` — server config snapshot: version · environment · public_url · auth/encryption/admin-token presence · slack_mode (`off` / `single-workspace` / `multi-workspace`) · email transport + from. Dedicated test proves no env-var name ever leaks into the response.
- `GET /api/channels/slack/installations` — lists workspaces via the public `SlackInstallationResponse` shape. `bot_token` stays server-side (encrypted at rest).
- `DELETE /api/channels/slack/installations/{team_id}` — uninstall.

**Dashboard**
- `lib/server/{status,slack,email-identities}.ts` — typed wrappers.
- `components/settings/` — shared section chrome, StatusDot, and three cards:
  - **System** — per-row ok/warn/off badges
  - **Slack workspaces** — install button (multi-workspace mode only) + per-row uninstall; advisory copy for single-workspace / off modes
  - **Email sender identities** — list + inline create form (id, display_name, from_email, transport dropdown, transport_config JSON) + delete. Surfaces the real 503 when `AWAITHUMANS_ADMIN_API_TOKEN` isn't set.

## Test plan

- [x] 212/212 python tests pass (10 new)
- [x] `ruff check awaithumans/` clean
- [x] `npx tsc --noEmit` clean
- [x] Manual: Settings page renders all three sections against a live server
- [ ] Manual: set `AWAITHUMANS_ADMIN_API_TOKEN`, create/delete an email identity through the form
- [ ] Manual: install a real Slack workspace via OAuth, verify it appears + can be uninstalled

🤖 Generated with [Claude Code](https://claude.com/claude-code)