### PR TITLE
fix: three bugs surfaced by the E2E walkthrough

### DIFF
--- a/packages/dashboard/components/form-renderer/index.tsx
+++ b/packages/dashboard/components/form-renderer/index.tsx
@@ -332,9 +332,26 @@ export function initialValueFor(form: FormDefinition): FormValue {
 	return out;
 }
 
+// Kinds that render UI but don't contribute a value to the response.
+// Skipping them here keeps display-only primitives (text blocks, media,
+// layout) out of the submitted response payload even when they have a
+// `name`. Without this, e.g. a display_text named "intro" shows up as
+// `{"intro": null}` in the human's response — misleading and pollutes
+// the audit trail.
+const NON_INPUT_KINDS = new Set([
+	"display_text",
+	"image",
+	"video",
+	"pdf_viewer",
+	"html",
+	"section",
+	"divider",
+]);
+
 function walk(fields: FormField[], out: FormValue): void {
 	for (const f of fields) {
 		if (!f.name) continue;
+		if (NON_INPUT_KINDS.has(f.kind)) continue;
 		switch (f.kind) {
 			case "switch":
 				out[f.name] = f.default ?? null;
@@ -375,6 +392,8 @@ function walk(fields: FormField[], out: FormValue): void {
 				walk(f.fields, out);
 				break;
 			default:
+				// Plain-value input kinds (short_text, long_text, rich_text,
+				// file_upload, signature, date_range) start blank.
 				out[f.name] = null;
 		}
 	}

--- a/packages/python/awaithumans/server/schemas/_datetime.py
+++ b/packages/python/awaithumans/server/schemas/_datetime.py
@@ -1,0 +1,38 @@
+"""Datetime serialization mixin for response schemas.
+
+SQLite stores datetimes as naive strings (no timezone suffix). When those
+come back through SQLModel, Pydantic serializes them without a `Z`, and
+the dashboard's `new Date(...)` parses them as *local* time — not UTC.
+The result is up to ±14h of drift in "created … ago" labels depending
+on the viewer's timezone.
+
+All our stored timestamps ARE UTC (the service layer calls
+`datetime.now(timezone.utc)`); SQLite just drops the tzinfo on the way
+out. Fix at the serialization boundary: assume naive-in-DB means UTC,
+and emit ISO strings with a `Z` suffix that `new Date(...)` interprets
+correctly on every client.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def utc_iso(dt: datetime | None) -> str | None:
+    """Serialize a datetime as ISO-8601 in UTC with a `Z` suffix.
+
+    - Naive datetimes are assumed to be UTC (our write path guarantees
+      this) and annotated before formatting.
+    - Aware datetimes are converted to UTC.
+    """
+    if dt is None:
+        return None
+    dt = (
+        dt.replace(tzinfo=timezone.utc)
+        if dt.tzinfo is None
+        else dt.astimezone(timezone.utc)
+    )
+    # Python emits `+00:00`; the web convention is `Z`. Both are valid
+    # ISO-8601, but `Z` is 5 bytes shorter and what `JSON.parse`-y
+    # clients expect.
+    return dt.isoformat().replace("+00:00", "Z")

--- a/packages/python/awaithumans/server/schemas/audit.py
+++ b/packages/python/awaithumans/server/schemas/audit.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_serializer
+
+from awaithumans.server.schemas._datetime import utc_iso
 
 
 class AuditEntryResponse(BaseModel):
@@ -21,3 +23,7 @@ class AuditEntryResponse(BaseModel):
     created_at: datetime
 
     model_config = {"from_attributes": True}
+
+    @field_serializer("created_at")
+    def _ser_dt(self, dt: datetime | None) -> str | None:
+        return utc_iso(dt)

--- a/packages/python/awaithumans/server/schemas/task.py
+++ b/packages/python/awaithumans/server/schemas/task.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_serializer
 
+from awaithumans.server.schemas._datetime import utc_iso
 from awaithumans.types import TaskStatus
 
 
@@ -56,9 +57,17 @@ class TaskResponse(BaseModel):
 
     model_config = {"from_attributes": True}
 
+    @field_serializer("created_at", "updated_at", "completed_at", "timed_out_at")
+    def _ser_dt(self, dt: datetime | None) -> str | None:
+        return utc_iso(dt)
+
 
 class PollResponse(BaseModel):
     status: str
     response: dict[str, Any] | None = None
     completed_at: datetime | None = None
     timed_out_at: datetime | None = None
+
+    @field_serializer("completed_at", "timed_out_at")
+    def _ser_dt(self, dt: datetime | None) -> str | None:
+        return utc_iso(dt)

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -2,15 +2,12 @@
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-# Ship non-Python template files inside the wheel. Without this, the
-# build step drops `.html` and `.txt` files and `importlib.resources`
-# fails at runtime against an installed wheel (dev installs still
-# resolve via the source tree, which hides the bug until release).
+# Hatchling includes the whole `awaithumans` package by default, and
+# that sweep picks up non-Python files (the email template `.html`/
+# `.txt` loaded via importlib.resources at runtime). No force-include
+# needed — if you add it, you get duplicate-name warnings.
 [tool.hatch.build.targets.wheel]
 packages = ["awaithumans"]
-
-[tool.hatch.build.targets.wheel.force-include]
-"awaithumans/server/channels/email/templates/html" = "awaithumans/server/channels/email/templates/html"
 
 [project]
 name = "awaithumans"
@@ -45,6 +42,12 @@ server = [
     "uvicorn[standard]>=0.32.0",
     "pydantic-settings>=2.0.0",
     "sqlmodel>=0.0.22",
+    # `greenlet` is SQLAlchemy's C-extension dep for async sessions.
+    # sqlmodel doesn't ship the `[asyncio]` extra transitively, so on
+    # fresh installs the aiosqlite driver raises `ValueError: the
+    # greenlet library is required` at first connection. List it
+    # explicitly so `pip install awaithumans[server]` just works.
+    "greenlet>=3.0",
     "alembic>=1.14.0",
     "aiosqlite>=0.20.0",
     "asyncpg>=0.30.0",


### PR DESCRIPTION
Live walkthrough of the core user story (build wheel → install in fresh venv → create a task → complete it via the dashboard) found three real bugs. All three would have shipped if we'd only relied on unit tests.

## 1. Fresh install crashes on first DB connection
\`pip install awaithumans[server]\` in a clean venv fails at startup:

\`\`\`
ValueError: the greenlet library is required to use this function. No module named 'greenlet'
\`\`\`

sqlmodel pulls sqlalchemy but not the \`[asyncio]\` extra; aiosqlite silently assumes greenlet is there. On the dev machine it's been transitively installed by something else, hiding the issue.

**Fix:** \`greenlet>=3.0\` added explicitly to the \`server\` extra.

## 2. Dashboard showed "-25149s ago" on freshly created tasks
SQLite drops tzinfo on write; on read datetimes come back naive; Pydantic emits \`2026-04-20T22:23:48.617207\` with no \`Z\`; the dashboard's \`new Date(...)\` parses that as local time, not UTC. A developer on UTC-7 sees tasks as 7 hours in the future.

**Fix:** \`server/schemas/_datetime.py::utc_iso\` — assumes naive-in-DB means UTC (true by construction in our write path), emits \`2026-04-20T22:29:47.903222Z\`. Applied via Pydantic \`field_serializer\` on every datetime field in \`TaskResponse\`, \`PollResponse\`, \`AuditEntryResponse\`.

## 3. Display-only form fields polluted the response payload
A named \`display_text\` field ended up as \`{"intro": null}\` in the submitted response because \`initialValueFor\` default-assigned null for every named field, including display primitives that don't render an input.

**Fix:** \`NON_INPUT_KINDS\` skip list in \`FormRenderer\` — display_text, image, video, pdf_viewer, html, section, divider never contribute to the form value.

## Also (not a bug, build hygiene)
Removed the redundant \`[tool.hatch.build.targets.wheel.force-include]\` config. Default package discovery already sweeps the HTML templates; force-include was duplicating them and emitting warnings on every wheel build.

## Test plan

- [x] Fresh venv install → \`awaithumans dev\` → \`/api/health\` = 200
- [x] Magic-link HTML template loads from the wheel (proves \`importlib.resources\` resolves against installed package)
- [x] Task created via API → timestamp is ISO-UTC with \`Z\` → dashboard reads \"15s ago\" correctly
- [x] Form with named display_text submits → response is \`{\"approved\": true}\`, no intro key
- [x] 221 python tests pass, ruff clean, tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)