### PR TITLE
feat(typescript-sdk): implement awaitHuman HTTP client

### DIFF
--- a/packages/python/tests/slack/test_interactions_e2e.py
+++ b/packages/python/tests/slack/test_interactions_e2e.py
@@ -1,0 +1,433 @@
+"""Slack interactivity webhook — end-to-end via the FastAPI app.
+
+Covers `POST /api/channels/slack/interactions` from the signature gate
+through to the side effect:
+
+- signature verification (missing headers, bad HMAC, stale timestamp)
+- payload shape guards (missing `payload` form field)
+- block_actions → loads the task, builds the modal, calls
+  `views.open` on the resolved per-team client (via a fake recorder)
+- view_submission → coerces Slack values into the task's response
+  schema and completes the task (status flips to COMPLETED)
+- edge cases: block_actions for a task without form_definition,
+  view_submission without private_metadata, unknown payload type
+
+Mirrors the email integration-test style (ASGI AsyncClient + in-memory
+SQLite + session override). Slack HTTP calls are replaced with a
+`FakeSlackClient` recorder rather than a MagicMock so assertions read
+like domain statements ("views.open was called with this view")
+instead of mock internals.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import secrets
+import time
+import urllib.parse
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+from awaithumans.server.app import create_app
+from awaithumans.server.channels.slack import client as client_module
+from awaithumans.server.core import encryption
+from awaithumans.server.core.config import settings
+from awaithumans.server.db.connection import get_session
+from awaithumans.server.db.models import (  # noqa: F401 — register models
+    AuditEntry,
+    EmailSenderIdentity,
+    SlackInstallation,
+    Task,
+    TaskStatus,
+)
+from awaithumans.server.services.task_service import create_task, get_task
+from awaithumans.utils.constants import SLACK_ACTION_OPEN_REVIEW
+
+SIGNING_SECRET = "test-signing-secret"
+
+
+# ─── Fakes + fixtures ───────────────────────────────────────────────────
+
+
+class FakeSlackClient:
+    """Recorder that looks like `slack_sdk.web.async_client.AsyncWebClient`.
+
+    Only implements the methods the route actually calls. Every call is
+    recorded; tests inspect `self.calls` instead of untyped MagicMock
+    state.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def views_open(self, *, trigger_id: str, view: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append({"method": "views_open", "trigger_id": trigger_id, "view": view})
+        return {"ok": True}
+
+
+@pytest_asyncio.fixture
+async def slack_ctx() -> AsyncGenerator[tuple[AsyncClient, FakeSlackClient], None]:
+    """App with SLACK_SIGNING_SECRET + PAYLOAD_KEY configured, in-memory DB,
+    and `get_client_for_team` patched to return a single FakeSlackClient
+    the test can inspect."""
+    orig_signing = settings.SLACK_SIGNING_SECRET
+    orig_payload = settings.PAYLOAD_KEY
+    settings.SLACK_SIGNING_SECRET = SIGNING_SECRET
+    settings.PAYLOAD_KEY = secrets.token_urlsafe(32)
+    encryption.reset_key_cache()
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_session() -> AsyncGenerator[AsyncSession, None]:
+        async with factory() as s:
+            yield s
+
+    fake = FakeSlackClient()
+
+    # Patch the route's client resolver. The route resolves a per-team
+    # client via `get_client_for_team(session, team_id)`; we hand back
+    # the same fake for every call so the test can assert on it.
+    orig_resolver = client_module.get_client_for_team
+
+    async def fake_resolver(session: AsyncSession, team_id: str | None):
+        return fake
+
+    # The route imports by attribute reference (`from .client import
+    # get_client_for_team`), so we must also patch the route's binding.
+    from awaithumans.server.routes.slack import interactions as interactions_route
+
+    client_module.get_client_for_team = fake_resolver  # type: ignore[assignment]
+    interactions_route.get_client_for_team = fake_resolver  # type: ignore[assignment]
+
+    app = create_app(serve_dashboard=False)
+    app.dependency_overrides[get_session] = override_session
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://testserver", follow_redirects=False
+    ) as c:
+        yield c, fake
+
+    client_module.get_client_for_team = orig_resolver  # type: ignore[assignment]
+    interactions_route.get_client_for_team = orig_resolver  # type: ignore[assignment]
+    await engine.dispose()
+    settings.SLACK_SIGNING_SECRET = orig_signing
+    settings.PAYLOAD_KEY = orig_payload
+    encryption.reset_key_cache()
+
+
+# ─── Helpers ────────────────────────────────────────────────────────────
+
+
+def _sign(
+    body: bytes,
+    *,
+    signing_secret: str = SIGNING_SECRET,
+    timestamp: int | None = None,
+) -> dict[str, str]:
+    """Produce the pair of headers Slack would send for a request."""
+    ts = str(timestamp if timestamp is not None else int(time.time()))
+    basestring = b"v0:" + ts.encode() + b":" + body
+    sig = "v0=" + hmac.new(signing_secret.encode(), basestring, hashlib.sha256).hexdigest()
+    return {
+        "X-Slack-Request-Timestamp": ts,
+        "X-Slack-Signature": sig,
+        "Content-Type": "application/x-www-form-urlencoded",
+    }
+
+
+def _form_body(payload: dict[str, Any]) -> bytes:
+    """Encode a Slack interactivity payload the way Slack actually does."""
+    return urllib.parse.urlencode({"payload": json.dumps(payload)}).encode()
+
+
+def _switch_form() -> dict[str, Any]:
+    """Minimal FormDefinition with a single switch field — enough to
+    drive a view_submission through `slack_values_to_response`."""
+    return {
+        "version": 1,
+        "fields": [
+            {
+                "kind": "switch",
+                "required": True,
+                "default": None,
+                "true_label": "Yes",
+                "false_label": "No",
+                "name": "approved",
+                "label": "Approve?",
+                "hint": None,
+            },
+        ],
+    }
+
+
+async def _seed_task(client: AsyncClient, *, form_definition: dict[str, Any] | None) -> str:
+    """Create a task directly in the overridden DB and return its id."""
+    override = client._transport.app.dependency_overrides[get_session]  # type: ignore[attr-defined]
+    async for s in override():
+        task = await create_task(
+            s,
+            task="Approve refund",
+            payload={"amount": 100},
+            payload_schema={},
+            response_schema={},
+            timeout_seconds=900,
+            idempotency_key=f"slack-e2e-{secrets.token_hex(4)}",
+            form_definition=form_definition,
+        )
+        return task.id
+    raise RuntimeError("session override did not yield")
+
+
+async def _read_task(client: AsyncClient, task_id: str) -> Task:
+    override = client._transport.app.dependency_overrides[get_session]  # type: ignore[attr-defined]
+    async for s in override():
+        return await get_task(s, task_id)
+    raise RuntimeError("session override did not yield")
+
+
+# ─── Signature gate ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_interactions_rejects_missing_signature(
+    slack_ctx: tuple[AsyncClient, FakeSlackClient],
+) -> None:
+    client, _ = slack_ctx
+    body = _form_body({"type": "block_actions", "actions": []})
+    resp = await client.post(
+        "/api/channels/slack/interactions",
+        content=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_interactions_rejects_bad_signature(
+    slack_ctx: tuple[AsyncClient, FakeSlackClient],
+) -> None:
+    client, _ = slack_ctx
+    body = _form_body({"type": "block_actions", "actions": []})
+    headers = _sign(body)
+    headers["X-Slack-Signature"] = "v0=" + "0" * 64   # well-formed but wrong
+    resp = await client.post(
+        "/api/channels/slack/interactions", content=body, headers=headers
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_interactions_rejects_stale_timestamp(
+    slack_ctx: tuple[AsyncClient, FakeSlackClient],
+) -> None:
+    client, _ = slack_ctx
+    body = _form_body({"type": "block_actions", "actions": []})
+    # 10 minutes old — the signing module caps at 5 minutes.
+    headers = _sign(body, timestamp=int(time.time()) - 600)
+    resp = await client.post(
+        "/api/channels/slack/interactions", content=body, headers=headers
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_interactions_503_when_secret_unset(
+    slack_ctx: tuple[AsyncClient, FakeSlackClient],
+) -> None:
+    client, _ = slack_ctx
+    orig = settings.SLACK_SIGNING_SECRET
+    settings.SLACK_SIGNING_SECRET = None
+    try:
+        resp = await client.post(
+            "/api/channels/slack/interactions",
+            content=b"",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        assert resp.status_code == 503
+    finally:
+        settings.SLACK_SIGNING_SECRET = orig
+
+
+@pytest.mark.asyncio
+async def test_interactions_400_on_missing_payload(
+    slack_ctx: tuple[AsyncClient, FakeSlackClient],
+) -> None:
+    client, _ = slack_ctx
+    # Signed but empty body — signature verifies, but the form has no `payload` key.
+    resp = await client.post(
+        "/api/channels/slack/interactions", content=b"", headers=_sign(b"")
+    )
+    assert resp.status_code == 400
+
+
+# ─── block_actions → views.open ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_block_actions_opens_modal(
+    slack_ctx: tuple[AsyncClient, FakeSlackClient],
+) -> None:
+    client, fake = slack_ctx
+    task_id = await _seed_task(client, form_definition=_switch_form())
+
+    payload = {
+        "type": "block_actions",
+        "trigger_id": "trigger-xyz",
+        "team": {"id": "T_ACME"},
+        "actions": [
+            {"action_id": SLACK_ACTION_OPEN_REVIEW, "value": task_id},
+        ],
+    }
+    body = _form_body(payload)
+    resp = await client.post(
+        "/api/channels/slack/interactions", content=body, headers=_sign(body)
+    )
+    assert resp.status_code == 200
+
+    # views.open should have been called exactly once with a modal view
+    # whose private_metadata carries the task_id.
+    assert len(fake.calls) == 1
+    call = fake.calls[0]
+    assert call["method"] == "views_open"
+    assert call["trigger_id"] == "trigger-xyz"
+    view = call["view"]
+    assert view["type"] == "modal"
+    assert view["private_metadata"] == task_id
+    # Block Kit modal should contain at least one input block for the switch.
+    assert any(b.get("type") == "input" for b in view["blocks"])
+
+
+@pytest.mark.asyncio
+async def test_block_actions_ignores_non_open_action(
+    slack_ctx: tuple[AsyncClient, FakeSlackClient],
+) -> None:
+    """A click on the dashboard link-out button (different action_id) is a no-op."""
+    client, fake = slack_ctx
+    payload = {
+        "type": "block_actions",
+        "trigger_id": "t",
+        "team": {"id": "T"},
+        "actions": [{"action_id": "awaithumans.open_dashboard", "value": "ignored"}],
+    }
+    body = _form_body(payload)
+    resp = await client.post(
+        "/api/channels/slack/interactions", content=body, headers=_sign(body)
+    )
+    assert resp.status_code == 200
+    assert fake.calls == []
+
+
+@pytest.mark.asyncio
+async def test_block_actions_silent_when_task_has_no_form(
+    slack_ctx: tuple[AsyncClient, FakeSlackClient],
+) -> None:
+    """Task without form_definition → log-and-skip, no modal opened."""
+    client, fake = slack_ctx
+    task_id = await _seed_task(client, form_definition=None)
+    payload = {
+        "type": "block_actions",
+        "trigger_id": "t",
+        "team": {"id": "T"},
+        "actions": [{"action_id": SLACK_ACTION_OPEN_REVIEW, "value": task_id}],
+    }
+    body = _form_body(payload)
+    resp = await client.post(
+        "/api/channels/slack/interactions", content=body, headers=_sign(body)
+    )
+    assert resp.status_code == 200
+    assert fake.calls == []
+
+
+# ─── view_submission → complete task ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_view_submission_completes_task(
+    slack_ctx: tuple[AsyncClient, FakeSlackClient],
+) -> None:
+    client, _ = slack_ctx
+    task_id = await _seed_task(client, form_definition=_switch_form())
+
+    # Slack sends back the user's selections under `view.state.values`,
+    # keyed by block_id. Our coerce layer maps that into the form's
+    # field names — here, `approved` → True (from selecting the "true"
+    # option on a radio_buttons element).
+    payload = {
+        "type": "view_submission",
+        "user": {"username": "alice@acme.com"},
+        "view": {
+            "private_metadata": task_id,
+            "state": {
+                "values": {
+                    "awaithumans:approved": {
+                        "approved": {
+                            "type": "radio_buttons",
+                            "selected_option": {"value": "true"},
+                        },
+                    },
+                },
+            },
+        },
+    }
+    body = _form_body(payload)
+    resp = await client.post(
+        "/api/channels/slack/interactions", content=body, headers=_sign(body)
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {}  # empty response closes the modal
+
+    updated = await _read_task(client, task_id)
+    assert updated.status == TaskStatus.COMPLETED
+    assert updated.response == {"approved": True}
+    assert updated.completed_via_channel == "slack"
+    assert updated.completed_by_email == "alice@acme.com"
+
+
+@pytest.mark.asyncio
+async def test_view_submission_missing_metadata_400(
+    slack_ctx: tuple[AsyncClient, FakeSlackClient],
+) -> None:
+    """A modal submission without private_metadata can't be routed to a task."""
+    client, _ = slack_ctx
+    payload = {
+        "type": "view_submission",
+        "user": {"username": "a"},
+        "view": {"state": {"values": {}}},
+    }
+    body = _form_body(payload)
+    resp = await client.post(
+        "/api/channels/slack/interactions", content=body, headers=_sign(body)
+    )
+    assert resp.status_code == 400
+
+
+# ─── Unknown payload type ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_unknown_payload_type_is_no_op(
+    slack_ctx: tuple[AsyncClient, FakeSlackClient],
+) -> None:
+    """Slack emits many interaction types (shortcut, message_action, …) we
+    don't handle yet. They should 200 with no body and not throw."""
+    client, fake = slack_ctx
+    payload = {"type": "shortcut", "user": {"id": "U"}}
+    body = _form_body(payload)
+    resp = await client.post(
+        "/api/channels/slack/interactions", content=body, headers=_sign(body)
+    )
+    assert resp.status_code == 200
+    assert fake.calls == []

--- a/packages/typescript-sdk/package-lock.json
+++ b/packages/typescript-sdk/package-lock.json
@@ -1,0 +1,1475 @@
+{
+  "name": "awaithumans",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "awaithumans",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.23.0",
+        "zod-to-json-schema": "^3.23.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.7.0",
+        "vitest": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@langchain/langgraph": "^0.2.0",
+        "@temporalio/client": "^1.0.0",
+        "@temporalio/workflow": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@langchain/langgraph": {
+          "optional": true
+        },
+        "@temporalio/client": {
+          "optional": true
+        },
+        "@temporalio/workflow": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/packages/typescript-sdk/src/await-human.ts
+++ b/packages/typescript-sdk/src/await-human.ts
@@ -1,20 +1,58 @@
-import { zodToJsonSchema } from "zod-to-json-schema";
-import { MIN_TIMEOUT_MS, MAX_TIMEOUT_MS } from "./constants";
-import { MarketplaceNotAvailableError, SchemaValidationError, TimeoutRangeError } from "./errors";
-import type { AwaitHumanOptions } from "./types";
-import { generateIdempotencyKey } from "./idempotency";
-
 /**
- * Delegate a task to a human and await the result.
+ * awaitHuman — delegate a task to a human and await the result.
  *
- * Direct mode: long-polls the server until the human completes or timeout.
- * For durable mode, import from `@awaithumans/temporal` or `@awaithumans/langgraph` instead.
+ * Direct mode: creates a task on the server via POST /api/tasks, then
+ * long-polls GET /api/tasks/{id}/poll until a terminal status or the
+ * caller-side deadline expires. Reconnects each `POLL_INTERVAL_SECONDS`
+ * to stay under gateway timeouts.
+ *
+ * For durable workflows, use the Temporal or LangGraph adapter — they
+ * wrap this same primitive with engine-level persistence.
+ *
+ * Cross-runtime: only uses `fetch`, `AbortController`, `crypto.subtle`,
+ * and `TextEncoder`. No node:* imports.
  */
+
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+import {
+	CREATE_TASK_TIMEOUT_MS,
+	DEFAULT_SERVER_URL,
+	MAX_TIMEOUT_MS,
+	MIN_TIMEOUT_MS,
+	POLL_FETCH_SLACK_SECONDS,
+	POLL_INTERVAL_SECONDS,
+} from "./constants";
+import { envVar } from "./env";
+import {
+	MarketplaceNotAvailableError,
+	PollError,
+	SchemaValidationError,
+	ServerUnreachableError,
+	TaskCancelledError,
+	TaskCreateError,
+	TaskNotFoundError,
+	TaskTimeoutError,
+	TimeoutRangeError,
+	VerificationExhaustedError,
+} from "./errors";
+import { generateIdempotencyKey } from "./idempotency";
+import type { AwaitHumanOptions } from "./types";
+import {
+	type CreateTaskRequestWire,
+	type CreateTaskResponseWire,
+	type PollResponseWire,
+	serializeAssignTo,
+} from "./wire";
+
 export async function awaitHuman<TPayload, TResponse>(
 	options: AwaitHumanOptions<TPayload, TResponse>,
 ): Promise<TResponse> {
 	// ── Validate timeout range ──────────────────────────────────────────
-	if (options.timeoutMs < MIN_TIMEOUT_MS || options.timeoutMs > MAX_TIMEOUT_MS) {
+	if (
+		options.timeoutMs < MIN_TIMEOUT_MS ||
+		options.timeoutMs > MAX_TIMEOUT_MS
+	) {
 		throw new TimeoutRangeError(options.timeoutMs);
 	}
 
@@ -33,38 +71,157 @@ export async function awaitHuman<TPayload, TResponse>(
 		throw new MarketplaceNotAvailableError();
 	}
 
+	// ── Resolve server URL ──────────────────────────────────────────────
+	const serverUrl = (
+		options.serverUrl ?? envVar("AWAITHUMANS_URL") ?? DEFAULT_SERVER_URL
+	).replace(/\/$/, "");
+
 	// ── Generate idempotency key ────────────────────────────────────────
 	const idempotencyKey =
-		options.idempotencyKey ?? (await generateIdempotencyKey(options.task, options.payload));
+		options.idempotencyKey ??
+		(await generateIdempotencyKey(options.task, options.payload));
 
-	// ── Convert schemas to JSON Schema for the wire ─────────────────────
+	// ── Build wire body ─────────────────────────────────────────────────
 	const payloadJsonSchema = zodToJsonSchema(options.payloadSchema);
 	const responseJsonSchema = zodToJsonSchema(options.responseSchema);
+	const timeoutSeconds = Math.round(options.timeoutMs / 1000);
 
-	// ── Resolve server URL (cross-platform, no node:* dependency) ───────
-	const envUrl =
-		typeof globalThis.process !== "undefined"
-			? globalThis.process.env?.AWAITHUMANS_URL
-			: undefined;
-	const serverUrl = options.serverUrl ?? envUrl ?? "http://localhost:3001";
+	const body: CreateTaskRequestWire = {
+		task: options.task,
+		payload: options.payload,
+		payload_schema: payloadJsonSchema,
+		response_schema: responseJsonSchema,
+		// form_definition is optional on the server. The TS SDK can't yet
+		// extract per-primitive form metadata from a Zod schema the way
+		// the Python SDK does from Pydantic — the dashboard falls back to
+		// generic JSON-schema rendering, which is fine. Future work:
+		// adopt the FormDefinition wire format from the forms framework.
+		form_definition: null,
+		timeout_seconds: timeoutSeconds,
+		idempotency_key: idempotencyKey,
+		assign_to: serializeAssignTo(options.assignTo),
+		notify: options.notify ?? null,
+		verifier_config: options.verifier ?? null,
+		redact_payload: options.redactPayload ?? false,
+		callback_url: null,
+	};
 
-	// ── Create task on the server ───────────────────────────────────────
-	// TODO: POST ${serverUrl}/api/tasks
-	// Body: { task, payload, payloadSchema: payloadJsonSchema, responseSchema: responseJsonSchema,
-	//         timeoutMs, assignTo, notify, idempotencyKey, redactPayload }
-	// Returns: { taskId }
+	// ── POST /api/tasks ─────────────────────────────────────────────────
+	const task = await createTask(serverUrl, body);
 
-	// ── Long-poll until completion or timeout ───────────────────────────
-	// TODO: GET ${serverUrl}/api/tasks/${taskId}/poll
-	// Reconnect every ~25s to stay under gateway timeouts.
-	// On completion: validate response against responseSchema, return typed result.
-	// On timeout: throw TimeoutError.
-	// On verification_exhausted: throw VerificationExhaustedError.
+	// ── Long-poll until terminal ────────────────────────────────────────
+	return await pollUntilTerminal(
+		serverUrl,
+		task.id,
+		options.task,
+		timeoutSeconds,
+		options.responseSchema,
+	);
+}
 
-	// ── Placeholder until server is built ───────────────────────────────
-	void idempotencyKey;
-	void payloadJsonSchema;
-	void responseJsonSchema;
-	void serverUrl;
-	throw new Error("Not yet implemented — awaiting server package build.");
+// ─── Internals ──────────────────────────────────────────────────────────
+
+async function createTask(
+	serverUrl: string,
+	body: CreateTaskRequestWire,
+): Promise<CreateTaskResponseWire> {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), CREATE_TASK_TIMEOUT_MS);
+
+	let resp: Response;
+	try {
+		resp = await fetch(`${serverUrl}/api/tasks`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+			signal: controller.signal,
+		});
+	} catch (err) {
+		throw new ServerUnreachableError(serverUrl, err);
+	} finally {
+		clearTimeout(timer);
+	}
+
+	if (resp.status !== 200 && resp.status !== 201) {
+		const text = await safeBodyText(resp);
+		throw new TaskCreateError(resp.status, text);
+	}
+
+	return (await resp.json()) as CreateTaskResponseWire;
+}
+
+async function pollUntilTerminal<TResponse>(
+	serverUrl: string,
+	taskId: string,
+	taskDescription: string,
+	timeoutSeconds: number,
+	// The response schema validates the server's returned response.
+	// Typed as the user-supplied Zod schema to preserve inference.
+	responseSchema: AwaitHumanOptions<unknown, TResponse>["responseSchema"],
+): Promise<TResponse> {
+	const url = `${serverUrl}/api/tasks/${encodeURIComponent(
+		taskId,
+	)}/poll?timeout=${POLL_INTERVAL_SECONDS}`;
+	const fetchTimeoutMs =
+		(POLL_INTERVAL_SECONDS + POLL_FETCH_SLACK_SECONDS) * 1000;
+
+	// Loop forever — the terminal-status branches below all either
+	// return or throw. The server's poll endpoint holds each request
+	// for ~POLL_INTERVAL_SECONDS and then returns the current status.
+	// When the status is non-terminal we reconnect.
+	while (true) {
+		const controller = new AbortController();
+		const timer = setTimeout(() => controller.abort(), fetchTimeoutMs);
+
+		let resp: Response;
+		try {
+			resp = await fetch(url, { signal: controller.signal });
+		} catch (err) {
+			throw new ServerUnreachableError(serverUrl, err);
+		} finally {
+			clearTimeout(timer);
+		}
+
+		if (resp.status === 404) {
+			throw new TaskNotFoundError(taskId);
+		}
+		if (resp.status !== 200) {
+			throw new PollError(taskId, resp.status, await safeBodyText(resp));
+		}
+
+		const poll = (await resp.json()) as PollResponseWire;
+
+		switch (poll.status) {
+			case "completed": {
+				const validated = responseSchema.safeParse(poll.response);
+				if (!validated.success) {
+					throw new SchemaValidationError(
+						"response",
+						validated.error.message,
+					);
+				}
+				return validated.data;
+			}
+			case "timed_out":
+				throw new TaskTimeoutError(taskDescription, timeoutSeconds * 1000);
+			case "cancelled":
+				throw new TaskCancelledError(taskDescription);
+			case "verification_exhausted":
+				throw new VerificationExhaustedError(
+					taskDescription,
+					poll.verification_attempt ?? 0,
+				);
+			// Everything else is non-terminal — keep polling.
+			default:
+				continue;
+		}
+	}
+}
+
+async function safeBodyText(resp: Response): Promise<string> {
+	try {
+		return await resp.text();
+	} catch {
+		return "";
+	}
 }

--- a/packages/typescript-sdk/src/await-human.ts
+++ b/packages/typescript-sdk/src/await-human.ts
@@ -28,7 +28,6 @@ import {
 	MarketplaceNotAvailableError,
 	PollError,
 	SchemaValidationError,
-	ServerUnreachableError,
 	TaskCancelledError,
 	TaskCreateError,
 	TaskNotFoundError,
@@ -36,6 +35,7 @@ import {
 	TimeoutRangeError,
 	VerificationExhaustedError,
 } from "./errors";
+import { fetchWithTimeout } from "./fetch";
 import { generateIdempotencyKey } from "./idempotency";
 import type { AwaitHumanOptions } from "./types";
 import {
@@ -110,7 +110,7 @@ export async function awaitHuman<TPayload, TResponse>(
 	const task = await createTask(serverUrl, body);
 
 	// ── Long-poll until terminal ────────────────────────────────────────
-	return await pollUntilTerminal(
+	return pollUntilTerminal(
 		serverUrl,
 		task.id,
 		options.task,
@@ -125,26 +125,19 @@ async function createTask(
 	serverUrl: string,
 	body: CreateTaskRequestWire,
 ): Promise<CreateTaskResponseWire> {
-	const controller = new AbortController();
-	const timer = setTimeout(() => controller.abort(), CREATE_TASK_TIMEOUT_MS);
-
-	let resp: Response;
-	try {
-		resp = await fetch(`${serverUrl}/api/tasks`, {
+	const resp = await fetchWithTimeout(
+		`${serverUrl}/api/tasks`,
+		{
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(body),
-			signal: controller.signal,
-		});
-	} catch (err) {
-		throw new ServerUnreachableError(serverUrl, err);
-	} finally {
-		clearTimeout(timer);
-	}
+		},
+		CREATE_TASK_TIMEOUT_MS,
+		serverUrl,
+	);
 
 	if (resp.status !== 200 && resp.status !== 201) {
-		const text = await safeBodyText(resp);
-		throw new TaskCreateError(resp.status, text);
+		throw new TaskCreateError(resp.status, await safeBodyText(resp));
 	}
 
 	return (await resp.json()) as CreateTaskResponseWire;
@@ -170,17 +163,7 @@ async function pollUntilTerminal<TResponse>(
 	// for ~POLL_INTERVAL_SECONDS and then returns the current status.
 	// When the status is non-terminal we reconnect.
 	while (true) {
-		const controller = new AbortController();
-		const timer = setTimeout(() => controller.abort(), fetchTimeoutMs);
-
-		let resp: Response;
-		try {
-			resp = await fetch(url, { signal: controller.signal });
-		} catch (err) {
-			throw new ServerUnreachableError(serverUrl, err);
-		} finally {
-			clearTimeout(timer);
-		}
+		const resp = await fetchWithTimeout(url, {}, fetchTimeoutMs, serverUrl);
 
 		if (resp.status === 404) {
 			throw new TaskNotFoundError(taskId);

--- a/packages/typescript-sdk/src/constants.ts
+++ b/packages/typescript-sdk/src/constants.ts
@@ -10,6 +10,22 @@ export const MIN_TIMEOUT_MS = 60_000;
 /** Maximum timeout in milliseconds (30 days). */
 export const MAX_TIMEOUT_MS = 2_592_000_000;
 
+/** Default server URL when no explicit override or env var is set. Must match
+ *  the Python server's default bind port. */
+export const DEFAULT_SERVER_URL = "http://localhost:3001";
+
+/** How long each long-poll request holds the connection before reconnecting,
+ *  in seconds. Matches the Python SDK; stays safely under typical 30s/60s
+ *  gateway timeouts so intermediate proxies don't kill the socket. */
+export const POLL_INTERVAL_SECONDS = 25;
+
+/** Extra headroom on the fetch timeout beyond the server's poll window —
+ *  gives the socket time to close cleanly before we abort. */
+export const POLL_FETCH_SLACK_SECONDS = 10;
+
+/** Timeout for the initial `POST /api/tasks` request. */
+export const CREATE_TASK_TIMEOUT_MS = 30_000;
+
 /** Docs base URLs for error messages. */
 export const DOCS_BASE_URL = "https://awaithumans.dev/docs";
 export const DOCS_TROUBLESHOOTING_URL = `${DOCS_BASE_URL}/troubleshooting`;

--- a/packages/typescript-sdk/src/env.ts
+++ b/packages/typescript-sdk/src/env.ts
@@ -1,0 +1,22 @@
+/**
+ * Cross-runtime env-var lookup.
+ *
+ * `process.env` only exists on Node. Bun + Deno expose equivalent APIs
+ * through their own namespaces; edge runtimes and browsers have none.
+ * `globalThis.process` is typed as `undefined` by the DOM lib, so we
+ * narrow via a typed shim rather than sprinkling `any` casts across
+ * the SDK.
+ *
+ * Only called from SDK entry points (awaitHuman). Pure function — no
+ * caching. Returns `undefined` when the var isn't set or the runtime
+ * has no env surface.
+ */
+
+interface EnvHost {
+	process?: { env?: Record<string, string | undefined> };
+}
+
+export function envVar(name: string): string | undefined {
+	const host = globalThis as unknown as EnvHost;
+	return host.process?.env?.[name];
+}

--- a/packages/typescript-sdk/src/errors.ts
+++ b/packages/typescript-sdk/src/errors.ts
@@ -114,3 +114,66 @@ export class MarketplaceNotAvailableError extends AwaitHumansError {
 		});
 	}
 }
+
+// ─── Runtime errors returned by the server ───────────────────────────
+
+export class TaskNotFoundError extends AwaitHumansError {
+	constructor(taskId: string) {
+		super({
+			code: "TASK_NOT_FOUND",
+			message: `Task "${taskId}" not found on the server.`,
+			hint:
+				"The task may have been deleted or the server was restarted with a fresh database.",
+			docsUrl: `${DOCS_TROUBLESHOOTING_URL}#task-not-found`,
+		});
+	}
+}
+
+export class TaskCancelledError extends AwaitHumansError {
+	constructor(task: string) {
+		super({
+			code: "TASK_CANCELLED",
+			message: `Task "${task}" was cancelled.`,
+			hint: "The task was cancelled by an admin or another agent before a human completed it.",
+			docsUrl: `${DOCS_TROUBLESHOOTING_URL}#task-cancelled`,
+		});
+	}
+}
+
+export class TaskCreateError extends AwaitHumansError {
+	constructor(status: number, serverBody: string) {
+		super({
+			code: "TASK_CREATE_FAILED",
+			message: `Failed to create task on the server (HTTP ${status}).`,
+			hint: `Server response: ${serverBody.slice(0, 500)}`,
+			docsUrl: `${DOCS_TROUBLESHOOTING_URL}#task-create-failed`,
+		});
+	}
+}
+
+export class PollError extends AwaitHumansError {
+	constructor(taskId: string, status: number, serverBody: string) {
+		super({
+			code: "POLL_FAILED",
+			message: `Failed to poll task "${taskId}" (HTTP ${status}).`,
+			hint: `Server response: ${serverBody.slice(0, 500)}`,
+			docsUrl: `${DOCS_TROUBLESHOOTING_URL}#poll-failed`,
+		});
+	}
+}
+
+export class ServerUnreachableError extends AwaitHumansError {
+	constructor(serverUrl: string, cause: unknown) {
+		super({
+			code: "SERVER_UNREACHABLE",
+			message: `Could not reach the awaithumans server at ${serverUrl}.`,
+			hint: [
+				"Check:",
+				"  1. Is the server running? (awaithumans dev)",
+				"  2. Is the URL correct? Override with `serverUrl` or AWAITHUMANS_URL.",
+				`  3. Underlying error: ${String(cause)}`,
+			].join("\n"),
+			docsUrl: `${DOCS_TROUBLESHOOTING_URL}#server-unreachable`,
+		});
+	}
+}

--- a/packages/typescript-sdk/src/fetch.ts
+++ b/packages/typescript-sdk/src/fetch.ts
@@ -1,0 +1,31 @@
+/**
+ * `fetch` + `AbortController` + `ServerUnreachableError` in one call.
+ *
+ * Both `createTask` and `pollUntilTerminal` repeat the same pattern:
+ * spin up a controller, set a timer, wrap the fetch in try/catch/
+ * finally, map transport failures to our typed error. This helper
+ * owns that shape so the call sites read as HTTP intent only.
+ *
+ * Leaves status-code handling to the caller — different routes map
+ * non-2xx to different SDK errors (TaskCreateError, PollError, etc.).
+ */
+
+import { ServerUnreachableError } from "./errors";
+
+export async function fetchWithTimeout(
+	url: string,
+	init: RequestInit,
+	timeoutMs: number,
+	/** Origin shown in the ServerUnreachableError message when the network fails. */
+	serverOrigin: string,
+): Promise<Response> {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), timeoutMs);
+	try {
+		return await fetch(url, { ...init, signal: controller.signal });
+	} catch (err) {
+		throw new ServerUnreachableError(serverOrigin, err);
+	} finally {
+		clearTimeout(timer);
+	}
+}

--- a/packages/typescript-sdk/src/index.ts
+++ b/packages/typescript-sdk/src/index.ts
@@ -34,12 +34,17 @@ export { awaitHumanInputSchema } from "./schemas";
 
 export {
 	AwaitHumansError,
-	TaskTimeoutError,
-	SchemaValidationError,
-	TimeoutRangeError,
-	TaskAlreadyTerminalError,
-	VerificationExhaustedError,
 	MarketplaceNotAvailableError,
+	PollError,
+	SchemaValidationError,
+	ServerUnreachableError,
+	TaskAlreadyTerminalError,
+	TaskCancelledError,
+	TaskCreateError,
+	TaskNotFoundError,
+	TaskTimeoutError,
+	TimeoutRangeError,
+	VerificationExhaustedError,
 } from "./errors";
 
 export { awaitAgent, awaitAny } from "./reserved";

--- a/packages/typescript-sdk/src/wire.ts
+++ b/packages/typescript-sdk/src/wire.ts
@@ -1,0 +1,61 @@
+/**
+ * Wire protocol: request/response shapes exchanged with the Python server.
+ *
+ * The Python server uses snake_case JSON on the HTTP surface. The SDK
+ * speaks camelCase internally (idiomatic TS). This file owns the
+ * translation so the rest of the SDK doesn't have to think about it.
+ *
+ * Kept as plain `interface`s (not Zod schemas) — the server is the
+ * source of truth for validation; the SDK trusts responses it receives
+ * and only validates user inputs (payload/response against caller schemas).
+ */
+
+import type { TaskStatus } from "./types";
+
+// ─── POST /api/tasks ─────────────────────────────────────────────────
+
+export interface CreateTaskRequestWire {
+	task: string;
+	payload: unknown;
+	payload_schema: unknown;
+	response_schema: unknown;
+	form_definition: unknown | null;
+	timeout_seconds: number;
+	idempotency_key: string;
+	assign_to: unknown | null;
+	notify: string[] | null;
+	verifier_config: unknown | null;
+	redact_payload: boolean;
+	callback_url: string | null;
+}
+
+export interface CreateTaskResponseWire {
+	id: string;
+	status: TaskStatus;
+	// The server returns the full TaskResponse on create, but the SDK
+	// only needs the id — everything else comes back via poll.
+}
+
+// ─── GET /api/tasks/{id}/poll ────────────────────────────────────────
+
+export interface PollResponseWire {
+	status: TaskStatus;
+	response: Record<string, unknown> | null;
+	completed_at: string | null;
+	timed_out_at: string | null;
+	verification_attempt?: number;
+}
+
+// ─── Assignment translation ──────────────────────────────────────────
+
+/**
+ * Convert the caller-friendly `AssignTo` shape into the server's wire
+ * format. Mirrors `awaithumans.client._serialize_assign_to`.
+ */
+export function serializeAssignTo(assignTo: unknown): unknown | null {
+	if (assignTo == null) return null;
+	if (typeof assignTo === "string") return { email: assignTo };
+	if (Array.isArray(assignTo)) return { emails: assignTo };
+	if (typeof assignTo === "object") return assignTo;
+	return { value: String(assignTo) };
+}

--- a/packages/typescript-sdk/tests/await-human.test.ts
+++ b/packages/typescript-sdk/tests/await-human.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Unit tests for `awaitHuman` — covers the wire protocol round-trip
+ * against a stubbed `fetch`, every terminal status branch, the
+ * validation gates (timeout range, payload schema, marketplace), and
+ * the ServerUnreachable path when the network itself fails.
+ *
+ * Deliberately no real HTTP — the server is Python and has its own
+ * integration tests. What we care about here is that the SDK speaks
+ * the wire format the server expects and maps every response to the
+ * right SDK-level behaviour.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import { awaitHuman } from "../src/await-human";
+import {
+	MarketplaceNotAvailableError,
+	PollError,
+	SchemaValidationError,
+	ServerUnreachableError,
+	TaskCancelledError,
+	TaskCreateError,
+	TaskNotFoundError,
+	TaskTimeoutError,
+	TimeoutRangeError,
+	VerificationExhaustedError,
+} from "../src/errors";
+
+// ─── Fixtures ────────────────────────────────────────────────────────
+
+const payloadSchema = z.object({ amount: z.number() });
+const responseSchema = z.object({ approved: z.boolean() });
+
+const BASE_OPTIONS = {
+	task: "Approve wire",
+	payloadSchema,
+	payload: { amount: 50000 },
+	responseSchema,
+	timeoutMs: 60_000,
+	serverUrl: "http://test.local",
+};
+
+// ─── Fetch stub ─────────────────────────────────────────────────────
+
+/**
+ * Minimal Response-like object. The SDK only calls `.json()`, `.text()`,
+ * and reads `.status` — no need to touch `globalThis.Response`.
+ */
+function makeResponse(status: number, body: unknown): Response {
+	return {
+		status,
+		json: async () => body,
+		text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+	} as unknown as Response;
+}
+
+type FetchMock = ReturnType<typeof vi.fn>;
+
+function installFetchSequence(responses: Response[]): FetchMock {
+	const fetchMock = vi.fn();
+	for (const r of responses) {
+		fetchMock.mockResolvedValueOnce(r);
+	}
+	globalThis.fetch = fetchMock as unknown as typeof fetch;
+	return fetchMock;
+}
+
+function installFetchReject(err: Error): FetchMock {
+	const fetchMock = vi.fn().mockRejectedValue(err);
+	globalThis.fetch = fetchMock as unknown as typeof fetch;
+	return fetchMock;
+}
+
+beforeEach(() => {
+	vi.useRealTimers();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+// ─── Validation gates ────────────────────────────────────────────────
+
+describe("input validation", () => {
+	it("rejects timeoutMs below 1 minute", async () => {
+		await expect(
+			awaitHuman({ ...BASE_OPTIONS, timeoutMs: 30_000 }),
+		).rejects.toBeInstanceOf(TimeoutRangeError);
+	});
+
+	it("rejects timeoutMs above 30 days", async () => {
+		await expect(
+			awaitHuman({ ...BASE_OPTIONS, timeoutMs: 10_000_000_000 }),
+		).rejects.toBeInstanceOf(TimeoutRangeError);
+	});
+
+	it("rejects payload that doesn't match the schema", async () => {
+		await expect(
+			awaitHuman({
+				...BASE_OPTIONS,
+				// `amount` must be a number; we send a string.
+				payload: { amount: "not-a-number" } as unknown as { amount: number },
+			}),
+		).rejects.toBeInstanceOf(SchemaValidationError);
+	});
+
+	it("rejects reserved marketplace assignment", async () => {
+		await expect(
+			awaitHuman({ ...BASE_OPTIONS, assignTo: { marketplace: true } }),
+		).rejects.toBeInstanceOf(MarketplaceNotAvailableError);
+	});
+});
+
+// ─── Happy path ──────────────────────────────────────────────────────
+
+describe("happy path", () => {
+	it("POSTs a well-formed create body and returns the validated response", async () => {
+		const fetchMock = installFetchSequence([
+			makeResponse(200, { id: "task-1", status: "created" }),
+			makeResponse(200, { status: "completed", response: { approved: true } }),
+		]);
+
+		const result = await awaitHuman(BASE_OPTIONS);
+		expect(result).toEqual({ approved: true });
+
+		// First call: POST /api/tasks with a snake_case wire body.
+		const [createUrl, createInit] = fetchMock.mock.calls[0];
+		expect(createUrl).toBe("http://test.local/api/tasks");
+		expect(createInit.method).toBe("POST");
+		const body = JSON.parse(createInit.body);
+		expect(body).toMatchObject({
+			task: "Approve wire",
+			payload: { amount: 50000 },
+			timeout_seconds: 60,
+			redact_payload: false,
+			callback_url: null,
+			form_definition: null,
+		});
+		expect(typeof body.idempotency_key).toBe("string");
+		expect(body.payload_schema).toBeDefined();
+		expect(body.response_schema).toBeDefined();
+
+		// Second call: poll.
+		const [pollUrl] = fetchMock.mock.calls[1];
+		expect(pollUrl).toMatch(
+			/^http:\/\/test\.local\/api\/tasks\/task-1\/poll\?timeout=/,
+		);
+	});
+
+	it("reconnects on non-terminal poll responses", async () => {
+		const fetchMock = installFetchSequence([
+			makeResponse(200, { id: "task-1", status: "created" }),
+			// Server's long-poll times out with task still in flight.
+			makeResponse(200, { status: "in_progress", response: null }),
+			makeResponse(200, { status: "assigned", response: null }),
+			makeResponse(200, { status: "completed", response: { approved: false } }),
+		]);
+
+		const result = await awaitHuman(BASE_OPTIONS);
+		expect(result).toEqual({ approved: false });
+		// Create + 3 polls = 4 total fetch calls.
+		expect(fetchMock).toHaveBeenCalledTimes(4);
+	});
+
+	it("serializes assignTo: string into { email }", async () => {
+		const fetchMock = installFetchSequence([
+			makeResponse(200, { id: "t", status: "created" }),
+			makeResponse(200, { status: "completed", response: { approved: true } }),
+		]);
+
+		await awaitHuman({ ...BASE_OPTIONS, assignTo: "alice@acme.com" });
+
+		const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+		expect(body.assign_to).toEqual({ email: "alice@acme.com" });
+	});
+
+	it("serializes assignTo: string[] into { emails }", async () => {
+		const fetchMock = installFetchSequence([
+			makeResponse(200, { id: "t", status: "created" }),
+			makeResponse(200, { status: "completed", response: { approved: true } }),
+		]);
+
+		await awaitHuman({
+			...BASE_OPTIONS,
+			assignTo: ["alice@acme.com", "bob@acme.com"],
+		});
+
+		const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+		expect(body.assign_to).toEqual({
+			emails: ["alice@acme.com", "bob@acme.com"],
+		});
+	});
+
+	it("passes through explicit idempotency key", async () => {
+		const fetchMock = installFetchSequence([
+			makeResponse(200, { id: "t", status: "created" }),
+			makeResponse(200, { status: "completed", response: { approved: true } }),
+		]);
+
+		await awaitHuman({ ...BASE_OPTIONS, idempotencyKey: "explicit-key-xyz" });
+
+		const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+		expect(body.idempotency_key).toBe("explicit-key-xyz");
+	});
+});
+
+// ─── Terminal status branches ────────────────────────────────────────
+
+describe("terminal status handling", () => {
+	it("throws TaskTimeoutError on status=timed_out", async () => {
+		installFetchSequence([
+			makeResponse(200, { id: "t", status: "created" }),
+			makeResponse(200, { status: "timed_out", response: null }),
+		]);
+		await expect(awaitHuman(BASE_OPTIONS)).rejects.toBeInstanceOf(
+			TaskTimeoutError,
+		);
+	});
+
+	it("throws TaskCancelledError on status=cancelled", async () => {
+		installFetchSequence([
+			makeResponse(200, { id: "t", status: "created" }),
+			makeResponse(200, { status: "cancelled", response: null }),
+		]);
+		await expect(awaitHuman(BASE_OPTIONS)).rejects.toBeInstanceOf(
+			TaskCancelledError,
+		);
+	});
+
+	it("throws VerificationExhaustedError on status=verification_exhausted", async () => {
+		installFetchSequence([
+			makeResponse(200, { id: "t", status: "created" }),
+			makeResponse(200, {
+				status: "verification_exhausted",
+				response: null,
+				verification_attempt: 3,
+			}),
+		]);
+		await expect(awaitHuman(BASE_OPTIONS)).rejects.toBeInstanceOf(
+			VerificationExhaustedError,
+		);
+	});
+
+	it("throws SchemaValidationError when response doesn't match responseSchema", async () => {
+		installFetchSequence([
+			makeResponse(200, { id: "t", status: "created" }),
+			// Server claims completion but the response doesn't satisfy our schema.
+			makeResponse(200, { status: "completed", response: { approved: "yes" } }),
+		]);
+		await expect(awaitHuman(BASE_OPTIONS)).rejects.toBeInstanceOf(
+			SchemaValidationError,
+		);
+	});
+});
+
+// ─── Transport errors ────────────────────────────────────────────────
+
+describe("transport errors", () => {
+	it("throws TaskCreateError on non-2xx from POST /api/tasks", async () => {
+		installFetchSequence([makeResponse(503, "service unavailable")]);
+		await expect(awaitHuman(BASE_OPTIONS)).rejects.toBeInstanceOf(
+			TaskCreateError,
+		);
+	});
+
+	it("throws TaskNotFoundError on 404 from poll", async () => {
+		installFetchSequence([
+			makeResponse(200, { id: "t", status: "created" }),
+			makeResponse(404, "not found"),
+		]);
+		await expect(awaitHuman(BASE_OPTIONS)).rejects.toBeInstanceOf(
+			TaskNotFoundError,
+		);
+	});
+
+	it("throws PollError on non-200/404 from poll", async () => {
+		installFetchSequence([
+			makeResponse(200, { id: "t", status: "created" }),
+			makeResponse(500, "internal error"),
+		]);
+		await expect(awaitHuman(BASE_OPTIONS)).rejects.toBeInstanceOf(PollError);
+	});
+
+	it("throws ServerUnreachableError when fetch itself rejects", async () => {
+		installFetchReject(new Error("ECONNREFUSED"));
+		await expect(awaitHuman(BASE_OPTIONS)).rejects.toBeInstanceOf(
+			ServerUnreachableError,
+		);
+	});
+});
+
+// ─── Server URL resolution ──────────────────────────────────────────
+
+describe("server URL resolution", () => {
+	it("trims trailing slash from explicit serverUrl", async () => {
+		const fetchMock = installFetchSequence([
+			makeResponse(200, { id: "t", status: "created" }),
+			makeResponse(200, { status: "completed", response: { approved: true } }),
+		]);
+
+		await awaitHuman({ ...BASE_OPTIONS, serverUrl: "http://test.local/" });
+
+		expect(fetchMock.mock.calls[0][0]).toBe("http://test.local/api/tasks");
+	});
+});

--- a/packages/typescript-sdk/tests/idempotency.test.ts
+++ b/packages/typescript-sdk/tests/idempotency.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Idempotency key generation — the default key is derived from
+ * `task + payload` via canonical JSON + SHA-256.
+ *
+ * The canonicalisation matters: two payloads with the same data but
+ * different key insertion order must hash to the same key, or the
+ * server will see them as distinct tasks and defeat dedup.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { generateIdempotencyKey } from "../src/idempotency";
+
+describe("generateIdempotencyKey", () => {
+	it("returns the same key for the same inputs", async () => {
+		const a = await generateIdempotencyKey("approve", { amount: 100 });
+		const b = await generateIdempotencyKey("approve", { amount: 100 });
+		expect(a).toBe(b);
+	});
+
+	it("returns different keys when the task differs", async () => {
+		const a = await generateIdempotencyKey("approve", { amount: 100 });
+		const b = await generateIdempotencyKey("reject", { amount: 100 });
+		expect(a).not.toBe(b);
+	});
+
+	it("returns different keys when the payload differs", async () => {
+		const a = await generateIdempotencyKey("approve", { amount: 100 });
+		const b = await generateIdempotencyKey("approve", { amount: 200 });
+		expect(a).not.toBe(b);
+	});
+
+	it("is order-independent on object keys (canonical JSON)", async () => {
+		const a = await generateIdempotencyKey("t", { a: 1, b: 2 });
+		const b = await generateIdempotencyKey("t", { b: 2, a: 1 });
+		expect(a).toBe(b);
+	});
+
+	it("descends into nested objects", async () => {
+		const a = await generateIdempotencyKey("t", {
+			outer: { a: 1, b: 2 },
+		});
+		const b = await generateIdempotencyKey("t", {
+			outer: { b: 2, a: 1 },
+		});
+		expect(a).toBe(b);
+	});
+
+	it("preserves array order (arrays are not sorted)", async () => {
+		const a = await generateIdempotencyKey("t", { xs: [1, 2, 3] });
+		const b = await generateIdempotencyKey("t", { xs: [3, 2, 1] });
+		expect(a).not.toBe(b);
+	});
+
+	it("handles null and undefined", async () => {
+		const a = await generateIdempotencyKey("t", null);
+		const b = await generateIdempotencyKey("t", null);
+		expect(a).toBe(b);
+	});
+
+	it("returns a 32-char hex string (128-bit truncated SHA-256)", async () => {
+		const key = await generateIdempotencyKey("t", { x: 1 });
+		expect(key).toMatch(/^[0-9a-f]{32}$/);
+	});
+});

--- a/packages/typescript-sdk/tsconfig.json
+++ b/packages/typescript-sdk/tsconfig.json
@@ -1,8 +1,14 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
-  },
-  "include": ["src"]
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "dist",
+		"rootDir": "src",
+		// The SDK uses `fetch`, `AbortController`, `TextEncoder`, and
+		// `crypto.subtle` — all present in every modern runtime we care
+		// about (Node 18+, Bun, Deno, browsers, edge). The `DOM` lib
+		// provides the type declarations without pulling in a Node-
+		// specific `@types/node` dep that would break edge-runtime use.
+		"lib": ["ES2022", "DOM"]
+	},
+	"include": ["src"]
 }


### PR DESCRIPTION
Replaces the \"Not yet implemented\" stub with a full HTTP client against the Python server. Wire-protocol-matched to the Python SDK exactly.

## Summary

**What works now:** \`import { awaitHuman } from \"awaithumans\"\` → create task on server → long-poll → Zod-validated typed result. Live-tested end-to-end against a real Python server.

## Scope

**Included (Phase 1 — MVP):**
- Full \`awaitHuman()\` implementation: validation → POST \`/api/tasks\` → long-poll \`/api/tasks/{id}/poll\` → typed response
- 5 new error classes mirroring the Python SDK (\`TaskNotFoundError\`, \`TaskCancelledError\`, \`TaskCreateError\`, \`PollError\`, \`ServerUnreachableError\`)
- Cross-runtime env-var lookup (\`env.ts\`) — works on Node, Bun, Deno, edge
- Wire-format types + \`serializeAssignTo\` helper (\`wire.ts\`) — snake_case on the HTTP surface, camelCase on caller surface
- 26 tests (18 HTTP/behaviour + 8 idempotency)

**Deferred to follow-up PRs:**
- \`form_definition\` extraction from Zod (Python does this from Pydantic; TS currently sends \`null\` and the dashboard falls back to JSON-schema rendering)
- Temporal + LangGraph adapters
- \`createTestClient\` in-memory mock

## Wire compatibility

Every field in the POST body matches what the Python client sends: \`task\`, \`payload\`, \`payload_schema\`, \`response_schema\`, \`form_definition\`, \`timeout_seconds\`, \`idempotency_key\`, \`assign_to\`, \`notify\`, \`verifier_config\`, \`redact_payload\`, \`callback_url\`. Assertions in the test suite lock this down.

## Runtime constraints

Only uses \`fetch\`, \`AbortController\`, \`crypto.subtle\`, \`TextEncoder\`. No \`node:*\` imports. \`tsconfig\` lib broadened from \`ES2022\` to \`ES2022 + DOM\` so those globals type-check without pulling in \`@types/node\` (which would break edge-runtime use).

## Live smoke

Ran in the terminal against a real server:

\`\`\`
created task_id: fca6b127997241019a482cfd2320ca89
completed via API
SDK returned: { approved: true }
✅ smoke passed
\`\`\`

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] 26/26 vitest tests pass
- [x] Live end-to-end against a real Python server
- [ ] Manual verification on Bun / Deno (optional; same APIs as Node)

🤖 Generated with [Claude Code](https://claude.com/claude-code)