### PR TITLE
feat(typescript-sdk): npx awaithumans wrapper + TS quickstart example

### DIFF
--- a/examples/quickstart-ts/README.md
+++ b/examples/quickstart-ts/README.md
@@ -1,0 +1,119 @@
+# Quickstart (TypeScript)
+
+The smallest thing that proves `awaithumans` works end-to-end from a
+TypeScript agent: the agent asks a human to approve a refund, the
+human clicks a button, the agent gets the typed response back.
+
+Mirrors [`../quickstart/`](../quickstart/) (Python), using the same
+server.
+
+## Prerequisites
+
+- Node 20+
+- [uv](https://docs.astral.sh/uv/) — a tiny Python runtime manager.
+  The `npx awaithumans` wrapper uses it to run the Python server
+  without forcing you to touch a Python env.
+
+Install uv (one line):
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+## Run
+
+**Terminal 1** — the server + dashboard:
+
+```bash
+npx awaithumans dev
+```
+
+You should see:
+
+```
+Ready — waiting for tasks...
+Dashboard at http://0.0.0.0:3001
+```
+
+**Terminal 2** — the example agent:
+
+```bash
+npm install
+npm start
+```
+
+You should see:
+
+```
+→ creating task on the awaithumans server...
+  Open http://localhost:3001 to review.
+```
+
+## What to do
+
+1. Open <http://localhost:3001>. The task appears in the queue:
+   **“Approve refund request”**.
+2. Click the row. The detail view shows the request (order, customer,
+   amount, reason) and a form with two fields — **Approve?** (toggle)
+   and **Note to customer** (textarea).
+3. Fill it in. Click **Submit response**.
+
+Terminal 2 unblocks and prints:
+
+```
+✓ Refund approved. Note: Issuing refund immediately.
+```
+
+## What the code looks like
+
+```ts
+import { z } from "zod";
+import { awaitHuman } from "awaithumans";
+
+const RefundRequest = z.object({
+  orderId: z.string(),
+  customer: z.string(),
+  amountUsd: z.number(),
+  reason: z.string(),
+});
+
+const Decision = z.object({
+  approved: z.boolean(),
+  note: z.string().optional(),
+});
+
+const decision = await awaitHuman({
+  task: "Approve refund request",
+  payloadSchema: RefundRequest,
+  payload: {
+    orderId: "A-4721",
+    customer: "jane@example.com",
+    amountUsd: 180,
+    reason: "Item arrived damaged",
+  },
+  responseSchema: Decision,
+  timeoutMs: 900_000,
+});
+
+if (decision.approved) {
+  // ...
+}
+```
+
+Zod schemas on both sides: `payloadSchema` drives what the human sees,
+`responseSchema` drives the form they fill out, and your agent gets the
+typed `decision` back. No JSON-twiddling.
+
+## Next steps
+
+- **Temporal:** `import { awaitHuman } from "awaithumans/temporal"` for
+  signal-based durable workflows.
+- **LangGraph:** `import { awaitHuman } from "awaithumans/langgraph"`
+  for interrupt/resume in a LangGraph agent.
+- **Send to Slack or email:** add `notify: ["slack:#ops"]` or
+  `notify: ["email:reviewer@company.com"]`. Needs the channel
+  configured on the server — see [docs](https://awaithumans.dev/docs).
+- **Docker:** don't want to install uv? `docker run -p 3001:3001
+  ghcr.io/awaithumans/awaithumans:latest` runs the same server.
+- **Python:** the same flow in Python —
+  [`examples/quickstart/`](../quickstart/).

--- a/examples/quickstart-ts/package.json
+++ b/examples/quickstart-ts/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "awaithumans-quickstart-ts",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "tsx refund.ts"
+  },
+  "dependencies": {
+    "awaithumans": "^0.0.1",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/quickstart-ts/refund.ts
+++ b/examples/quickstart-ts/refund.ts
@@ -1,0 +1,68 @@
+/**
+ * awaithumans quickstart (TypeScript) — delegate a refund approval to a human.
+ *
+ * Prerequisite (in another terminal):
+ *     npx awaithumans dev
+ *
+ * Then in this terminal:
+ *     npm install
+ *     npm start
+ *
+ * What happens:
+ *     1. This script creates a task on the server and awaits until
+ *        a human completes it.
+ *     2. Open http://localhost:3001 — the task shows up in the queue
+ *        with an approve/reject form.
+ *     3. Submit your decision. This script receives the typed response
+ *        and prints it. That's it.
+ */
+
+import { z } from "zod";
+import { awaitHuman } from "awaithumans";
+
+// Data the human sees while reviewing.
+const RefundRequest = z.object({
+	orderId: z.string(),
+	customer: z.string(),
+	amountUsd: z.number(),
+	reason: z.string(),
+});
+
+// Structured response the human fills out. `approved` drives a toggle;
+// `note` renders as an optional long-text field.
+const Decision = z.object({
+	approved: z.boolean().describe("Approve the refund?"),
+	note: z
+		.string()
+		.optional()
+		.describe("Optional message to send to the customer."),
+});
+
+async function main(): Promise<void> {
+	console.log("→ creating task on the awaithumans server...");
+	console.log("  Open http://localhost:3001 to review.\n");
+
+	const decision = await awaitHuman({
+		task: "Approve refund request",
+		payloadSchema: RefundRequest,
+		payload: {
+			orderId: "A-4721",
+			customer: "jane@example.com",
+			amountUsd: 180.0,
+			reason: "Item arrived damaged",
+		},
+		responseSchema: Decision,
+		timeoutMs: 900_000, // 15 minutes — plenty of time to walk to the kitchen
+	});
+
+	if (decision.approved) {
+		console.log(`✓ Refund approved. Note: ${decision.note ?? "(none)"}`);
+	} else {
+		console.log(`✗ Refund rejected. Note: ${decision.note ?? "(none)"}`);
+	}
+}
+
+main().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/examples/quickstart-ts/tsconfig.json
+++ b/examples/quickstart-ts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["*.ts"]
+}

--- a/packages/typescript-sdk/bin/awaithumans.mjs
+++ b/packages/typescript-sdk/bin/awaithumans.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// npx awaithumans <args> — thin wrapper that runs the Python CLI via uv.
+//
+// Why uv: a single pre-built binary that resolves + fetches + runs a
+// Python package in one step. No pip, no venv, no "which python".
+// TS developers never touch a Python environment.
+//
+// Why not bundle a Python interpreter: tripling the npm install size
+// for something `uv` does natively on every major platform.
+
+import { spawn, spawnSync } from "node:child_process";
+import { platform } from "node:process";
+
+const DOCS_URL = "https://awaithumans.dev/docs/install";
+const UV_INSTALL_URL = "https://docs.astral.sh/uv/getting-started/installation/";
+const PIP_SPEC = "awaithumans[server]";
+
+function hasUv() {
+	const probe = spawnSync("uv", ["--version"], { stdio: "ignore" });
+	return probe.status === 0;
+}
+
+function printMissingUv() {
+	const installCmd =
+		platform === "win32"
+			? 'powershell -c "irm https://astral.sh/uv/install.ps1 | iex"'
+			: "curl -LsSf https://astral.sh/uv/install.sh | sh";
+
+	process.stderr.write(
+		[
+			"",
+			"  awaithumans: `uv` is required but was not found on PATH.",
+			"",
+			"  The TS wrapper runs the Python server via `uv` so you don't",
+			"  have to manage a Python environment yourself.",
+			"",
+			"  Install uv:",
+			`    ${installCmd}`,
+			"",
+			`  Or see ${UV_INSTALL_URL}`,
+			`  More: ${DOCS_URL}`,
+			"",
+			"",
+		].join("\n"),
+	);
+}
+
+function main() {
+	if (!hasUv()) {
+		printMissingUv();
+		process.exit(1);
+	}
+
+	const child = spawn(
+		"uvx",
+		["--from", PIP_SPEC, "awaithumans", ...process.argv.slice(2)],
+		{ stdio: "inherit" },
+	);
+
+	child.on("exit", (code, signal) => {
+		if (signal) {
+			process.kill(process.pid, signal);
+			return;
+		}
+		process.exit(code ?? 0);
+	});
+
+	for (const sig of ["SIGINT", "SIGTERM"]) {
+		process.on(sig, () => child.kill(sig));
+	}
+}
+
+main();

--- a/packages/typescript-sdk/package.json
+++ b/packages/typescript-sdk/package.json
@@ -4,9 +4,12 @@
   "description": "The human layer for AI agents. Your agents already await promises. Now they can await humans.",
   "type": "module",
   "sideEffects": false,
-  "files": ["dist"],
+  "files": ["dist", "bin"],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "awaithumans": "bin/awaithumans.mjs"
+  },
   "exports": {
     ".": {
       "import": "./dist/index.js",


### PR DESCRIPTION
## Summary
- **`npx awaithumans dev`** — one-command server + dashboard for TypeScript users. The Node bin shells out to `uvx --from 'awaithumans[server]' awaithumans <args>`. No pip, no venv, no "which python."
- Preflight check: if `uv` is missing, print the platform-specific install line + docs link and exit 1. No cryptic ENOENT.
- Signal forwarding: SIGINT/SIGTERM are relayed to the child so Ctrl-C cleanly shuts down `awaithumans dev`.
- **`examples/quickstart-ts/`** — mirrors `examples/quickstart/` (Python) exactly: `refund.ts` uses `awaitHuman()` with Zod `RefundRequest` + `Decision`, ~35 lines of agent code, two-terminal README walkthrough.

## Why uv (and not e.g. pipx or a bundled interpreter)
- Single pre-built binary on every major platform. Resolves + fetches + runs a Python package in one step.
- Bundling a Python interpreter in the npm tarball would triple install size for something uv already does natively.
- `pipx` would add a manual install step on Linux (not available by default) and doesn't have the "one-shot run" ergonomics of `uvx`.

## Smoke-tested
- [x] Preflight path — wrapper exits 1 with install instructions when uv is missing.
- [x] Happy path — `uvx --from '<local-wheel>[server]' awaithumans version` resolves and runs under the wrapper's exec model. (Full `dev` flow will work end-to-end once the 0.1.0 wheel with the `[server]` extra publishes to PyPI.)

## Follow-ups (out of scope for this PR)
- Publish `awaithumans` 0.1.0 with the `[server]` extra to PyPI — unlocks `npx awaithumans dev` end-to-end.
- README update linking the TS quickstart alongside the Python one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)