### PR TITLE
feat(examples): python quickstart + fix idempotency-after-terminal bug

### DIFF
--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -1,0 +1,102 @@
+# Quickstart
+
+The smallest thing that proves `awaithumans` works end-to-end: an
+agent asks a human to approve a refund, the human clicks a button,
+the agent gets the typed response back.
+
+## Setup
+
+```bash
+pip install "awaithumans[server]"
+```
+
+## Run
+
+**Terminal 1** — the server + dashboard:
+
+```bash
+awaithumans dev
+```
+
+You should see:
+
+```
+Ready — waiting for tasks...
+Dashboard at http://0.0.0.0:3001
+```
+
+**Terminal 2** — the example agent:
+
+```bash
+python refund.py
+```
+
+You should see:
+
+```
+→ creating task on the awaithumans server...
+  Open http://localhost:3001 to review.
+```
+
+## What to do
+
+1. Open <http://localhost:3001>. The task appears in the queue:
+   **“Approve refund request”**.
+2. Click the row. The detail view shows the request (order, customer,
+   amount, reason) and a form with two fields — **Approve?** (toggle)
+   and **Note to customer** (textarea).
+3. Fill it in. Click **Submit response**.
+
+Terminal 2 unblocks and prints:
+
+```
+✓ Refund approved. Note: Issuing refund immediately.
+```
+
+## What the code looks like
+
+```python
+from awaithumans import await_human_sync
+from pydantic import BaseModel
+
+
+class RefundRequest(BaseModel):
+    order_id: str
+    customer: str
+    amount_usd: float
+    reason: str
+
+
+class Decision(BaseModel):
+    approved: bool
+    note: str | None = None
+
+
+decision = await_human_sync(
+    task="Approve refund request",
+    payload_schema=RefundRequest,
+    payload=RefundRequest(order_id="A-4721", customer="...", amount_usd=180, reason="..."),
+    response_schema=Decision,
+    timeout_seconds=900,
+)
+
+if decision.approved:
+    ...
+```
+
+Pydantic models on both sides: the `payload_schema` drives what the
+human sees, the `response_schema` drives the form they fill out, and
+your agent gets the typed `Decision` back. No JSON-twiddling.
+
+## Next steps
+
+- **Async version:** use `await_human` (instead of `await_human_sync`)
+  inside an async agent loop.
+- **Send to Slack or email:** add `notify=["slack:#ops"]` or
+  `notify=["email:reviewer@company.com"]`. Needs the channel
+  configured on the server — see [docs](https://awaithumans.dev/docs).
+- **Durable workflows:** use the Temporal or LangGraph adapter so
+  `await_human()` survives process restarts. Import from
+  `awaithumans.adapters.temporal` or `awaithumans.adapters.langgraph`.
+- **TypeScript:** the same flow in Node —
+  [`examples/quickstart-ts/`](../quickstart-ts/).

--- a/examples/quickstart/refund.py
+++ b/examples/quickstart/refund.py
@@ -1,0 +1,71 @@
+"""
+awaithumans quickstart — delegate a refund approval to a human.
+
+Prerequisite (in another terminal):
+    pip install "awaithumans[server]"
+    awaithumans dev
+
+Then:
+    python refund.py
+
+What happens:
+    1. This script creates a task on the server and blocks until
+       a human completes it.
+    2. Open http://localhost:3001 — the task shows up in the queue
+       with an approve/reject form.
+    3. Submit your decision. This script receives the typed response
+       and prints it. That's it.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from awaithumans import await_human_sync
+
+
+class RefundRequest(BaseModel):
+    """Data the human sees while reviewing."""
+
+    order_id: str
+    customer: str
+    amount_usd: float
+    reason: str
+
+
+class Decision(BaseModel):
+    """Structured response the human fills out. `approved` drives a
+    switch (toggle); `note` renders as an optional long-text field."""
+
+    approved: bool = Field(..., description="Approve the refund?")
+    note: str | None = Field(
+        default=None,
+        description="Optional message to send to the customer.",
+    )
+
+
+def main() -> None:
+    print("→ creating task on the awaithumans server...")
+    print("  Open http://localhost:3001 to review.\n")
+
+    decision = await_human_sync(
+        task="Approve refund request",
+        payload_schema=RefundRequest,
+        payload=RefundRequest(
+            order_id="A-4721",
+            customer="jane@example.com",
+            amount_usd=180.00,
+            reason="Item arrived damaged",
+        ),
+        response_schema=Decision,
+        timeout_seconds=900,  # 15 minutes — plenty of time to walk to the kitchen
+    )
+
+    if decision.approved:
+        print(f"✓ Refund approved. Note: {decision.note or '(none)'}")
+    else:
+        print(f"✗ Refund rejected. Note: {decision.note or '(none)'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/quickstart/requirements.txt
+++ b/examples/quickstart/requirements.txt
@@ -1,0 +1,1 @@
+awaithumans

--- a/packages/python/awaithumans/server/db/models/task.py
+++ b/packages/python/awaithumans/server/db/models/task.py
@@ -10,12 +10,21 @@ from sqlmodel import JSON, Column, Field, SQLModel
 
 from awaithumans.server.db.models.base import new_id, utc_now
 from awaithumans.types import TaskStatus
+from awaithumans.utils.constants import TERMINAL_STATUSES_SET
 
 # Partial unique index — only ACTIVE tasks have unique idempotency keys.
-# After a task reaches a terminal state, another task with the same key can
-# be created. This lets developers retry failed/timed-out tasks with the
-# same content without hitting a duplicate-key error.
-_TERMINAL_STATUS_VALUES = "('completed', 'timed_out', 'cancelled', 'verification_exhausted')"
+# After a task reaches a terminal state, another task with the same key
+# can be created. This lets developers retry failed/timed-out tasks
+# with the same content without hitting a duplicate-key error.
+#
+# SQLAlchemy stores enum columns as the enum's NAME (uppercase),
+# not .value (lowercase). The WHERE clause has to match, or the
+# partial index never filters anything and the "retry after terminal"
+# story silently fails with a raw UNIQUE violation. Derive the names
+# from TERMINAL_STATUSES_SET so this can't drift.
+_TERMINAL_STATUS_VALUES = (
+    "(" + ", ".join(f"'{s.name}'" for s in sorted(TERMINAL_STATUSES_SET, key=lambda s: s.name)) + ")"
+)
 _ACTIVE_IDEMPOTENCY_WHERE = f"status NOT IN {_TERMINAL_STATUS_VALUES}"
 
 

--- a/packages/python/tests/tasks/test_idempotency_after_terminal.py
+++ b/packages/python/tests/tasks/test_idempotency_after_terminal.py
@@ -1,0 +1,113 @@
+"""Regression test: after a task reaches a terminal state, a new task
+can be created with the same idempotency key.
+
+The partial unique index on `tasks.idempotency_key` is conditional on
+`status NOT IN (...terminal...)`, so terminal rows shouldn't block a
+re-insert. Early on the WHERE clause used lowercase values
+(`'completed'`) while SQLAlchemy serialized the enum as uppercase
+names (`'COMPLETED'`), so the index never excluded anything and the
+retry-after-terminal story silently failed with a raw UNIQUE violation.
+
+This test pins that behaviour: create a task, complete it, create
+another one with the same key — should succeed and return a distinct
+row."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+from awaithumans.server.db.models import (  # noqa: F401 — register models
+    AuditEntry,
+    EmailSenderIdentity,
+    SlackInstallation,
+    Task,
+)
+from awaithumans.server.services.task_service import (
+    complete_task,
+    create_task,
+)
+
+
+@pytest_asyncio.fixture
+async def session() -> AsyncGenerator[AsyncSession, None]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_retry_after_terminal_with_same_idempotency_key(
+    session: AsyncSession,
+) -> None:
+    # Create #1.
+    first = await create_task(
+        session,
+        task="Approve refund",
+        payload={"amount": 100},
+        payload_schema={},
+        response_schema={},
+        timeout_seconds=900,
+        idempotency_key="shared-key-xyz",
+    )
+
+    # Complete it — status moves to COMPLETED (terminal).
+    await complete_task(
+        session,
+        task_id=first.id,
+        response={"approved": True},
+        completed_via_channel="test",
+    )
+
+    # Create #2 with the same idempotency key. Should succeed and
+    # return a DIFFERENT row from the terminal one.
+    second = await create_task(
+        session,
+        task="Approve refund",
+        payload={"amount": 100},
+        payload_schema={},
+        response_schema={},
+        timeout_seconds=900,
+        idempotency_key="shared-key-xyz",
+    )
+
+    assert second.id != first.id
+    assert second.status.value == "created"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_idempotency_key_while_active_returns_existing(
+    session: AsyncSession,
+) -> None:
+    """Dedup semantics: while the original task is still non-terminal,
+    creating with the same idempotency key returns the same row."""
+    first = await create_task(
+        session,
+        task="Approve refund",
+        payload={"amount": 100},
+        payload_schema={},
+        response_schema={},
+        timeout_seconds=900,
+        idempotency_key="shared-key-active",
+    )
+
+    second = await create_task(
+        session,
+        task="Approve refund",
+        payload={"amount": 100},
+        payload_schema={},
+        response_schema={},
+        timeout_seconds=900,
+        idempotency_key="shared-key-active",
+    )
+
+    assert second.id == first.id


### PR DESCRIPTION
## Summary
- `examples/quickstart/` — a ~30-line `refund.py` using `await_human_sync()` with Pydantic `RefundRequest` / `Decision` models, a README walkthrough, and a `requirements.txt`.
- **Bug fix** surfaced while smoking the example in a fresh venv: the `tasks.idempotency_key` partial unique index WHERE clause was lowercase (`'completed'`) while SQLAlchemy serializes enum columns as their uppercase NAME (`'COMPLETED'`), so the index never excluded terminal rows and retry-after-terminal silently hit a raw UNIQUE violation.
- Derive the WHERE values from `TERMINAL_STATUSES_SET` using `.name` so this can't drift again.
- Regression test (`tests/tasks/test_idempotency_after_terminal.py`) — two cases: retry-after-terminal returns a new row; retry-while-active dedups to the same row.

## Replaces
PR #14, which auto-closed when its base branch was deleted during the merge of #16. Same commit (`21828f0`), re-targeted at `main`.

## Test plan
- [x] Full test suite: 223 passing (up from 221)
- [x] Fresh venv → `pip install awaithumans[server]` from local wheel → `awaithumans dev` → `python refund.py` → complete via API → script prints `✓ Refund approved. Note: Issuing refund immediately.`
- [x] Same flow with the idempotency-key reused after completion — no `IntegrityError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)