### PR TITLE
feat(docker): multi-stage Dockerfile + compose + GHA multi-arch publish

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,29 @@
+# Everything that shouldn't end up in the build context. Speeds up
+# `docker build` and avoids leaking dev junk into image layers.
+
+.git/
+.github/
+.pytest_cache/
+.ruff_cache/
+.turbo/
+.next/
+.venv/
+.env
+.env.*
+!.env.example
+
+**/node_modules/
+**/dist/
+**/build/
+**/__pycache__/
+**/*.pyc
+**/.DS_Store
+**/*.db
+**/*.sqlite*
+**/coverage/
+**/*.egg-info/
+
+# Other packages we don't need to build the Docker image:
+packages/typescript-sdk/
+examples/
+docs/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,79 @@
+name: Docker image
+
+# When this runs:
+#  - every push to main (tag: `:main`)
+#  - every push of a `v*.*.*` tag (tags: `:vX.Y.Z`, `:X.Y.Z`, `:latest`)
+#  - manual dispatch for one-off builds
+#
+# Publishes to ghcr.io/<owner>/awaithumans. GHCR is free, integrates
+# with GitHub auth (no extra secrets needed — GITHUB_TOKEN works), and
+# supports multi-arch manifests out of the box.
+#
+# Security note: every ${{ ... }} expansion below is a trusted context
+# value (github.repository, github.ref, github.actor, GITHUB_TOKEN,
+# workflow outputs from pinned actions). No user-controlled fields
+# like issue titles, commit messages, or PR bodies are interpolated
+# into `run:` blocks — nothing to inject.
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*.*.*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # QEMU lets us build linux/arm64 on an amd64 runner. Slower than
+      # a native arm runner but free and simple; switch to the
+      # `ubuntu-24.04-arm` runner for faster arm builds once it's GA on
+      # public repos. For now cross-compile is fine — heavy work is
+      # pure compute so the emulation overhead is bearable.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Produces tags for every trigger kind:
+      # push main       → :main
+      # push v1.2.3     → :v1.2.3, :1.2.3, :1.2, :1, :latest
+      - name: Resolve image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Cross-run cache — speeds up subsequent builds a lot.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,108 @@
+# syntax=docker/dockerfile:1.7
+
+# ──────────────────────────────────────────────────────────────────────
+# awaithumans — server + bundled dashboard in a single image.
+#
+# Multi-stage build:
+#
+#   1. `dashboard-builder` — Node + npm, runs scripts/build-bundled.sh
+#       which stashes app/api/, runs `next build` with static-export
+#       flags, and drops the output into the Python package at
+#       awaithumans/dashboard_dist/.
+#
+#   2. `wheel-builder` — Python + hatchling, takes the tree with the
+#       dashboard bundled in and produces a wheel (non-Python files
+#       inside the package ship automatically).
+#
+#   3. `runtime` — slim Python, installs the wheel with [server]
+#       extras, runs as a non-root user, exposes :3001.
+#
+# Users run `docker run -p 3001:3001 ghcr.io/awaithumans/awaithumans`
+# and get API + UI on the same port. No Python toolchain needed.
+# ──────────────────────────────────────────────────────────────────────
+
+# ── Stage 1: dashboard ──────────────────────────────────────────────
+FROM --platform=$BUILDPLATFORM node:22-slim AS dashboard-builder
+
+WORKDIR /src
+
+# Lockfile first — lets Docker cache `npm ci` across source changes.
+# The dashboard package.json is standalone; no cross-workspace deps,
+# so we don't need to copy other packages' manifests here.
+COPY packages/dashboard/package.json packages/dashboard/package-lock.json packages/dashboard/
+
+RUN cd packages/dashboard && npm ci --prefer-offline --no-audit
+
+# Copy everything except what's in .dockerignore. Turbopack's tsconfig
+# resolution is fussier than tsc's about directory structure; giving
+# it the full tree (including root tsconfig.base.json and the whole
+# packages/) keeps paths identical to how devs run the script locally.
+COPY . .
+
+RUN chmod +x scripts/build-bundled.sh && ./scripts/build-bundled.sh
+
+# ── Stage 2: wheel ──────────────────────────────────────────────────
+FROM --platform=$BUILDPLATFORM python:3.12-slim AS wheel-builder
+
+WORKDIR /src
+
+# Tree with the dashboard already bundled into the package. We need
+# the whole Python package for hatchling to walk.
+COPY packages/python/ packages/python/
+COPY --from=dashboard-builder /src/packages/python/awaithumans/dashboard_dist \
+     packages/python/awaithumans/dashboard_dist
+
+RUN pip install --no-cache-dir build==1.2.2 \
+ && cd packages/python \
+ && python -m build --wheel
+
+# ── Stage 3: runtime ────────────────────────────────────────────────
+FROM python:3.12-slim AS runtime
+
+# psycopg / asyncpg for Postgres deployments need libpq; install it
+# preemptively since the [server] extras include asyncpg.
+# libffi for cryptography; libssl for TLS.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      libpq5 \
+      libffi8 \
+      libssl3 \
+      ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install the wheel + server extras into the system Python. Slim
+# image → no venv overhead needed.
+# Copy the whole dist/ dir then install by wildcard — Docker's COPY
+# with a glob source sometimes resolves to nothing when the target
+# stage is untagged; grabbing the dir avoids that edge case.
+COPY --from=wheel-builder /src/packages/python/dist /tmp/dist
+# `pip install <path>[extra]` reads `[extra]` as literal, but bash
+# globs `[...]` as a character class — `*.whl[server]` would expand
+# to nothing. Resolve the wheel path first, then concat the extras.
+RUN WHEEL=$(ls /tmp/dist/*.whl | head -1) \
+ && pip install --no-cache-dir "${WHEEL}[server]" \
+ && rm -rf /tmp/dist
+
+# Non-root runtime user. SQLite + any writes go to /var/lib/awaithumans.
+RUN useradd --system --uid 10001 --home-dir /var/lib/awaithumans awaithumans \
+ && mkdir -p /var/lib/awaithumans \
+ && chown -R awaithumans:awaithumans /var/lib/awaithumans
+
+USER awaithumans
+WORKDIR /var/lib/awaithumans
+
+# Container config: bind all interfaces, persist DB to the volume.
+ENV AWAITHUMANS_HOST=0.0.0.0 \
+    AWAITHUMANS_PORT=3001 \
+    AWAITHUMANS_DB_PATH=/var/lib/awaithumans/awaithumans.db
+
+EXPOSE 3001
+VOLUME ["/var/lib/awaithumans"]
+
+# /api/health is an unauthenticated route (public even when dashboard
+# auth is on), so healthcheck works in every config.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD python -c "import urllib.request,sys; urllib.request.urlopen('http://localhost:3001/api/health', timeout=3)" \
+      || exit 1
+
+CMD ["awaithumans", "dev"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help bundle-dashboard wheel dev-server dev-dashboard test clean
+.PHONY: help bundle-dashboard wheel docker-build docker-run dev-server dev-dashboard test clean
 
 help:  ## Show this help.
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -8,6 +8,12 @@ bundle-dashboard:  ## Build the Next.js dashboard and drop it into the Python pa
 
 wheel: bundle-dashboard  ## Build the Python wheel with the dashboard bundled in.
 	cd packages/python && rm -rf dist/ build/ && python -m build --wheel
+
+docker-build:  ## Build the local Docker image (awaithumans:local).
+	docker build -t awaithumans:local .
+
+docker-run: docker-build  ## Run the local image on :3001.
+	docker run --rm -p 3001:3001 --name awaithumans awaithumans:local
 
 dev-server:  ## Run the Python API server from source (no dashboard mount).
 	cd packages/python && uvicorn awaithumans.server.app:create_app --factory --reload --port 3001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,61 @@
+# Docker Compose for self-hosters.
+#
+# Quick start:
+#   docker compose up
+#
+# What you get:
+#   - API + dashboard on http://localhost:3001
+#   - SQLite DB persisted in the `awaithumans-data` volume
+#
+# Production notes:
+#   1. Set AWAITHUMANS_PAYLOAD_KEY (required for Slack OAuth and
+#      dashboard password auth): `openssl rand -base64 32`
+#   2. Set AWAITHUMANS_DASHBOARD_PASSWORD to gate the dashboard.
+#   3. Point AWAITHUMANS_DATABASE_URL at Postgres when you outgrow
+#      SQLite (example below, commented out).
+
+services:
+  awaithumans:
+    image: ghcr.io/awaithumans/awaithumans:latest
+    # Build from source instead if you're working in the repo:
+    # build: .
+    restart: unless-stopped
+    ports:
+      - "3001:3001"
+    environment:
+      - AWAITHUMANS_PUBLIC_URL=${AWAITHUMANS_PUBLIC_URL:-http://localhost:3001}
+      - AWAITHUMANS_PAYLOAD_KEY=${AWAITHUMANS_PAYLOAD_KEY:-}
+      - AWAITHUMANS_DASHBOARD_PASSWORD=${AWAITHUMANS_DASHBOARD_PASSWORD:-}
+      - AWAITHUMANS_ADMIN_API_TOKEN=${AWAITHUMANS_ADMIN_API_TOKEN:-}
+      # Channel config (all optional). See docs for full list.
+      - AWAITHUMANS_SLACK_BOT_TOKEN=${AWAITHUMANS_SLACK_BOT_TOKEN:-}
+      - AWAITHUMANS_SLACK_SIGNING_SECRET=${AWAITHUMANS_SLACK_SIGNING_SECRET:-}
+      - AWAITHUMANS_EMAIL_TRANSPORT=${AWAITHUMANS_EMAIL_TRANSPORT:-}
+      - AWAITHUMANS_EMAIL_FROM=${AWAITHUMANS_EMAIL_FROM:-}
+      - AWAITHUMANS_RESEND_KEY=${AWAITHUMANS_RESEND_KEY:-}
+    volumes:
+      - awaithumans-data:/var/lib/awaithumans
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request,sys; urllib.request.urlopen('http://localhost:3001/api/health', timeout=3)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  # Uncomment when you're ready for Postgres. Then set
+  # AWAITHUMANS_DATABASE_URL=postgresql://awaithumans:change-me@postgres:5432/awaithumans
+  # on the `awaithumans` service above.
+  #
+  # postgres:
+  #   image: postgres:16-alpine
+  #   restart: unless-stopped
+  #   environment:
+  #     - POSTGRES_USER=awaithumans
+  #     - POSTGRES_PASSWORD=change-me
+  #     - POSTGRES_DB=awaithumans
+  #   volumes:
+  #     - postgres-data:/var/lib/postgresql/data
+
+volumes:
+  awaithumans-data:
+  # postgres-data:


### PR DESCRIPTION
Stacks on PR #12. Delivers the Docker path for TS users and anyone who doesn't want a Python toolchain.

## What users can now do

\`\`\`bash
docker run -p 3001:3001 ghcr.io/awaithumans/awaithumans
# or:
docker compose up
\`\`\`

Both land on http://localhost:3001 with API + dashboard on the same port. Verified locally: \`make docker-run\` → \`/api/health\` 200, \`/\` serves the bundled dashboard HTML.

## Dockerfile (3 stages)

1. **\`dashboard-builder\`** — node:22-slim, runs \`scripts/build-bundled.sh\` against a full-tree copy. Turbopack's tsconfig resolution is fussier than tsc's about relative paths; giving it the whole repo matches how devs run the script locally.
2. **\`wheel-builder\`** — python:3.12-slim + hatchling, builds the wheel with \`dashboard_dist/\` already in the package.
3. **\`runtime\`** — python:3.12-slim + libpq/libffi/libssl for asyncpg + cryptography. Installs the wheel with \`[server]\` extras. Runs as non-root uid 10001. Healthcheck against \`/api/health\`.

**Subtle bug fixed during local build:** \`pip install /tmp/dist/*.whl[server]\` doesn't work — bash globs \`[...]\` as a character class, so \`*.whl[server]\` expands to nothing. Resolve the path first (\`$(ls …)\`), concat extras literally.

## docker-compose.yml

Self-hosters' \`docker compose up\` story. Volumes the SQLite db, passes through every \`AWAITHUMANS_*\` env var with sensible defaults. Includes a commented-out Postgres service for later.

## CI (\`.github/workflows/docker.yml\`)

- **Triggers:** push main, push \`v*.*.*\` tag, workflow_dispatch
- **Platforms:** linux/amd64 + linux/arm64 via QEMU + Buildx
- **Registry:** ghcr.io/\<owner\>/awaithumans (free, no secrets needed beyond GITHUB_TOKEN)
- **Tags:** :main, :vX.Y.Z, :X.Y.Z, :X.Y, :X, :latest (last only on tag pushes) via docker/metadata-action
- **Cache:** GHA layer cache across runs

**Security:** every \`${{ ... }}\` expansion in the workflow is a trusted context value (repo, ref, actor, GITHUB_TOKEN, pinned-action outputs). No user-controlled fields reach \`run:\` blocks — nothing to inject. Documented inline.

## Makefile

\`make docker-build\` and \`make docker-run\` added.

## .dockerignore

Excludes .git, other packages, build artifacts, DB files. Keeps context small and avoids leaking dev state.

## Test plan

- [x] Local build: \`docker build .\` succeeds
- [x] Local run: \`docker run -p 3001:3001 awaithumans:local\` → /api/health 200, / serves dashboard HTML
- [ ] Next tagged push: verify GHA publishes :vX.Y.Z, :latest to GHCR
- [ ] Pull + run the published image on a clean machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)