### PR TITLE
feat(users): password hashing + user service + admin API + CLI (PR A2)

### DIFF
--- a/packages/python/awaithumans/cli/commands/_session.py
+++ b/packages/python/awaithumans/cli/commands/_session.py
@@ -1,0 +1,35 @@
+"""Shared helper: open a local SQLite session for CLI commands.
+
+CLI commands run locally against the same database the server writes
+to. Auth is "you already have shell access to the box" — no extra gate.
+
+Runs `alembic upgrade head` first so fresh dev machines don't have to
+remember to migrate before adding their first user.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from awaithumans.server.db.connection import (
+    close_db,
+    get_async_session_factory,
+    init_db,
+)
+
+
+@asynccontextmanager
+async def with_session() -> AsyncIterator[AsyncSession]:
+    """Yield a DB session, applying migrations on entry and disposing
+    the engine on exit so the CLI process doesn't leave a stray
+    connection pool alive."""
+    await init_db()
+    factory = get_async_session_factory()
+    try:
+        async with factory() as session:
+            yield session
+    finally:
+        await close_db()

--- a/packages/python/awaithumans/cli/commands/add_user.py
+++ b/packages/python/awaithumans/cli/commands/add_user.py
@@ -1,30 +1,89 @@
-"""Add a user to the awaithumans user directory."""
+"""Add a user to the directory."""
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 import typer
+
+from awaithumans.cli.commands._session import with_session
+from awaithumans.server.services.exceptions import (
+    UserAlreadyExistsError,
+    UserNoAddressError,
+)
+from awaithumans.server.services.user_service import create_user
 
 logger = logging.getLogger("awaithumans.cli")
 
 
 def add_user(
-    email: str = typer.Argument(help="User's email address."),
-    role: str = typer.Option(None, help="Role to assign (e.g., kyc-reviewer)."),
-    access_level: str = typer.Option(None, help="Access level (e.g., senior)."),
-    pool: str = typer.Option(None, help="Pool to add the user to."),
+    email: str | None = typer.Option(None, help="Email address (for email notifications + login)."),
+    slack_team_id: str | None = typer.Option(
+        None, help="Slack workspace ID (e.g. T01ABC234) — required if --slack-user-id is set."
+    ),
+    slack_user_id: str | None = typer.Option(
+        None, help="Slack user ID within that workspace (e.g. U01XYZ789)."
+    ),
+    display_name: str | None = typer.Option(None, help="Human-readable name."),
+    role: str | None = typer.Option(None, help="Routing role, e.g. 'kyc-reviewer'."),
+    access_level: str | None = typer.Option(None, help="Routing access level, e.g. 'senior'."),
+    pool: str | None = typer.Option(None, help="Routing pool, e.g. 'ops'."),
+    is_operator: bool = typer.Option(
+        False, "--operator", help="Grant dashboard admin rights."
+    ),
+    password: str | None = typer.Option(
+        None,
+        help="Dashboard login password (min 8 chars). Leave blank for users who only receive tasks.",
+        prompt=False,
+    ),
 ) -> None:
-    """Add a user to the awaithumans user directory."""
-    # TODO: implement — write to the user directory (JSON file or DB)
-    logger.info(
-        "Adding user: %s (role=%s, access_level=%s, pool=%s)",
-        email, role, access_level, pool,
-    )
-    typer.echo(f"Added user: {email}")
-    if role:
-        typer.echo(f"  Role: {role}")
-    if access_level:
-        typer.echo(f"  Access level: {access_level}")
-    if pool:
-        typer.echo(f"  Pool: {pool}")
+    """Add a user to the directory.
+
+    At least one of `--email` or (`--slack-team-id` + `--slack-user-id`)
+    must be set. Slack identifiers come in pairs because Slack user IDs
+    are workspace-scoped.
+    """
+    if password is not None and len(password) < 8:
+        raise typer.BadParameter("Password must be at least 8 characters.")
+
+    async def _run() -> None:
+        async with with_session() as session:
+            try:
+                user = await create_user(
+                    session,
+                    display_name=display_name,
+                    email=email,
+                    slack_team_id=slack_team_id,
+                    slack_user_id=slack_user_id,
+                    role=role,
+                    access_level=access_level,
+                    pool=pool,
+                    is_operator=is_operator,
+                    password=password,
+                )
+            except UserNoAddressError as exc:
+                raise typer.BadParameter(str(exc)) from exc
+            except UserAlreadyExistsError as exc:
+                typer.echo(f"Error: {exc.message}", err=True)
+                raise typer.Exit(code=1) from exc
+
+        typer.echo(f"Added user: {user.id}")
+        if user.display_name:
+            typer.echo(f"  Name:  {user.display_name}")
+        if user.email:
+            typer.echo(f"  Email: {user.email}")
+        if user.slack_team_id:
+            typer.echo(f"  Slack: {user.slack_team_id}/{user.slack_user_id}")
+        if user.role:
+            typer.echo(f"  Role:  {user.role}")
+        if user.access_level:
+            typer.echo(f"  Level: {user.access_level}")
+        if user.pool:
+            typer.echo(f"  Pool:  {user.pool}")
+        if user.is_operator:
+            typer.echo("  Operator: yes")
+        if user.password_hash:
+            typer.echo("  Password: set")
+
+    asyncio.run(_run())

--- a/packages/python/awaithumans/cli/commands/list_users.py
+++ b/packages/python/awaithumans/cli/commands/list_users.py
@@ -1,0 +1,51 @@
+"""List users in the directory."""
+
+from __future__ import annotations
+
+import asyncio
+
+import typer
+
+from awaithumans.cli.commands._session import with_session
+from awaithumans.server.services.user_service import list_users
+
+
+def list_users_cmd(
+    role: str | None = typer.Option(None, help="Only users with this role."),
+    access_level: str | None = typer.Option(None, help="Only users with this access level."),
+    pool: str | None = typer.Option(None, help="Only users in this pool."),
+    active: bool | None = typer.Option(None, help="Only active (true) or inactive (false) users."),
+) -> None:
+    """List users in the directory."""
+
+    async def _run() -> None:
+        async with with_session() as session:
+            users = await list_users(
+                session,
+                role=role,
+                access_level=access_level,
+                pool=pool,
+                active=active,
+            )
+
+        if not users:
+            typer.echo("No users found.")
+            return
+
+        header = f"{'ID':<12} {'EMAIL':<30} {'SLACK':<22} {'ROLE':<18} {'LEVEL':<10} {'POOL':<10} {'OP':<3}"
+        typer.echo(header)
+        typer.echo("-" * len(header))
+        for u in users:
+            slack_addr = f"{u.slack_team_id}/{u.slack_user_id}" if u.slack_team_id else ""
+            typer.echo(
+                f"{u.id[:10]:<12} "
+                f"{(u.email or ''):<30} "
+                f"{slack_addr:<22} "
+                f"{(u.role or ''):<18} "
+                f"{(u.access_level or ''):<10} "
+                f"{(u.pool or ''):<10} "
+                f"{('yes' if u.is_operator else ''):<3}"
+            )
+        typer.echo(f"\nTotal: {len(users)}")
+
+    asyncio.run(_run())

--- a/packages/python/awaithumans/cli/commands/remove_user.py
+++ b/packages/python/awaithumans/cli/commands/remove_user.py
@@ -1,0 +1,48 @@
+"""Remove a user from the directory by ID or email."""
+
+from __future__ import annotations
+
+import asyncio
+
+import typer
+
+from awaithumans.cli.commands._session import with_session
+from awaithumans.server.services.user_service import (
+    delete_user,
+    get_user,
+    get_user_by_email,
+)
+
+
+def remove_user(
+    identifier: str = typer.Argument(help="User ID or email address."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
+) -> None:
+    """Remove a user from the directory.
+
+    Hard delete — the row is gone. Use `update-user --active false`
+    to deactivate without deleting.
+    """
+
+    async def _run() -> None:
+        async with with_session() as session:
+            # Try ID first, fall back to email lookup
+            user = await get_user(session, identifier)
+            if user is None and "@" in identifier:
+                user = await get_user_by_email(session, identifier)
+
+            if user is None:
+                typer.echo(f"Error: user not found: {identifier}", err=True)
+                raise typer.Exit(code=1)
+
+            label = user.display_name or user.email or user.id
+            if not yes:
+                typer.confirm(
+                    f"Remove user {label} ({user.id})?",
+                    abort=True,
+                )
+
+            await delete_user(session, user.id)
+            typer.echo(f"Removed: {user.id}")
+
+    asyncio.run(_run())

--- a/packages/python/awaithumans/cli/commands/set_password.py
+++ b/packages/python/awaithumans/cli/commands/set_password.py
@@ -1,0 +1,68 @@
+"""Set or clear a user's dashboard login password."""
+
+from __future__ import annotations
+
+import asyncio
+
+import typer
+
+from awaithumans.cli.commands._session import with_session
+from awaithumans.server.services.exceptions import UserNotFoundError
+from awaithumans.server.services.user_service import (
+    get_user,
+    get_user_by_email,
+    set_password,
+)
+
+
+def set_password_cmd(
+    identifier: str = typer.Argument(help="User ID or email address."),
+    password: str | None = typer.Option(
+        None,
+        "--password",
+        "-p",
+        help="New password (min 8 chars). Omit to prompt interactively.",
+    ),
+    clear: bool = typer.Option(
+        False, "--clear", help="Clear the password (user can no longer log in)."
+    ),
+) -> None:
+    """Set or clear a user's dashboard login password.
+
+    Pass `--clear` to disable login for a user without deleting them —
+    they can still receive tasks via their configured channels.
+    """
+    if clear and password:
+        raise typer.BadParameter("Pass either --password or --clear, not both.")
+
+    new_password: str | None
+    if clear:
+        new_password = None
+    elif password is not None:
+        new_password = password
+    else:
+        new_password = typer.prompt("New password", hide_input=True, confirmation_prompt=True)
+
+    if new_password is not None and len(new_password) < 8:
+        raise typer.BadParameter("Password must be at least 8 characters.")
+
+    async def _run() -> None:
+        async with with_session() as session:
+            user = await get_user(session, identifier)
+            if user is None and "@" in identifier:
+                user = await get_user_by_email(session, identifier)
+            if user is None:
+                raise UserNotFoundError(identifier)
+
+            await set_password(session, user.id, new_password)
+
+        if clear:
+            typer.echo(f"Password cleared for {user.id}")
+        else:
+            typer.echo(f"Password updated for {user.id}")
+
+    try:
+        asyncio.run(_run())
+    except UserNotFoundError as exc:
+        typer.echo(f"Error: {exc.message}", err=True)
+        raise typer.Exit(code=1) from exc

--- a/packages/python/awaithumans/cli/main.py
+++ b/packages/python/awaithumans/cli/main.py
@@ -15,6 +15,9 @@ except ImportError:
 
 from awaithumans.cli.commands.add_user import add_user
 from awaithumans.cli.commands.dev import dev
+from awaithumans.cli.commands.list_users import list_users_cmd
+from awaithumans.cli.commands.remove_user import remove_user
+from awaithumans.cli.commands.set_password import set_password_cmd
 from awaithumans.cli.commands.version import version
 
 app = typer.Typer(
@@ -24,7 +27,10 @@ app = typer.Typer(
 )
 
 app.command()(dev)
-app.command()(add_user)
+app.command("add-user")(add_user)
+app.command("list-users")(list_users_cmd)
+app.command("remove-user")(remove_user)
+app.command("set-password")(set_password_cmd)
 app.command()(version)
 
 if __name__ == "__main__":

--- a/packages/python/awaithumans/server/app.py
+++ b/packages/python/awaithumans/server/app.py
@@ -22,7 +22,7 @@ from awaithumans.server.core.exceptions import exception_handlers
 from awaithumans.server.core.logging_config import setup_logging
 from awaithumans.server.core.middleware import RequestIDMiddleware
 from awaithumans.server.db.connection import close_db, init_db
-from awaithumans.server.routes import auth, email, health, slack, stats, status, tasks
+from awaithumans.server.routes import auth, email, health, slack, stats, status, tasks, users
 from awaithumans.server.services.timeout_scheduler import run_timeout_scheduler
 
 logger = logging.getLogger("awaithumans.server")
@@ -123,6 +123,7 @@ def create_app(*, serve_dashboard: bool = True) -> FastAPI:
     app.include_router(health.router, prefix="/api")
     app.include_router(slack.router, prefix="/api")
     app.include_router(email.router, prefix="/api")
+    app.include_router(users.router, prefix="/api")
 
     # ── Dashboard static files ───────────────────────────────────────
     # The bundled dashboard lives inside the package

--- a/packages/python/awaithumans/server/core/password.py
+++ b/packages/python/awaithumans/server/core/password.py
@@ -1,0 +1,44 @@
+"""Password hashing — argon2id via argon2-cffi.
+
+Argon2id is the OWASP-recommended default for new systems as of 2024
+(memory-hard, side-channel-resistant, winner of the Password Hashing
+Competition). The defaults in `argon2-cffi` match the minimum
+parameters from RFC 9106; we don't tune them here.
+
+Usage:
+
+    from awaithumans.server.core.password import hash_password, verify_password
+    h = hash_password("s3cret")
+    verify_password("s3cret", h)        # True
+    verify_password("wrong", h)         # False
+"""
+
+from __future__ import annotations
+
+import logging
+
+from argon2 import PasswordHasher
+from argon2.exceptions import VerifyMismatchError
+
+logger = logging.getLogger("awaithumans.server.core.password")
+
+# Module-level singleton — `PasswordHasher` is threadsafe and cheap to
+# keep around. Expensive to construct on every call.
+_hasher = PasswordHasher()
+
+
+def hash_password(password: str) -> str:
+    """Return an argon2id hash string (PHC format, fully self-describing)."""
+    return _hasher.hash(password)
+
+
+def verify_password(password: str, stored_hash: str) -> bool:
+    """Constant-time verify. Returns False on mismatch or malformed hash;
+    never raises on bad input — callers just see "wrong password." """
+    try:
+        return _hasher.verify(stored_hash, password)
+    except VerifyMismatchError:
+        return False
+    except Exception as exc:  # malformed hash, unexpected algorithm, etc.
+        logger.warning("password verify failed (treated as mismatch): %s", exc)
+        return False

--- a/packages/python/awaithumans/server/routes/users.py
+++ b/packages/python/awaithumans/server/routes/users.py
@@ -1,0 +1,178 @@
+"""Admin user directory routes — /api/admin/users CRUD.
+
+Gated by `require_admin` (shared `X-Admin-Token` bearer). PR A3 adds
+operator-session auth as an alternative path; until then, ops runs
+with the admin token.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from awaithumans.server.core.admin_auth import require_admin
+from awaithumans.server.db.connection import get_session
+from awaithumans.server.schemas.users import (
+    SetPasswordRequest,
+    UserCreateRequest,
+    UserResponse,
+    UserUpdateRequest,
+)
+from awaithumans.server.services.exceptions import UserNotFoundError
+from awaithumans.server.services.user_service import (
+    create_user,
+    delete_user,
+    get_user,
+    list_users,
+    set_password,
+    update_user,
+)
+
+router = APIRouter(prefix="/admin/users", tags=["admin"])
+logger = logging.getLogger("awaithumans.server.routes.users")
+
+
+def _to_public(row: object) -> UserResponse:
+    """Convert a User model row to its public view. Computes
+    `has_password` from the hash presence so callers can tell
+    whether the user can log in without seeing the hash."""
+    # `row` is a User but typed loosely so the module doesn't import
+    # the model unnecessarily — we only read attributes.
+    return UserResponse(
+        id=row.id,  # type: ignore[attr-defined]
+        display_name=row.display_name,  # type: ignore[attr-defined]
+        email=row.email,  # type: ignore[attr-defined]
+        slack_team_id=row.slack_team_id,  # type: ignore[attr-defined]
+        slack_user_id=row.slack_user_id,  # type: ignore[attr-defined]
+        role=row.role,  # type: ignore[attr-defined]
+        access_level=row.access_level,  # type: ignore[attr-defined]
+        pool=row.pool,  # type: ignore[attr-defined]
+        is_operator=row.is_operator,  # type: ignore[attr-defined]
+        has_password=bool(row.password_hash),  # type: ignore[attr-defined]
+        active=row.active,  # type: ignore[attr-defined]
+        last_assigned_at=row.last_assigned_at,  # type: ignore[attr-defined]
+        created_at=row.created_at,  # type: ignore[attr-defined]
+        updated_at=row.updated_at,  # type: ignore[attr-defined]
+    )
+
+
+@router.post(
+    "",
+    response_model=UserResponse,
+    status_code=201,
+    dependencies=[Depends(require_admin)],
+)
+async def create_user_route(
+    body: UserCreateRequest,
+    session: AsyncSession = Depends(get_session),
+) -> UserResponse:
+    row = await create_user(
+        session,
+        display_name=body.display_name,
+        email=body.email,
+        slack_team_id=body.slack_team_id,
+        slack_user_id=body.slack_user_id,
+        role=body.role,
+        access_level=body.access_level,
+        pool=body.pool,
+        is_operator=body.is_operator,
+        password=body.password,
+        active=body.active,
+    )
+    return _to_public(row)
+
+
+@router.get(
+    "",
+    response_model=list[UserResponse],
+    dependencies=[Depends(require_admin)],
+)
+async def list_users_route(
+    role: str | None = Query(default=None),
+    access_level: str | None = Query(default=None),
+    pool: str | None = Query(default=None),
+    active: bool | None = Query(default=None),
+    session: AsyncSession = Depends(get_session),
+) -> list[UserResponse]:
+    rows = await list_users(
+        session, role=role, access_level=access_level, pool=pool, active=active
+    )
+    return [_to_public(r) for r in rows]
+
+
+@router.get(
+    "/{user_id}",
+    response_model=UserResponse,
+    dependencies=[Depends(require_admin)],
+)
+async def get_user_route(
+    user_id: str,
+    session: AsyncSession = Depends(get_session),
+) -> UserResponse:
+    row = await get_user(session, user_id)
+    if row is None:
+        raise UserNotFoundError(user_id)
+    return _to_public(row)
+
+
+@router.patch(
+    "/{user_id}",
+    response_model=UserResponse,
+    dependencies=[Depends(require_admin)],
+)
+async def update_user_route(
+    user_id: str,
+    body: UserUpdateRequest,
+    session: AsyncSession = Depends(get_session),
+) -> UserResponse:
+    # Only send non-null fields to the service — nulls mean "leave alone."
+    changes = {k: v for k, v in body.model_dump().items() if v is not None}
+    row = await update_user(session, user_id, **changes)
+    return _to_public(row)
+
+
+@router.delete(
+    "/{user_id}",
+    status_code=204,
+    dependencies=[Depends(require_admin)],
+)
+async def delete_user_route(
+    user_id: str,
+    session: AsyncSession = Depends(get_session),
+) -> Response:
+    if not await delete_user(session, user_id):
+        raise UserNotFoundError(user_id)
+    return Response(status_code=204)
+
+
+@router.post(
+    "/{user_id}/password",
+    response_model=UserResponse,
+    dependencies=[Depends(require_admin)],
+)
+async def set_password_route(
+    user_id: str,
+    body: SetPasswordRequest,
+    session: AsyncSession = Depends(get_session),
+) -> UserResponse:
+    row = await set_password(session, user_id, body.password)
+    return _to_public(row)
+
+
+@router.delete(
+    "/{user_id}/password",
+    response_model=UserResponse,
+    dependencies=[Depends(require_admin)],
+)
+async def clear_password_route(
+    user_id: str,
+    session: AsyncSession = Depends(get_session),
+) -> UserResponse:
+    """Explicitly clear a password — user can no longer log in but can
+    still receive tasks via their configured channels. Separate from
+    DELETE /users/{id} which hard-deletes the row."""
+    row = await set_password(session, user_id, None)
+    return _to_public(row)

--- a/packages/python/awaithumans/server/schemas/users.py
+++ b/packages/python/awaithumans/server/schemas/users.py
@@ -1,0 +1,91 @@
+"""User directory API request/response schemas.
+
+Public responses NEVER include `password_hash`. The hash stays in the
+DB and the service layer; even operators can't read it back via the
+API — same discipline as email `transport_config`.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class UserCreateRequest(BaseModel):
+    """Create a user. At least one of `email` or the slack pair must be set —
+    validation happens in the service layer (the DB can't express
+    "at least one of these two fields" portably)."""
+
+    display_name: str | None = None
+
+    email: str | None = None
+    slack_team_id: str | None = None
+    slack_user_id: str | None = None
+
+    role: str | None = None
+    access_level: str | None = None
+    pool: str | None = None
+
+    is_operator: bool = False
+    # Set this only if the user is expected to log into the dashboard.
+    # Leave null for Slack-only or email-only reviewers who never see
+    # the dashboard directly.
+    password: str | None = Field(default=None, min_length=8)
+
+    active: bool = True
+
+
+class UserUpdateRequest(BaseModel):
+    """Partial update. Null fields are left unchanged; to clear a field,
+    pass an empty string (for text fields) or false (for booleans).
+
+    `password`: pass a non-null string to set a new password. Pass null
+    to leave the current one alone. Use DELETE /api/admin/users/{id}/password
+    to explicitly clear it.
+    """
+
+    display_name: str | None = None
+
+    email: str | None = None
+    slack_team_id: str | None = None
+    slack_user_id: str | None = None
+
+    role: str | None = None
+    access_level: str | None = None
+    pool: str | None = None
+
+    is_operator: bool | None = None
+    password: str | None = Field(default=None, min_length=8)
+    active: bool | None = None
+
+
+class UserResponse(BaseModel):
+    """Public view of a user. Omits `password_hash` and raw timestamps
+    are emitted as ISO strings."""
+
+    id: str
+    display_name: str | None
+
+    email: str | None
+    slack_team_id: str | None
+    slack_user_id: str | None
+
+    role: str | None
+    access_level: str | None
+    pool: str | None
+
+    is_operator: bool
+    has_password: bool  # surfaces "can this user log in?" without leaking the hash
+
+    active: bool
+    last_assigned_at: datetime | None
+
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class SetPasswordRequest(BaseModel):
+    password: str = Field(min_length=8)

--- a/packages/python/awaithumans/server/services/exceptions.py
+++ b/packages/python/awaithumans/server/services/exceptions.py
@@ -63,3 +63,45 @@ class TaskAlreadyExistsError(ServiceError):
         super().__init__(
             f"Task with idempotency key '{idempotency_key}' already exists (id={task_id})."
         )
+
+
+# ─── User service errors ──────────────────────────────────────────────
+
+
+class UserNotFoundError(ServiceError):
+    status_code = 404
+    error_code = "USER_NOT_FOUND"
+    docs_path = "user-not-found"
+
+    def __init__(self, user_id: str) -> None:
+        self.user_id = user_id
+        super().__init__(f"User '{user_id}' not found.")
+
+
+class UserAlreadyExistsError(ServiceError):
+    status_code = 409
+    error_code = "USER_ALREADY_EXISTS"
+    docs_path = "user-already-exists"
+
+    def __init__(self, conflict: str) -> None:
+        self.conflict = conflict
+        super().__init__(
+            f"A user with this {conflict} already exists. Each email and each "
+            f"(slack_team_id, slack_user_id) pair is unique across the directory."
+        )
+
+
+class UserNoAddressError(ServiceError):
+    """At least one delivery address (email or slack pair) must be set —
+    a user with neither is unreachable and useless for routing."""
+
+    status_code = 422
+    error_code = "USER_NO_ADDRESS"
+    docs_path = "user-no-address"
+
+    def __init__(self) -> None:
+        super().__init__(
+            "A user must have at least one delivery address: either an email "
+            "or a (slack_team_id, slack_user_id) pair. Rows with neither "
+            "can't be reached by any channel."
+        )

--- a/packages/python/awaithumans/server/services/user_service.py
+++ b/packages/python/awaithumans/server/services/user_service.py
@@ -1,0 +1,225 @@
+"""User directory CRUD.
+
+The one place that writes to the `users` table. The admin API, the
+CLI, the `/setup` bootstrap, and the task router all go through this
+module so they can't diverge on validation or hashing.
+
+At-least-one-address rule: enforced here, not in the DB. Partial unique
+indexes catch duplicates but can't express "at least one of these two
+fields must be non-null" portably across SQLite and Postgres.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from awaithumans.server.core.password import hash_password
+from awaithumans.server.db.models import User
+from awaithumans.server.services.exceptions import (
+    UserAlreadyExistsError,
+    UserNoAddressError,
+    UserNotFoundError,
+)
+
+logger = logging.getLogger("awaithumans.server.services.user")
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _validate_addresses(
+    *, email: str | None, slack_team_id: str | None, slack_user_id: str | None
+) -> None:
+    """At least one of {email} or {slack_team_id + slack_user_id}.
+
+    A partial slack address (one of the pair set but not the other) is
+    invalid — slack IDs are workspace-scoped and only meaningful together.
+    """
+    has_email = bool(email)
+    has_full_slack = bool(slack_team_id) and bool(slack_user_id)
+    has_partial_slack = bool(slack_team_id) != bool(slack_user_id)
+
+    if has_partial_slack:
+        raise UserNoAddressError()  # partial slack = broken, same remediation
+    if not (has_email or has_full_slack):
+        raise UserNoAddressError()
+
+
+def _infer_conflict(exc: IntegrityError) -> str:
+    """Best-effort extraction of which unique constraint fired.
+
+    SQLAlchemy wraps the driver exception; the original message usually
+    mentions the index name. Falls back to a generic label so the caller
+    always gets a non-empty string.
+    """
+    msg = str(exc.orig).lower() if exc.orig else str(exc).lower()
+    if "ix_users_email_unique" in msg or "email" in msg:
+        return "email"
+    if "ix_users_slack_unique" in msg or "slack" in msg:
+        return "slack identity"
+    return "identity"
+
+
+async def create_user(
+    session: AsyncSession,
+    *,
+    display_name: str | None = None,
+    email: str | None = None,
+    slack_team_id: str | None = None,
+    slack_user_id: str | None = None,
+    role: str | None = None,
+    access_level: str | None = None,
+    pool: str | None = None,
+    is_operator: bool = False,
+    password: str | None = None,
+    active: bool = True,
+) -> User:
+    """Insert a new user. Raises UserAlreadyExistsError on uniqueness conflict."""
+    _validate_addresses(
+        email=email, slack_team_id=slack_team_id, slack_user_id=slack_user_id
+    )
+
+    row = User(
+        display_name=display_name,
+        email=email,
+        slack_team_id=slack_team_id,
+        slack_user_id=slack_user_id,
+        role=role,
+        access_level=access_level,
+        pool=pool,
+        is_operator=is_operator,
+        password_hash=hash_password(password) if password else None,
+        active=active,
+    )
+    session.add(row)
+    try:
+        await session.commit()
+    except IntegrityError as exc:
+        await session.rollback()
+        raise UserAlreadyExistsError(_infer_conflict(exc)) from exc
+    await session.refresh(row)
+    return row
+
+
+async def get_user(session: AsyncSession, user_id: str) -> User | None:
+    result = await session.execute(select(User).where(User.id == user_id))
+    return result.scalar_one_or_none()
+
+
+async def get_user_by_email(session: AsyncSession, email: str) -> User | None:
+    result = await session.execute(select(User).where(User.email == email))
+    return result.scalar_one_or_none()
+
+
+async def get_user_by_slack(
+    session: AsyncSession, *, slack_team_id: str, slack_user_id: str
+) -> User | None:
+    result = await session.execute(
+        select(User).where(
+            User.slack_team_id == slack_team_id,
+            User.slack_user_id == slack_user_id,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def list_users(
+    session: AsyncSession,
+    *,
+    role: str | None = None,
+    access_level: str | None = None,
+    pool: str | None = None,
+    active: bool | None = None,
+) -> list[User]:
+    """List users with optional filters. `None` filters are ignored."""
+    stmt = select(User)
+    if role is not None:
+        stmt = stmt.where(User.role == role)
+    if access_level is not None:
+        stmt = stmt.where(User.access_level == access_level)
+    if pool is not None:
+        stmt = stmt.where(User.pool == pool)
+    if active is not None:
+        stmt = stmt.where(User.active == active)
+    stmt = stmt.order_by(User.created_at.asc())
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def update_user(
+    session: AsyncSession,
+    user_id: str,
+    **changes: Any,
+) -> User:
+    """Patch a user. Unknown keys are ignored.
+
+    Pass `password=<str>` to set a new password; it's hashed here
+    (service never stores plaintext). Pass `password_hash=<str>`
+    directly at your peril — that's an escape hatch for migrations,
+    not normal use.
+    """
+    row = await get_user(session, user_id)
+    if row is None:
+        raise UserNotFoundError(user_id)
+
+    if "password" in changes:
+        pw = changes.pop("password")
+        row.password_hash = hash_password(pw) if pw else None
+
+    updatable = {
+        "display_name", "email", "slack_team_id", "slack_user_id",
+        "role", "access_level", "pool", "is_operator", "active",
+        "password_hash",
+    }
+    for k, v in changes.items():
+        if k in updatable:
+            setattr(row, k, v)
+
+    _validate_addresses(
+        email=row.email,
+        slack_team_id=row.slack_team_id,
+        slack_user_id=row.slack_user_id,
+    )
+    row.updated_at = _now()
+    session.add(row)
+    try:
+        await session.commit()
+    except IntegrityError as exc:
+        await session.rollback()
+        raise UserAlreadyExistsError(_infer_conflict(exc)) from exc
+    await session.refresh(row)
+    return row
+
+
+async def set_password(
+    session: AsyncSession, user_id: str, password: str | None
+) -> User:
+    """Set or clear a user's password.
+
+    Passing None clears the hash — the user can no longer log in but
+    can still receive tasks via their configured channels.
+    """
+    return await update_user(session, user_id, password=password)
+
+
+async def delete_user(session: AsyncSession, user_id: str) -> bool:
+    """Hard delete. Returns True if a row was removed, False if not found."""
+    result = await session.execute(delete(User).where(User.id == user_id))
+    await session.commit()
+    return result.rowcount > 0
+
+
+async def count_users(session: AsyncSession) -> int:
+    """Used by the /setup bootstrap path to decide whether the setup
+    token is still valid (zero users = first-run, > 0 = setup done)."""
+    from sqlalchemy import func
+
+    result = await session.execute(select(func.count()).select_from(User))
+    return int(result.scalar_one())

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -76,6 +76,9 @@ server = [
     "typer>=0.13.0",
     "cryptography>=43.0.0",
     "aiosmtplib>=3.0.0",
+    # Password hashing for per-user dashboard login. argon2id is the
+    # OWASP-recommended default for new systems (RFC 9106 params).
+    "argon2-cffi>=23.1.0",
 ]
 temporal = [
     "temporalio>=1.7.0",

--- a/packages/python/tests/users/conftest.py
+++ b/packages/python/tests/users/conftest.py
@@ -1,0 +1,30 @@
+"""Shared fixtures for user directory tests."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+# Register models so create_all picks up the tables.
+from awaithumans.server.db.models import (  # noqa: F401
+    AuditEntry,
+    EmailSenderIdentity,
+    SlackInstallation,
+    Task,
+    User,
+)
+
+
+@pytest_asyncio.fixture
+async def session() -> AsyncGenerator[AsyncSession, None]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()

--- a/packages/python/tests/users/test_admin_routes.py
+++ b/packages/python/tests/users/test_admin_routes.py
@@ -1,0 +1,240 @@
+"""Admin user CRUD routes — end-to-end via the FastAPI app."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+from awaithumans.server.app import create_app
+from awaithumans.server.core.config import settings
+from awaithumans.server.db.connection import get_session
+from awaithumans.server.db.models import (  # noqa: F401 — register models
+    AuditEntry,
+    EmailSenderIdentity,
+    SlackInstallation,
+    Task,
+    User,
+)
+
+ADMIN_TOKEN = "test-admin-token-super-secret"
+AUTH = {"X-Admin-Token": ADMIN_TOKEN}
+
+
+@pytest_asyncio.fixture
+async def client() -> AsyncGenerator[AsyncClient, None]:
+    orig = settings.ADMIN_API_TOKEN
+    settings.ADMIN_API_TOKEN = ADMIN_TOKEN
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_session() -> AsyncGenerator[AsyncSession, None]:
+        async with factory() as s:
+            yield s
+
+    app = create_app(serve_dashboard=False)
+    app.dependency_overrides[get_session] = override_session
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://testserver", follow_redirects=False
+    ) as c:
+        yield c
+
+    await engine.dispose()
+    settings.ADMIN_API_TOKEN = orig
+
+
+# ─── Auth gate ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_requires_admin_token(client: AsyncClient) -> None:
+    resp = await client.get("/api/admin/users")
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_wrong_token_rejected(client: AsyncClient) -> None:
+    resp = await client.get(
+        "/api/admin/users", headers={"X-Admin-Token": "nope"}
+    )
+    assert resp.status_code == 403
+
+
+# ─── Create ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_user_returns_public_fields(client: AsyncClient) -> None:
+    resp = await client.post(
+        "/api/admin/users",
+        headers=AUTH,
+        json={
+            "email": "alice@example.com",
+            "display_name": "Alice",
+            "role": "kyc-reviewer",
+            "access_level": "senior",
+            "password": "hunter2a",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["email"] == "alice@example.com"
+    assert body["role"] == "kyc-reviewer"
+    assert body["has_password"] is True
+    # Password hash NEVER leaks out of the API.
+    assert "password_hash" not in body
+    assert "password" not in body
+
+
+@pytest.mark.asyncio
+async def test_create_no_address_returns_422(client: AsyncClient) -> None:
+    """Validation happens in the service layer → mapped to 422 via
+    UserNoAddressError."""
+    resp = await client.post(
+        "/api/admin/users",
+        headers=AUTH,
+        json={"display_name": "Ghost"},
+    )
+    assert resp.status_code == 422
+    assert resp.json()["error"] == "USER_NO_ADDRESS"
+
+
+@pytest.mark.asyncio
+async def test_create_duplicate_email_returns_409(client: AsyncClient) -> None:
+    await client.post(
+        "/api/admin/users", headers=AUTH, json={"email": "a@example.com"}
+    )
+    resp = await client.post(
+        "/api/admin/users", headers=AUTH, json={"email": "a@example.com"}
+    )
+    assert resp.status_code == 409
+    assert resp.json()["error"] == "USER_ALREADY_EXISTS"
+
+
+# ─── List + filter ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_users_filter_by_role(client: AsyncClient) -> None:
+    await client.post(
+        "/api/admin/users",
+        headers=AUTH,
+        json={"email": "a@example.com", "role": "kyc"},
+    )
+    await client.post(
+        "/api/admin/users",
+        headers=AUTH,
+        json={"email": "b@example.com", "role": "support"},
+    )
+
+    resp = await client.get("/api/admin/users?role=kyc", headers=AUTH)
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) == 1
+    assert rows[0]["email"] == "a@example.com"
+
+
+# ─── Get / Update / Delete ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_user_by_id(client: AsyncClient) -> None:
+    created = (
+        await client.post(
+            "/api/admin/users", headers=AUTH, json={"email": "a@example.com"}
+        )
+    ).json()
+
+    resp = await client.get(f"/api/admin/users/{created['id']}", headers=AUTH)
+    assert resp.status_code == 200
+    assert resp.json()["email"] == "a@example.com"
+
+
+@pytest.mark.asyncio
+async def test_get_missing_returns_404(client: AsyncClient) -> None:
+    resp = await client.get("/api/admin/users/no-such-id", headers=AUTH)
+    assert resp.status_code == 404
+    assert resp.json()["error"] == "USER_NOT_FOUND"
+
+
+@pytest.mark.asyncio
+async def test_patch_user_updates_fields(client: AsyncClient) -> None:
+    created = (
+        await client.post(
+            "/api/admin/users", headers=AUTH, json={"email": "a@example.com"}
+        )
+    ).json()
+
+    resp = await client.patch(
+        f"/api/admin/users/{created['id']}",
+        headers=AUTH,
+        json={"display_name": "Alice", "role": "kyc"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["display_name"] == "Alice"
+    assert body["role"] == "kyc"
+
+
+@pytest.mark.asyncio
+async def test_delete_user_removes_row(client: AsyncClient) -> None:
+    created = (
+        await client.post(
+            "/api/admin/users", headers=AUTH, json={"email": "a@example.com"}
+        )
+    ).json()
+
+    resp = await client.delete(f"/api/admin/users/{created['id']}", headers=AUTH)
+    assert resp.status_code == 204
+
+    resp = await client.get(f"/api/admin/users/{created['id']}", headers=AUTH)
+    assert resp.status_code == 404
+
+
+# ─── Password routes ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_set_password_flips_has_password(client: AsyncClient) -> None:
+    created = (
+        await client.post(
+            "/api/admin/users", headers=AUTH, json={"email": "a@example.com"}
+        )
+    ).json()
+    assert created["has_password"] is False
+
+    resp = await client.post(
+        f"/api/admin/users/{created['id']}/password",
+        headers=AUTH,
+        json={"password": "hunter2a"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["has_password"] is True
+
+
+@pytest.mark.asyncio
+async def test_clear_password_flips_has_password(client: AsyncClient) -> None:
+    created = (
+        await client.post(
+            "/api/admin/users",
+            headers=AUTH,
+            json={"email": "a@example.com", "password": "hunter2a"},
+        )
+    ).json()
+    assert created["has_password"] is True
+
+    resp = await client.delete(
+        f"/api/admin/users/{created['id']}/password", headers=AUTH
+    )
+    assert resp.status_code == 200
+    assert resp.json()["has_password"] is False

--- a/packages/python/tests/users/test_user_service.py
+++ b/packages/python/tests/users/test_user_service.py
@@ -1,0 +1,216 @@
+"""User service — CRUD, validation, uniqueness, password hashing."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from awaithumans.server.core.password import verify_password
+from awaithumans.server.services.exceptions import (
+    UserAlreadyExistsError,
+    UserNoAddressError,
+    UserNotFoundError,
+)
+from awaithumans.server.services.user_service import (
+    count_users,
+    create_user,
+    delete_user,
+    get_user,
+    get_user_by_email,
+    get_user_by_slack,
+    list_users,
+    set_password,
+    update_user,
+)
+
+
+# ─── At-least-one-address rule ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_user_with_no_address(session: AsyncSession) -> None:
+    with pytest.raises(UserNoAddressError):
+        await create_user(session, display_name="Ghost")
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_partial_slack(session: AsyncSession) -> None:
+    """Slack identifiers come in pairs — team alone or user alone is broken."""
+    with pytest.raises(UserNoAddressError):
+        await create_user(session, slack_team_id="T01")
+    with pytest.raises(UserNoAddressError):
+        await create_user(session, slack_user_id="U01")
+
+
+@pytest.mark.asyncio
+async def test_create_accepts_email_only(session: AsyncSession) -> None:
+    u = await create_user(session, email="a@example.com")
+    assert u.email == "a@example.com"
+    assert u.slack_team_id is None
+
+
+@pytest.mark.asyncio
+async def test_create_accepts_slack_only(session: AsyncSession) -> None:
+    u = await create_user(session, slack_team_id="T01", slack_user_id="U01")
+    assert u.slack_team_id == "T01"
+    assert u.email is None
+
+
+# ─── Uniqueness ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_duplicate_email_rejected(session: AsyncSession) -> None:
+    await create_user(session, email="a@example.com")
+    with pytest.raises(UserAlreadyExistsError) as exc:
+        await create_user(session, email="a@example.com")
+    assert exc.value.conflict == "email"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_slack_pair_rejected(session: AsyncSession) -> None:
+    await create_user(session, slack_team_id="T01", slack_user_id="U01")
+    with pytest.raises(UserAlreadyExistsError):
+        await create_user(session, slack_team_id="T01", slack_user_id="U01")
+
+
+@pytest.mark.asyncio
+async def test_same_slack_user_in_different_team_allowed(session: AsyncSession) -> None:
+    """U01 in team A and U01 in team B are different humans."""
+    await create_user(session, slack_team_id="T01", slack_user_id="U01")
+    u2 = await create_user(session, slack_team_id="T02", slack_user_id="U01")
+    assert u2.id != ""
+
+
+@pytest.mark.asyncio
+async def test_two_users_with_null_email_allowed(session: AsyncSession) -> None:
+    """Partial unique index only applies when email is non-null."""
+    await create_user(session, slack_team_id="T01", slack_user_id="U01")
+    await create_user(session, slack_team_id="T01", slack_user_id="U02")
+    # Neither has an email — both should coexist.
+    users = await list_users(session)
+    assert len([u for u in users if u.email is None]) == 2
+
+
+# ─── Password hashing ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_password_is_hashed(session: AsyncSession) -> None:
+    u = await create_user(session, email="a@example.com", password="hunter2a")
+    assert u.password_hash is not None
+    # Argon2id hashes start with $argon2id$ — quick sanity check.
+    assert u.password_hash.startswith("$argon2id$")
+    assert u.password_hash != "hunter2a"
+
+
+@pytest.mark.asyncio
+async def test_password_verify(session: AsyncSession) -> None:
+    u = await create_user(session, email="a@example.com", password="hunter2a")
+    assert verify_password("hunter2a", u.password_hash or "")
+    assert not verify_password("wrong", u.password_hash or "")
+
+
+@pytest.mark.asyncio
+async def test_set_password_updates_hash(session: AsyncSession) -> None:
+    u = await create_user(session, email="a@example.com", password="first8ch")
+    original = u.password_hash
+
+    u2 = await set_password(session, u.id, "second8c")
+    assert u2.password_hash != original
+    assert verify_password("second8c", u2.password_hash or "")
+
+
+@pytest.mark.asyncio
+async def test_set_password_none_clears_hash(session: AsyncSession) -> None:
+    u = await create_user(session, email="a@example.com", password="first8ch")
+    assert u.password_hash is not None
+
+    u2 = await set_password(session, u.id, None)
+    assert u2.password_hash is None
+
+
+# ─── Lookups ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_user_by_id_and_email(session: AsyncSession) -> None:
+    u = await create_user(session, email="a@example.com")
+    by_id = await get_user(session, u.id)
+    by_email = await get_user_by_email(session, "a@example.com")
+    assert by_id is not None and by_email is not None
+    assert by_id.id == by_email.id == u.id
+
+
+@pytest.mark.asyncio
+async def test_get_user_by_slack(session: AsyncSession) -> None:
+    u = await create_user(session, slack_team_id="T01", slack_user_id="U01")
+    found = await get_user_by_slack(session, slack_team_id="T01", slack_user_id="U01")
+    assert found is not None
+    assert found.id == u.id
+
+
+@pytest.mark.asyncio
+async def test_list_users_filters(session: AsyncSession) -> None:
+    await create_user(session, email="a@example.com", role="kyc", pool="ops")
+    await create_user(session, email="b@example.com", role="kyc", pool="fraud")
+    await create_user(session, email="c@example.com", role="support", pool="ops")
+
+    kyc = await list_users(session, role="kyc")
+    assert len(kyc) == 2
+
+    ops = await list_users(session, pool="ops")
+    assert len(ops) == 2
+
+    kyc_ops = await list_users(session, role="kyc", pool="ops")
+    assert len(kyc_ops) == 1
+    assert kyc_ops[0].email == "a@example.com"
+
+
+# ─── Update + delete ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_user_patches_fields(session: AsyncSession) -> None:
+    u = await create_user(session, email="a@example.com")
+    u2 = await update_user(session, u.id, display_name="Alice", role="kyc")
+    assert u2.display_name == "Alice"
+    assert u2.role == "kyc"
+    assert u2.email == "a@example.com"
+
+
+@pytest.mark.asyncio
+async def test_update_rejects_removing_last_address(session: AsyncSession) -> None:
+    """You can't update a user into an unreachable state."""
+    u = await create_user(session, email="a@example.com")
+    with pytest.raises(UserNoAddressError):
+        await update_user(session, u.id, email=None)
+
+
+@pytest.mark.asyncio
+async def test_update_unknown_id_raises(session: AsyncSession) -> None:
+    with pytest.raises(UserNotFoundError):
+        await update_user(session, "does-not-exist", role="kyc")
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_row(session: AsyncSession) -> None:
+    u = await create_user(session, email="a@example.com")
+    assert await delete_user(session, u.id) is True
+    assert await get_user(session, u.id) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_missing_returns_false(session: AsyncSession) -> None:
+    assert await delete_user(session, "nope") is False
+
+
+@pytest.mark.asyncio
+async def test_count_users_for_bootstrap(session: AsyncSession) -> None:
+    """`/setup` bootstrap uses count_users to decide whether to show the
+    first-run form. This test pins that count is zero on empty and grows."""
+    assert await count_users(session) == 0
+    await create_user(session, email="a@example.com")
+    assert await count_users(session) == 1
+    await create_user(session, email="b@example.com")
+    assert await count_users(session) == 2


### PR DESCRIPTION
## Summary

Second PR in the A-series. Implements the full user directory CRUD — service layer, admin API, and four CLI commands — on top of the User model from PR A1. Auth for the dashboard / `/setup` bootstrap / task router comes in later PRs; this one is pure directory management.

## What's in

**Password hashing** (`server/core/password.py`)
- argon2id via argon2-cffi (OWASP-recommended for new systems, memory-hard, side-channel-resistant)
- Simple API: `hash_password(pw)` / `verify_password(pw, hash)`
- `verify_password` returns False on mismatch or malformed hash — never raises

**User service** (`services/user_service.py`) — the one place that writes the `users` table
- At-least-one-address rule enforced here (DB can't portably express "at least one of these two fields")
- Partial Slack identifiers (team alone or user alone) rejected — Slack IDs are workspace-scoped and meaningless individually
- `IntegrityError` on unique-constraint violation → `UserAlreadyExistsError` with best-effort conflict labeling
- `set_password` hashes inline; `password` never stored as plaintext anywhere
- `count_users` hook for the `/setup` bootstrap (PR A3)

**Admin API** (`routes/users.py`) — gated by existing `require_admin` (`X-Admin-Token` bearer)

| Method | Path | Purpose |
|---|---|---|
| POST | `/api/admin/users` | create |
| GET | `/api/admin/users[?role=&access_level=&pool=&active=]` | list |
| GET | `/api/admin/users/{id}` | get one |
| PATCH | `/api/admin/users/{id}` | update |
| DELETE | `/api/admin/users/{id}` | hard delete |
| POST | `/api/admin/users/{id}/password` | set password |
| DELETE | `/api/admin/users/{id}/password` | clear password (user can't log in but still receives tasks) |

`UserResponse` never includes `password_hash`. A `has_password` bool surfaces "can this user log in?" without leaking the hash — same discipline as email `transport_config`.

**CLI commands**
```
awaithumans add-user --email / --slack-team-id + --slack-user-id [--role --access-level --pool --operator --password --display-name]
awaithumans list-users [--role --access-level --pool --active]
awaithumans remove-user <id-or-email> [--yes]
awaithumans set-password <id-or-email> [--password | --clear]
```
CLI auth model: \"you already have shell access to the box.\" CLI writes directly to local SQLite; runs `alembic upgrade head` first so fresh dev machines don't need to remember to migrate.

**Dependency:** `argon2-cffi>=23.1.0` added to `[server]` extras.

## Test plan
- [x] 21 service tests (at-least-one-address, partial slack rejection, uniqueness per-scope, password round-trip, lookups, filters, update/delete, count)
- [x] 12 admin-route tests (auth gate, create/get/list/patch/delete, password set/clear, 404/409/422, no `password_hash` in any response)
- [x] Full suite: **267 passing** (up from 234)
- [x] CLI smoke: `add-user` / `list-users` / `remove-user` / `set-password` all work end-to-end against a local SQLite DB

## Scope deliberately excluded
- **A3** — auth overhaul: DB-backed sessions + `/setup` bootstrap token + CLI `bootstrap-operator` + dashboard login wiring
- **A4** — task router (Option C: least-recently-assigned, transactional)
- **A5** — dashboard Settings UI for users + `/setup` page
- **B** — Slack broadcast + workspace member picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)