### PR TITLE
feat(dashboard): analytics page — task stats + volume chart + channel mix

### DIFF
--- a/packages/dashboard/app/(dashboard)/analytics/page.tsx
+++ b/packages/dashboard/app/(dashboard)/analytics/page.tsx
@@ -1,13 +1,163 @@
-import { BarChart3 } from "lucide-react";
+"use client";
 
-import { ComingSoon } from "@/components/coming-soon";
+import {
+	Activity,
+	CheckCircle,
+	Clock,
+	ListChecks,
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+import { ChannelMix } from "@/components/analytics/channel-mix";
+import { StatCard } from "@/components/analytics/stat-card";
+import { TaskVolumeChart } from "@/components/analytics/task-volume-chart";
+import { ErrorBanner } from "@/components/error-banner";
+import { fetchTaskStats, type TaskStats } from "@/lib/server";
+
+const WINDOW_OPTIONS = [7, 30, 90] as const;
+type Window = (typeof WINDOW_OPTIONS)[number];
 
 export default function AnalyticsPage() {
+	const [windowDays, setWindowDays] = useState<Window>(30);
+	const [stats, setStats] = useState<TaskStats | null>(null);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		setError(null);
+		fetchTaskStats(windowDays)
+			.then(setStats)
+			.catch((err) =>
+				setError(err instanceof Error ? err.message : "Failed to load"),
+			);
+	}, [windowDays]);
+
+	const openTaskCount = useMemo(() => {
+		if (!stats) return 0;
+		return (
+			(stats.totals.created ?? 0) +
+			(stats.totals.assigned ?? 0) +
+			(stats.totals.in_progress ?? 0) +
+			(stats.totals.notified ?? 0) +
+			(stats.totals.submitted ?? 0)
+		);
+	}, [stats]);
+
 	return (
-		<ComingSoon
-			icon={BarChart3}
-			title="Analytics"
-			body="Completion rate, time-to-complete, channel mix, and verifier outcomes across your tasks."
-		/>
+		<div className="max-w-5xl">
+			<div className="flex items-start justify-between mb-8 gap-4">
+				<div>
+					<h1 className="text-2xl font-bold">Analytics</h1>
+					<p className="text-white/45 text-sm mt-1">
+						How your humans + agents are moving tasks through the system.
+					</p>
+				</div>
+				<WindowPicker value={windowDays} onChange={setWindowDays} />
+			</div>
+
+			{error && <ErrorBanner message={error} />}
+
+			{!stats && !error ? (
+				<div className="text-white/30 text-sm">Loading stats…</div>
+			) : stats ? (
+				<div className="space-y-6">
+					{/* KPI row */}
+					<div className="grid grid-cols-4 gap-4">
+						<StatCard
+							icon={ListChecks}
+							label="Tasks in flight"
+							value={openTaskCount}
+							sub={`${stats.totals.completed ?? 0} completed all-time`}
+						/>
+						<StatCard
+							icon={CheckCircle}
+							label="Completion rate"
+							accent
+							value={
+								stats.completion_rate === null
+									? "—"
+									: `${(stats.completion_rate * 100).toFixed(0)}%`
+							}
+							sub={
+								stats.completion_rate === null
+									? "No terminal tasks yet"
+									: "completed / terminal"
+							}
+						/>
+						<StatCard
+							icon={Clock}
+							label="Avg time to complete"
+							value={formatDuration(stats.avg_completion_seconds)}
+							sub={
+								stats.avg_completion_seconds === null
+									? `in last ${windowDays} days`
+									: `mean across ${windowDays} days`
+							}
+						/>
+						<StatCard
+							icon={Activity}
+							label="Timed out"
+							value={stats.totals.timed_out ?? 0}
+							sub={`${stats.totals.cancelled ?? 0} cancelled`}
+						/>
+					</div>
+
+					{/* Chart */}
+					<section>
+						<h2 className="text-sm font-semibold mb-3 text-white/70">
+							Volume
+						</h2>
+						<div className="border border-white/10 rounded-lg p-5 bg-white/[0.015]">
+							<TaskVolumeChart data={stats.by_day} />
+						</div>
+					</section>
+
+					{/* Channels */}
+					<section>
+						<h2 className="text-sm font-semibold mb-3 text-white/70">
+							Completion channels
+						</h2>
+						<ChannelMix byChannel={stats.by_channel} />
+					</section>
+				</div>
+			) : null}
+		</div>
 	);
+}
+
+function WindowPicker({
+	value,
+	onChange,
+}: {
+	value: Window;
+	onChange: (v: Window) => void;
+}) {
+	return (
+		<div className="inline-flex border border-white/10 rounded-md overflow-hidden">
+			{WINDOW_OPTIONS.map((w) => (
+				<button
+					key={w}
+					type="button"
+					onClick={() => onChange(w)}
+					className={
+						value === w
+							? "px-3 py-1.5 text-xs bg-brand/10 text-brand border-r border-white/10 last:border-r-0"
+							: "px-3 py-1.5 text-xs text-white/50 hover:text-white transition-colors border-r border-white/10 last:border-r-0"
+					}
+				>
+					{w}d
+				</button>
+			))}
+		</div>
+	);
+}
+
+function formatDuration(seconds: number | null): string {
+	if (seconds === null) return "—";
+	if (seconds < 60) return `${Math.round(seconds)}s`;
+	const minutes = seconds / 60;
+	if (minutes < 60) return `${minutes.toFixed(1)}m`;
+	const hours = minutes / 60;
+	if (hours < 24) return `${hours.toFixed(1)}h`;
+	const days = hours / 24;
+	return `${days.toFixed(1)}d`;
 }

--- a/packages/dashboard/components/analytics/channel-mix.tsx
+++ b/packages/dashboard/components/analytics/channel-mix.tsx
@@ -1,0 +1,95 @@
+import { Mail, Monitor, Slack } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const CHANNEL_META: Record<
+	string,
+	{ icon: LucideIcon; label: string }
+> = {
+	dashboard: { icon: Monitor, label: "Dashboard" },
+	slack: { icon: Slack, label: "Slack" },
+	email: { icon: Mail, label: "Email" },
+};
+
+/**
+ * Horizontal stacked bar of completion channels, followed by a per-
+ * channel breakdown. The stacked bar gives an at-a-glance "where are
+ * humans actually working" read; the list gives the raw counts.
+ */
+export function ChannelMix({ byChannel }: { byChannel: Record<string, number> }) {
+	const entries = Object.entries(byChannel).sort(
+		([, a], [, b]) => b - a,
+	);
+	const total = entries.reduce((acc, [, n]) => acc + n, 0);
+
+	if (total === 0) {
+		return (
+			<div className="border border-white/10 rounded-lg px-5 py-6 bg-white/[0.015] text-center text-sm text-white/35">
+				No completions in the window yet.
+			</div>
+		);
+	}
+
+	return (
+		<div className="border border-white/10 rounded-lg p-5 bg-white/[0.015] space-y-4">
+			<div className="flex rounded-full overflow-hidden h-2 bg-white/5">
+				{entries.map(([channel, count], i) => {
+					const pct = (count / total) * 100;
+					return (
+						<div
+							key={channel}
+							className={cn("h-full", barColor(i))}
+							style={{ width: `${pct}%` }}
+							title={`${channel}: ${count}`}
+						/>
+					);
+				})}
+			</div>
+
+			<ul className="space-y-2">
+				{entries.map(([channel, count], i) => {
+					const meta = CHANNEL_META[channel] ?? {
+						icon: Monitor,
+						label: channel,
+					};
+					const Icon = meta.icon;
+					const pct = ((count / total) * 100).toFixed(0);
+					return (
+						<li
+							key={channel}
+							className="flex items-center gap-3 text-sm"
+						>
+							<span
+								className={cn(
+									"inline-block w-2 h-2 rounded-sm shrink-0",
+									barColor(i),
+								)}
+							/>
+							<Icon size={14} className="text-white/50" />
+							<span className="flex-1">{meta.label}</span>
+							<span className="text-white/40 text-xs tabular-nums">
+								{count} · {pct}%
+							</span>
+						</li>
+					);
+				})}
+			</ul>
+		</div>
+	);
+}
+
+// First entry always brand-green (it's the most-used channel). Subsequent
+// entries step down in saturation so the eye reads the primary first.
+function barColor(index: number): string {
+	switch (index) {
+		case 0:
+			return "bg-brand";
+		case 1:
+			return "bg-white/40";
+		case 2:
+			return "bg-white/20";
+		default:
+			return "bg-white/10";
+	}
+}

--- a/packages/dashboard/components/analytics/stat-card.tsx
+++ b/packages/dashboard/components/analytics/stat-card.tsx
@@ -1,0 +1,50 @@
+import type { LucideIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Single-metric card — big number + label + optional delta/sub-line.
+ *
+ * `accent` swaps the number colour; we reserve brand-green for the
+ * completion-rate card so the main KPI reads first.
+ */
+export function StatCard({
+	icon: Icon,
+	label,
+	value,
+	sub,
+	accent,
+	className,
+}: {
+	icon?: LucideIcon;
+	label: string;
+	value: React.ReactNode;
+	sub?: React.ReactNode;
+	accent?: boolean;
+	className?: string;
+}) {
+	return (
+		<div
+			className={cn(
+				"border border-white/10 rounded-lg px-5 py-4 bg-white/[0.015]",
+				className,
+			)}
+		>
+			<div className="flex items-center gap-2 text-white/40 text-[10px] uppercase tracking-wider font-medium">
+				{Icon && <Icon size={12} />}
+				<span>{label}</span>
+			</div>
+			<div
+				className={cn(
+					"mt-1.5 text-2xl font-semibold tabular-nums",
+					accent ? "text-brand" : "text-fg",
+				)}
+			>
+				{value}
+			</div>
+			{sub && (
+				<div className="mt-1 text-white/40 text-xs tabular-nums">{sub}</div>
+			)}
+		</div>
+	);
+}

--- a/packages/dashboard/components/analytics/task-volume-chart.tsx
+++ b/packages/dashboard/components/analytics/task-volume-chart.tsx
@@ -1,0 +1,119 @@
+/**
+ * Grouped-bar chart for tasks created vs completed, per day.
+ *
+ * Hand-rolled SVG — sub-kilobyte, no chart library dep, legible enough
+ * for a sparkline-density view. When the Analytics page grows beyond
+ * "a few cards" we can swap in Recharts or Tremor, but for V1 this
+ * keeps the bundle lean and the render deterministic.
+ */
+
+import type { TaskStatsByDay } from "@/lib/server";
+
+const HEIGHT = 140;
+const BAR_GAP = 1;       // px between the created/completed pair inside one day
+const DAY_GAP = 2;       // px between day groups
+const LABEL_ROW_HEIGHT = 14;
+
+export function TaskVolumeChart({ data }: { data: TaskStatsByDay[] }) {
+	const max = Math.max(1, ...data.flatMap((d) => [d.created, d.completed]));
+	const days = data.length;
+
+	// One "day group" = 2 bars + 1 inner gap.
+	// Total width is flexible — we let CSS scale. We output a viewBox
+	// so bars compress gracefully on narrow screens.
+	const groupWidth = 12; // logical units per day group
+	const barWidth = (groupWidth - BAR_GAP) / 2;
+	const width = days * (groupWidth + DAY_GAP);
+
+	return (
+		<div className="w-full">
+			<div className="flex items-center gap-4 mb-3 text-xs text-white/50">
+				<Legend color="var(--color-brand)" label="Created" />
+				<Legend color="rgba(255,255,255,0.45)" label="Completed" />
+				<span className="ml-auto text-white/30">Last {days} days</span>
+			</div>
+			<svg
+				viewBox={`0 0 ${width} ${HEIGHT + LABEL_ROW_HEIGHT}`}
+				preserveAspectRatio="none"
+				className="w-full h-[160px]"
+				role="img"
+				aria-label="Task volume per day"
+			>
+				{/* Zero baseline */}
+				<line
+					x1="0"
+					y1={HEIGHT}
+					x2={width}
+					y2={HEIGHT}
+					stroke="rgba(255,255,255,0.08)"
+					strokeWidth="0.5"
+				/>
+				{data.map((d, i) => {
+					const x = i * (groupWidth + DAY_GAP);
+					const createdH = (d.created / max) * HEIGHT;
+					const completedH = (d.completed / max) * HEIGHT;
+					return (
+						<g key={d.date}>
+							<rect
+								x={x}
+								y={HEIGHT - createdH}
+								width={barWidth}
+								height={createdH}
+								fill="var(--color-brand)"
+								opacity="0.85"
+							/>
+							<rect
+								x={x + barWidth + BAR_GAP}
+								y={HEIGHT - completedH}
+								width={barWidth}
+								height={completedH}
+								fill="rgba(255,255,255,0.45)"
+							/>
+						</g>
+					);
+				})}
+				{/* First + last + midpoint day labels — keep the axis legible
+				    on narrow screens without scribbling 30 stamps. */}
+				{[0, Math.floor((days - 1) / 2), days - 1]
+					.filter((v, idx, arr) => arr.indexOf(v) === idx)
+					.map((i) => {
+						const x = i * (groupWidth + DAY_GAP) + groupWidth / 2;
+						return (
+							<text
+								key={i}
+								x={x}
+								y={HEIGHT + LABEL_ROW_HEIGHT - 2}
+								textAnchor="middle"
+								fontSize="6"
+								fill="rgba(255,255,255,0.3)"
+							>
+								{formatShortDate(data[i].date)}
+							</text>
+						);
+					})}
+			</svg>
+		</div>
+	);
+}
+
+function Legend({ color, label }: { color: string; label: string }) {
+	return (
+		<span className="inline-flex items-center gap-1.5">
+			<span
+				className="inline-block w-2 h-2 rounded-sm"
+				style={{ background: color }}
+			/>
+			{label}
+		</span>
+	);
+}
+
+function formatShortDate(iso: string): string {
+	// "2026-04-17" → "Apr 17"
+	const d = new Date(`${iso}T00:00:00Z`);
+	return d.toLocaleDateString("en-US", {
+		month: "short",
+		day: "numeric",
+		timeZone: "UTC",
+	});
+}

--- a/packages/dashboard/lib/server/index.ts
+++ b/packages/dashboard/lib/server/index.ts
@@ -30,5 +30,10 @@ export {
 	uninstallSlackWorkspace,
 	type SlackInstallation,
 } from "./slack";
+export {
+	fetchTaskStats,
+	type TaskStats,
+	type TaskStatsByDay,
+} from "./stats";
 export { fetchSystemStatus, type SystemStatus } from "./status";
 export { cancelTask, completeTask, fetchTask, fetchTasks } from "./tasks";

--- a/packages/dashboard/lib/server/stats.ts
+++ b/packages/dashboard/lib/server/stats.ts
@@ -1,0 +1,27 @@
+/**
+ * Task stats — aggregates for the Analytics page.
+ */
+
+import { apiFetch } from "./client";
+
+export interface TaskStatsByDay {
+	date: string; // YYYY-MM-DD
+	created: number;
+	completed: number;
+}
+
+export interface TaskStats {
+	window_days: number;
+	generated_at: string;
+	totals: Record<string, number>;
+	completion_rate: number | null;
+	avg_completion_seconds: number | null;
+	by_day: TaskStatsByDay[];
+	by_channel: Record<string, number>;
+}
+
+export async function fetchTaskStats(
+	windowDays: number = 30,
+): Promise<TaskStats> {
+	return apiFetch<TaskStats>(`/api/stats/tasks?window_days=${windowDays}`);
+}

--- a/packages/python/awaithumans/server/app.py
+++ b/packages/python/awaithumans/server/app.py
@@ -22,7 +22,7 @@ from awaithumans.server.core.exceptions import exception_handlers
 from awaithumans.server.core.logging_config import setup_logging
 from awaithumans.server.core.middleware import RequestIDMiddleware
 from awaithumans.server.db.connection import close_db, init_db
-from awaithumans.server.routes import auth, email, health, slack, status, tasks
+from awaithumans.server.routes import auth, email, health, slack, stats, status, tasks
 from awaithumans.server.services.timeout_scheduler import run_timeout_scheduler
 
 logger = logging.getLogger("awaithumans.server")
@@ -118,6 +118,7 @@ def create_app(*, serve_dashboard: bool = True) -> FastAPI:
     # ── Routes ───────────────────────────────────────────────────────
     app.include_router(auth.router, prefix="/api")
     app.include_router(status.router, prefix="/api")
+    app.include_router(stats.router, prefix="/api")
     app.include_router(tasks.router, prefix="/api")
     app.include_router(health.router, prefix="/api")
     app.include_router(slack.router, prefix="/api")

--- a/packages/python/awaithumans/server/routes/stats.py
+++ b/packages/python/awaithumans/server/routes/stats.py
@@ -1,0 +1,35 @@
+"""Stats route — GET /api/stats/tasks?window_days=N.
+
+Aggregate task metrics for the dashboard Analytics page. Gated by the
+dashboard auth middleware like every other authenticated API.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from awaithumans.server.db.connection import get_session
+from awaithumans.server.schemas.stats import TaskStats
+from awaithumans.server.services.stats_service import get_task_stats
+
+router = APIRouter(prefix="/stats", tags=["stats"])
+
+# Bounds on window_days: at least 1 day of data, at most a year. Larger
+# windows pull more rows into memory — see services/stats_service.py
+# for why this is OK at MVP scale.
+_MIN_WINDOW_DAYS = 1
+_MAX_WINDOW_DAYS = 365
+
+
+@router.get("/tasks", response_model=TaskStats)
+async def task_stats(
+    window_days: int = Query(
+        default=30,
+        ge=_MIN_WINDOW_DAYS,
+        le=_MAX_WINDOW_DAYS,
+        description="Lookback window for by-day / by-channel aggregates.",
+    ),
+    session: AsyncSession = Depends(get_session),
+) -> TaskStats:
+    return await get_task_stats(session, window_days=window_days)

--- a/packages/python/awaithumans/server/schemas/__init__.py
+++ b/packages/python/awaithumans/server/schemas/__init__.py
@@ -8,6 +8,7 @@ from awaithumans.server.schemas.audit import AuditEntryResponse
 from awaithumans.server.schemas.email import IdentityCreateRequest, IdentityResponse
 from awaithumans.server.schemas.health import HealthResponse
 from awaithumans.server.schemas.slack import SlackInstallationResponse
+from awaithumans.server.schemas.stats import TaskStats, TaskStatsByDay
 from awaithumans.server.schemas.status import SystemStatus
 from awaithumans.server.schemas.task import (
     CompleteTaskRequest,
@@ -27,4 +28,6 @@ __all__ = [
     "SlackInstallationResponse",
     "SystemStatus",
     "TaskResponse",
+    "TaskStats",
+    "TaskStatsByDay",
 ]

--- a/packages/python/awaithumans/server/schemas/stats.py
+++ b/packages/python/awaithumans/server/schemas/stats.py
@@ -1,0 +1,32 @@
+"""Task statistics schemas."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class TaskStatsByDay(BaseModel):
+    date: str        # YYYY-MM-DD
+    created: int
+    completed: int
+
+
+class TaskStats(BaseModel):
+    """Aggregated stats for the Analytics page.
+
+    `window_days` is the lookback used for `by_day` / `by_channel`.
+    `totals` is current counts across all time (not restricted to
+    the window) — operators want to see the real task queue size,
+    not just "tasks in the last 30 days".
+    """
+
+    window_days: int
+    generated_at: str
+    # status value → count (all-time)
+    totals: dict[str, int]
+    # completed / terminal; None when no terminal tasks yet
+    completion_rate: float | None
+    avg_completion_seconds: float | None
+    by_day: list[TaskStatsByDay]
+    # completed_via_channel → count (completed tasks in window only)
+    by_channel: dict[str, int]

--- a/packages/python/awaithumans/server/services/stats_service.py
+++ b/packages/python/awaithumans/server/services/stats_service.py
@@ -1,0 +1,169 @@
+"""Task statistics — aggregation for the Analytics page.
+
+For MVP we pull rows within the lookback window and group in Python.
+With a few thousand tasks/day this is still under 50 ms. When we
+outgrow it, replace with a CTE that does the grouping server-side
+(`SELECT DATE(created_at), COUNT(*) ... GROUP BY 1`).
+
+All queries go through the existing indexes on `created_at` and
+`status` — the window filter hits the b-tree in both SQLite and
+Postgres.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from awaithumans.server.db.models import Task
+from awaithumans.server.schemas.stats import TaskStats, TaskStatsByDay
+from awaithumans.types import TaskStatus
+
+# Terminal statuses that count as "finished" for completion rate.
+_TERMINAL = {
+    TaskStatus.COMPLETED,
+    TaskStatus.TIMED_OUT,
+    TaskStatus.CANCELLED,
+    TaskStatus.VERIFICATION_EXHAUSTED,
+}
+
+
+async def get_task_stats(
+    session: AsyncSession, *, window_days: int = 30
+) -> TaskStats:
+    now = datetime.now(timezone.utc)
+    window_start = now - timedelta(days=window_days)
+
+    totals = await _totals(session)
+    window_rows = await _window_rows(session, window_start)
+
+    by_day = _bucket_by_day(window_rows, now=now, window_days=window_days)
+    by_channel = _bucket_by_channel(window_rows)
+    avg_seconds = _avg_completion_seconds(window_rows)
+
+    # Completion rate uses totals (all-time), matching operator intent:
+    # "of tasks that ever finished, how many did a human actually complete".
+    terminal_count = sum(totals.get(s.value, 0) for s in _TERMINAL)
+    completed_count = totals.get(TaskStatus.COMPLETED.value, 0)
+    completion_rate: float | None = (
+        completed_count / terminal_count if terminal_count > 0 else None
+    )
+
+    return TaskStats(
+        window_days=window_days,
+        generated_at=now.isoformat(),
+        totals=totals,
+        completion_rate=completion_rate,
+        avg_completion_seconds=avg_seconds,
+        by_day=by_day,
+        by_channel=by_channel,
+    )
+
+
+# ─── Queries ─────────────────────────────────────────────────────────────
+
+
+async def _totals(session: AsyncSession) -> dict[str, int]:
+    """All-time counts grouped by status."""
+    result = await session.execute(select(Task.status))
+    counter: Counter[str] = Counter()
+    for (status,) in result.all():
+        # SQLAlchemy returns the enum member; .value normalises to str.
+        counter[_status_value(status)] += 1
+    return dict(counter)
+
+
+async def _window_rows(
+    session: AsyncSession, window_start: datetime
+) -> list[tuple[Any, datetime, datetime | None, str | None]]:
+    """Rows inside the lookback window.
+
+    Returns a list of (status, created_at, completed_at, completed_via_channel).
+    Kept small (four columns) so serialising doesn't balloon the payload.
+    """
+    result = await session.execute(
+        select(
+            Task.status,
+            Task.created_at,
+            Task.completed_at,
+            Task.completed_via_channel,
+        ).where(Task.created_at >= window_start)
+    )
+    return list(result.all())
+
+
+# ─── Grouping ────────────────────────────────────────────────────────────
+
+
+def _bucket_by_day(
+    rows: list[tuple[Any, datetime, datetime | None, str | None]],
+    *,
+    now: datetime,
+    window_days: int,
+) -> list[TaskStatsByDay]:
+    """Created/completed counts per calendar day, UTC.
+
+    Produces exactly `window_days` entries ending today — zero-filled so
+    the chart renders a clean axis even on days with no traffic.
+    """
+    created: Counter[str] = Counter()
+    completed: Counter[str] = Counter()
+
+    for _status, created_at, completed_at, _ch in rows:
+        created[created_at.date().isoformat()] += 1
+        if completed_at is not None:
+            completed[completed_at.date().isoformat()] += 1
+
+    today = now.date()
+    out: list[TaskStatsByDay] = []
+    for offset in range(window_days - 1, -1, -1):
+        d = (today - timedelta(days=offset)).isoformat()
+        out.append(
+            TaskStatsByDay(
+                date=d,
+                created=created.get(d, 0),
+                completed=completed.get(d, 0),
+            )
+        )
+    return out
+
+
+def _bucket_by_channel(
+    rows: list[tuple[Any, datetime, datetime | None, str | None]],
+) -> dict[str, int]:
+    """Count completed tasks by `completed_via_channel`."""
+    counter: Counter[str] = Counter()
+    for status, _created_at, _completed_at, channel in rows:
+        if _status_value(status) != TaskStatus.COMPLETED.value:
+            continue
+        counter[channel or "unknown"] += 1
+    return dict(counter)
+
+
+def _avg_completion_seconds(
+    rows: list[tuple[Any, datetime, datetime | None, str | None]],
+) -> float | None:
+    """Mean elapsed seconds from created_at → completed_at over the window.
+
+    Only completed tasks contribute. Returns None when nothing completed
+    so the UI can render "—" rather than a misleading 0.
+    """
+    deltas: list[float] = []
+    for status, created_at, completed_at, _ch in rows:
+        if _status_value(status) != TaskStatus.COMPLETED.value:
+            continue
+        if completed_at is None:
+            continue
+        deltas.append((completed_at - created_at).total_seconds())
+    if not deltas:
+        return None
+    return sum(deltas) / len(deltas)
+
+
+def _status_value(status: Any) -> str:
+    """TaskStatus enum member or raw string — return the string value."""
+    return status.value if hasattr(status, "value") else str(status)

--- a/packages/python/tests/stats/conftest.py
+++ b/packages/python/tests/stats/conftest.py
@@ -1,0 +1,28 @@
+"""In-memory SQLite session for stats-service unit tests."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+# Register models.
+from awaithumans.server.db.models import (  # noqa: F401
+    AuditEntry,
+    SlackInstallation,
+    Task,
+)
+
+
+@pytest_asyncio.fixture
+async def session() -> AsyncGenerator[AsyncSession, None]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()

--- a/packages/python/tests/stats/test_stats_service.py
+++ b/packages/python/tests/stats/test_stats_service.py
@@ -1,0 +1,234 @@
+"""Task-stats aggregation — totals, completion rate, by-day bucket, channels."""
+
+from __future__ import annotations
+
+import itertools
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from awaithumans.server.db.models import Task
+from awaithumans.server.services.stats_service import get_task_stats
+from awaithumans.types import TaskStatus
+
+_key_seq = itertools.count()
+
+
+def _task(
+    *,
+    created_at: datetime,
+    status: TaskStatus = TaskStatus.CREATED,
+    completed_at: datetime | None = None,
+    channel: str | None = None,
+    task: str = "do the thing",
+) -> Task:
+    return Task(
+        idempotency_key=f"k-{next(_key_seq)}",
+        task=task,
+        payload={},
+        payload_schema={},
+        response_schema={},
+        timeout_seconds=900,
+        status=status,
+        created_at=created_at,
+        updated_at=created_at,
+        completed_at=completed_at,
+        completed_via_channel=channel,
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_stats(session: AsyncSession) -> None:
+    stats = await get_task_stats(session, window_days=7)
+    assert stats.window_days == 7
+    assert stats.totals == {}
+    assert stats.completion_rate is None
+    assert stats.avg_completion_seconds is None
+    assert len(stats.by_day) == 7  # zero-filled
+    assert all(d.created == 0 and d.completed == 0 for d in stats.by_day)
+    assert stats.by_channel == {}
+
+
+@pytest.mark.asyncio
+async def test_totals_count_all_statuses(session: AsyncSession) -> None:
+    now = datetime.now(timezone.utc)
+    session.add_all([
+        _task(created_at=now, status=TaskStatus.CREATED),
+        _task(created_at=now, status=TaskStatus.CREATED),
+        _task(created_at=now, status=TaskStatus.COMPLETED, completed_at=now),
+        _task(created_at=now, status=TaskStatus.TIMED_OUT),
+        _task(created_at=now, status=TaskStatus.CANCELLED),
+    ])
+    await session.commit()
+
+    stats = await get_task_stats(session, window_days=30)
+    assert stats.totals["created"] == 2
+    assert stats.totals["completed"] == 1
+    assert stats.totals["timed_out"] == 1
+    assert stats.totals["cancelled"] == 1
+
+
+@pytest.mark.asyncio
+async def test_completion_rate(session: AsyncSession) -> None:
+    """2 completed out of 4 terminal → 0.5."""
+    now = datetime.now(timezone.utc)
+    session.add_all([
+        _task(created_at=now, status=TaskStatus.COMPLETED, completed_at=now),
+        _task(created_at=now, status=TaskStatus.COMPLETED, completed_at=now),
+        _task(created_at=now, status=TaskStatus.TIMED_OUT),
+        _task(created_at=now, status=TaskStatus.CANCELLED),
+        # In-progress ones DON'T count as "terminal" for the rate.
+        _task(created_at=now, status=TaskStatus.CREATED),
+        _task(created_at=now, status=TaskStatus.IN_PROGRESS),
+    ])
+    await session.commit()
+
+    stats = await get_task_stats(session, window_days=30)
+    assert stats.completion_rate == 0.5
+
+
+@pytest.mark.asyncio
+async def test_avg_completion_seconds(session: AsyncSession) -> None:
+    now = datetime.now(timezone.utc)
+    session.add_all([
+        _task(
+            created_at=now - timedelta(minutes=5),
+            status=TaskStatus.COMPLETED,
+            completed_at=now,  # 300s
+        ),
+        _task(
+            created_at=now - timedelta(minutes=15),
+            status=TaskStatus.COMPLETED,
+            completed_at=now,  # 900s
+        ),
+        # non-completed — excluded
+        _task(
+            created_at=now - timedelta(minutes=1),
+            status=TaskStatus.TIMED_OUT,
+        ),
+    ])
+    await session.commit()
+
+    stats = await get_task_stats(session, window_days=30)
+    assert stats.avg_completion_seconds == pytest.approx(600.0)
+
+
+@pytest.mark.asyncio
+async def test_by_day_zero_fills_window(session: AsyncSession) -> None:
+    """Every day in the window gets an entry — even days with no traffic."""
+    now = datetime.now(timezone.utc)
+    # Create two tasks, three days apart.
+    session.add_all([
+        _task(created_at=now, status=TaskStatus.CREATED),
+        _task(created_at=now - timedelta(days=3), status=TaskStatus.CREATED),
+    ])
+    await session.commit()
+
+    stats = await get_task_stats(session, window_days=7)
+    assert len(stats.by_day) == 7
+    # Last entry is today; first is today - 6.
+    today_str = now.date().isoformat()
+    assert stats.by_day[-1].date == today_str
+    assert stats.by_day[-1].created == 1
+    assert stats.by_day[-4].date == (now.date() - timedelta(days=3)).isoformat()
+    assert stats.by_day[-4].created == 1
+
+
+@pytest.mark.asyncio
+async def test_by_day_counts_completions(session: AsyncSession) -> None:
+    now = datetime.now(timezone.utc)
+    session.add_all([
+        _task(
+            created_at=now - timedelta(days=2),
+            status=TaskStatus.COMPLETED,
+            completed_at=now,
+        ),
+    ])
+    await session.commit()
+
+    stats = await get_task_stats(session, window_days=7)
+    today_entry = next(d for d in stats.by_day if d.date == now.date().isoformat())
+    two_days_ago = next(
+        d
+        for d in stats.by_day
+        if d.date == (now.date() - timedelta(days=2)).isoformat()
+    )
+    # Created counted at creation date.
+    assert two_days_ago.created == 1
+    # Completed counted at completion date (today).
+    assert today_entry.completed == 1
+
+
+@pytest.mark.asyncio
+async def test_by_channel_only_counts_completed(session: AsyncSession) -> None:
+    now = datetime.now(timezone.utc)
+    session.add_all([
+        _task(
+            created_at=now,
+            status=TaskStatus.COMPLETED,
+            completed_at=now,
+            channel="dashboard",
+        ),
+        _task(
+            created_at=now,
+            status=TaskStatus.COMPLETED,
+            completed_at=now,
+            channel="slack",
+        ),
+        _task(
+            created_at=now,
+            status=TaskStatus.COMPLETED,
+            completed_at=now,
+            channel="slack",
+        ),
+        # In-progress with a channel still shouldn't be counted.
+        _task(
+            created_at=now,
+            status=TaskStatus.IN_PROGRESS,
+            channel="slack",
+        ),
+    ])
+    await session.commit()
+
+    stats = await get_task_stats(session, window_days=30)
+    assert stats.by_channel == {"dashboard": 1, "slack": 2}
+
+
+@pytest.mark.asyncio
+async def test_window_filters_old_rows(session: AsyncSession) -> None:
+    """Tasks outside the window shouldn't affect by_day / by_channel.
+
+    They DO still show in `totals` — totals are all-time by design.
+    """
+    now = datetime.now(timezone.utc)
+    session.add_all([
+        _task(
+            created_at=now - timedelta(days=100),
+            status=TaskStatus.COMPLETED,
+            completed_at=now - timedelta(days=100),
+            channel="slack",
+        ),
+        _task(created_at=now, status=TaskStatus.CREATED),
+    ])
+    await session.commit()
+
+    stats = await get_task_stats(session, window_days=30)
+    # Old task NOT in by_channel (outside window)
+    assert stats.by_channel == {}
+    # But visible in totals
+    assert stats.totals["completed"] == 1
+    assert stats.totals["created"] == 1
+
+
+@pytest.mark.asyncio
+async def test_completion_rate_none_when_no_terminals(session: AsyncSession) -> None:
+    now = datetime.now(timezone.utc)
+    session.add_all([
+        _task(created_at=now, status=TaskStatus.CREATED),
+        _task(created_at=now, status=TaskStatus.IN_PROGRESS),
+    ])
+    await session.commit()
+
+    stats = await get_task_stats(session, window_days=30)
+    assert stats.completion_rate is None


### PR DESCRIPTION
Stacks on PR #4. Review that first — this branch only contains the Analytics page + its backing endpoint.

## Summary

Replaces the Analytics placeholder with a functional dashboard backed by a single aggregated \`GET /api/stats/tasks?window_days=N\` endpoint.

**Python server**
- \`services/stats_service.py\` — totals (all-time), completion rate, avg time-to-complete, by-day (zero-filled window), by-channel (completed in window only). MVP groups in Python after one windowed query (four columns). Comment flags the CTE-migration trigger for future scale.
- \`schemas/stats.py\` — \`TaskStats\` + \`TaskStatsByDay\` wire shape.
- \`routes/stats.py\` — \`window_days\` clamped 1..365.
- 9 new service tests: empty state, totals, completion rate math, avg duration, zero-filled day buckets, channel bucketing, window filtering, no-terminal-tasks edge case. **221 passing total.**

**Dashboard**
- \`lib/server/stats.ts\` — typed wrapper.
- \`components/analytics/\`
  - \`stat-card.tsx\` — single-metric chrome with accent variant (reserved for completion rate so the headline KPI reads first).
  - \`task-volume-chart.tsx\` — hand-rolled SVG grouped bar chart (created vs completed, last N days). No chart-lib dep, ~1kb of JSX, uses \`var(--color-brand)\`. Axis labels on first/mid/last day only.
  - \`channel-mix.tsx\` — horizontal stacked bar + per-channel breakdown with icons.
- \`app/(dashboard)/analytics/page.tsx\` — 4 KPI cards + volume chart + channel mix, with a 7/30/90-day window picker.

## Why no chart library

Considered Recharts / Tremor / Chart.js. Ruled out for V1:

- Bundle weight (Recharts adds ~60kb min+gzip); the dashboard is going to be served by the Python wheel and tiny matters
- We only need two chart shapes right now (grouped bars + stacked bar); a 40-line SVG is a wash with "set up the library"
- Avoiding a dep means avoiding a license / audit / update surface

If/when Analytics grows beyond these two shapes (verifier histograms, cohort retention, etc.), worth revisiting.

## Test plan

- [x] 221 python tests, ruff + tsc clean
- [x] Seeded 40 demo tasks, verified KPIs + volume chart + channel mix render correctly
- [ ] Manual: 7d / 90d window switching re-fetches and re-renders
- [ ] Manual: no-data state (fresh server) shows "—" and zero-filled chart without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)