### PR TITLE
feat(auth): DB-backed sessions + /setup bootstrap (PR A3)

### DIFF
--- a/packages/dashboard/app/login/page.tsx
+++ b/packages/dashboard/app/login/page.tsx
@@ -5,14 +5,13 @@ import { Suspense, useEffect, useState } from "react";
 
 import { LogoMark } from "@/components/logo";
 import { TerminalSpinner } from "@/components/terminal-spinner";
-import { login, fetchMe } from "@/lib/server";
+import { fetchMe, fetchSetupStatus, login } from "@/lib/server";
 
 /**
  * Wrapping the search-params reader in Suspense is required for
  * Next's static export (output: "export"). Without it, the build
  * fails with "useSearchParams() should be wrapped in a suspense
- * boundary at page /login". Split so the `?next=` lookup is inside
- * the boundary and the page shell renders statically.
+ * boundary at page /login".
  */
 export default function LoginPage() {
 	return (
@@ -33,24 +32,33 @@ function LoginPageInner() {
 	const params = useSearchParams();
 	const next = params.get("next") || "/";
 
-	const [user, setUser] = useState("admin");
+	const [email, setEmail] = useState("");
 	const [password, setPassword] = useState("");
 	const [submitting, setSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
-	const [authRequired, setAuthRequired] = useState<boolean | null>(null);
+	const [ready, setReady] = useState(false);
 
-	// If the server has auth off, bounce straight through.
+	// On mount: if the server has no users yet, bounce to /setup.
+	// If the caller is already logged in, bounce to `next`. Otherwise
+	// render the login form.
 	useEffect(() => {
-		fetchMe()
-			.then((me) => {
-				if (!me.auth_enabled) {
-					router.replace(next);
-				} else {
-					setAuthRequired(true);
-					if (me.authenticated) router.replace(next);
+		(async () => {
+			try {
+				const setup = await fetchSetupStatus();
+				if (setup.needs_setup) {
+					router.replace("/setup");
+					return;
 				}
-			})
-			.catch(() => setAuthRequired(true));
+				const me = await fetchMe();
+				if (me.authenticated) {
+					router.replace(next);
+					return;
+				}
+			} catch {
+				// Server unreachable — fall through and let the user try.
+			}
+			setReady(true);
+		})();
 	}, [router, next]);
 
 	const handleSubmit = async (e: React.FormEvent) => {
@@ -58,7 +66,7 @@ function LoginPageInner() {
 		setSubmitting(true);
 		setError(null);
 		try {
-			await login(user, password);
+			await login(email, password);
 			router.replace(next);
 		} catch (err) {
 			setError(
@@ -71,8 +79,7 @@ function LoginPageInner() {
 		}
 	};
 
-	// Don't flash the login form while we're checking session state.
-	if (authRequired === null) {
+	if (!ready) {
 		return (
 			<div className="min-h-screen flex items-center justify-center">
 				<TerminalSpinner label="checking session" />
@@ -93,15 +100,16 @@ function LoginPageInner() {
 				<div className="border border-white/10 rounded-lg p-6 bg-white/[0.02]">
 					<h1 className="text-lg font-semibold mb-1">Sign in</h1>
 					<p className="text-white/40 text-xs mb-5">
-						Enter the dashboard password configured for this server.
+						Sign in with your dashboard credentials.
 					</p>
 
 					<form onSubmit={handleSubmit} className="space-y-4">
 						<Field
-							label="Username"
-							value={user}
-							onChange={setUser}
-							autoFocus={!user}
+							label="Email"
+							type="email"
+							value={email}
+							onChange={setEmail}
+							autoFocus={!email}
 							disabled={submitting}
 						/>
 						<Field
@@ -109,7 +117,7 @@ function LoginPageInner() {
 							type="password"
 							value={password}
 							onChange={setPassword}
-							autoFocus={!!user}
+							autoFocus={!!email}
 							disabled={submitting}
 						/>
 
@@ -121,7 +129,7 @@ function LoginPageInner() {
 
 						<button
 							type="submit"
-							disabled={submitting || !password}
+							disabled={submitting || !password || !email}
 							className="w-full px-4 py-2.5 bg-brand text-black font-semibold text-sm rounded-md hover:bg-brand/90 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
 						>
 							{submitting ? "Signing in…" : "Sign in"}
@@ -130,9 +138,11 @@ function LoginPageInner() {
 				</div>
 
 				<p className="text-center text-white/25 text-xs mt-6">
-					Running behind your own auth proxy? Leave{" "}
-					<code className="text-white/40">AWAITHUMANS_DASHBOARD_PASSWORD</code>{" "}
-					unset to disable this screen.
+					First time?{" "}
+					<a href="/setup" className="text-brand/80 hover:text-brand">
+						Set up the first operator
+					</a>
+					.
 				</p>
 			</div>
 		</div>

--- a/packages/dashboard/app/setup/page.tsx
+++ b/packages/dashboard/app/setup/page.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useState } from "react";
+
+import { LogoMark } from "@/components/logo";
+import { TerminalSpinner } from "@/components/terminal-spinner";
+import { createFirstOperator, fetchSetupStatus } from "@/lib/server";
+
+/**
+ * First-run setup wizard. Creates the initial operator account
+ * using the one-shot bootstrap token printed in the server log.
+ *
+ * If setup is already complete, redirects to /login. Token can be
+ * pre-filled from `?token=...` (the server logs a clickable URL
+ * with that query param).
+ */
+export default function SetupPage() {
+	return (
+		<Suspense
+			fallback={
+				<div className="min-h-screen flex items-center justify-center">
+					<TerminalSpinner label="checking server" />
+				</div>
+			}
+		>
+			<SetupPageInner />
+		</Suspense>
+	);
+}
+
+function SetupPageInner() {
+	const router = useRouter();
+	const params = useSearchParams();
+
+	const [token, setToken] = useState(() => params.get("token") ?? "");
+	const [email, setEmail] = useState("");
+	const [displayName, setDisplayName] = useState("");
+	const [password, setPassword] = useState("");
+	const [confirm, setConfirm] = useState("");
+
+	const [submitting, setSubmitting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [state, setState] = useState<
+		"checking" | "ready" | "already-done" | "unreachable"
+	>("checking");
+
+	useEffect(() => {
+		(async () => {
+			try {
+				const status = await fetchSetupStatus();
+				if (!status.needs_setup) {
+					setState("already-done");
+				} else {
+					setState("ready");
+				}
+			} catch {
+				setState("unreachable");
+			}
+		})();
+	}, []);
+
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
+		setError(null);
+		if (password !== confirm) {
+			setError("Passwords don't match.");
+			return;
+		}
+		if (password.length < 8) {
+			setError("Password must be at least 8 characters.");
+			return;
+		}
+
+		setSubmitting(true);
+		try {
+			await createFirstOperator({
+				token,
+				email,
+				password,
+				display_name: displayName || undefined,
+			});
+			// Server sets the session cookie on 201 — land straight on the queue.
+			router.replace("/");
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			if (msg.includes("403")) {
+				setError(
+					"Setup token rejected. Check the server log for the latest token.",
+				);
+			} else if (msg.includes("409")) {
+				setError("Setup is already complete. Please sign in instead.");
+				setState("already-done");
+			} else {
+				setError(`Setup failed: ${msg}`);
+			}
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
+	if (state === "checking") {
+		return (
+			<div className="min-h-screen flex items-center justify-center">
+				<TerminalSpinner label="checking server" />
+			</div>
+		);
+	}
+
+	if (state === "already-done") {
+		return (
+			<Shell title="Setup already complete">
+				<p className="text-white/60 text-sm mb-4">
+					This server already has an operator account. Sign in with those
+					credentials.
+				</p>
+				<a
+					href="/login"
+					className="block w-full px-4 py-2.5 bg-brand text-black font-semibold text-sm rounded-md text-center hover:bg-brand/90"
+				>
+					Go to sign in
+				</a>
+			</Shell>
+		);
+	}
+
+	if (state === "unreachable") {
+		return (
+			<Shell title="Server unreachable">
+				<p className="text-white/60 text-sm">
+					Can't reach <code>/api/setup/status</code>. Make sure{" "}
+					<code>awaithumans dev</code> is running and refresh.
+				</p>
+			</Shell>
+		);
+	}
+
+	return (
+		<Shell title="First-run setup">
+			<p className="text-white/40 text-xs mb-5">
+				Create the initial operator account. The setup token was printed to
+				the server log when the process started — paste it below.
+			</p>
+
+			<form onSubmit={handleSubmit} className="space-y-4">
+				<Field
+					label="Setup token"
+					value={token}
+					onChange={setToken}
+					disabled={submitting}
+					autoFocus={!token}
+					type="text"
+				/>
+				<Field
+					label="Email"
+					type="email"
+					value={email}
+					onChange={setEmail}
+					disabled={submitting}
+					autoFocus={!!token && !email}
+				/>
+				<Field
+					label="Display name (optional)"
+					value={displayName}
+					onChange={setDisplayName}
+					disabled={submitting}
+				/>
+				<Field
+					label="Password"
+					type="password"
+					value={password}
+					onChange={setPassword}
+					disabled={submitting}
+				/>
+				<Field
+					label="Confirm password"
+					type="password"
+					value={confirm}
+					onChange={setConfirm}
+					disabled={submitting}
+				/>
+
+				{error && (
+					<div className="text-red-400 text-xs border border-red-400/30 bg-red-400/5 rounded-md px-3 py-2">
+						{error}
+					</div>
+				)}
+
+				<button
+					type="submit"
+					disabled={submitting || !token || !email || !password || !confirm}
+					className="w-full px-4 py-2.5 bg-brand text-black font-semibold text-sm rounded-md hover:bg-brand/90 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+				>
+					{submitting ? "Creating…" : "Create operator"}
+				</button>
+			</form>
+		</Shell>
+	);
+}
+
+function Shell({ title, children }: { title: string; children: React.ReactNode }) {
+	return (
+		<div className="min-h-screen flex items-center justify-center px-6">
+			<div className="w-full max-w-sm">
+				<div className="flex items-center gap-2.5 mb-8 justify-center">
+					<LogoMark size={24} className="text-fg" />
+					<span className="font-mono font-semibold tracking-tight text-base">
+						awaithumans
+					</span>
+				</div>
+				<div className="border border-white/10 rounded-lg p-6 bg-white/[0.02]">
+					<h1 className="text-lg font-semibold mb-1">{title}</h1>
+					{children}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function Field({
+	label,
+	value,
+	onChange,
+	type = "text",
+	autoFocus,
+	disabled,
+}: {
+	label: string;
+	value: string;
+	onChange: (v: string) => void;
+	type?: string;
+	autoFocus?: boolean;
+	disabled?: boolean;
+}) {
+	return (
+		<label className="block">
+			<span className="text-xs font-medium text-white/60 mb-1.5 block">
+				{label}
+			</span>
+			<input
+				type={type}
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+				autoFocus={autoFocus}
+				disabled={disabled}
+				className="w-full bg-white/5 border border-white/10 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-brand/40 disabled:opacity-40"
+			/>
+		</label>
+	);
+}

--- a/packages/dashboard/components/auth-guard.tsx
+++ b/packages/dashboard/components/auth-guard.tsx
@@ -3,19 +3,19 @@
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
-import { fetchMe } from "@/lib/server";
+import { fetchMe, fetchSetupStatus } from "@/lib/server";
 import { TerminalSpinner } from "./terminal-spinner";
 
 type State = "loading" | "allowed" | "redirecting";
 
 /**
- * Dashboard auth gate. On mount, calls /api/auth/me:
+ * Dashboard auth gate. On mount:
  *
- * - `auth_enabled: false`   → allow (behind-proxy mode)
- * - `authenticated: true`   → allow
- * - anything else           → redirect to /login?next=<current path>
+ * - If setup hasn't been completed → redirect to /setup
+ * - If /api/auth/me says `authenticated: true` → allow
+ * - Otherwise → redirect to /login?next=<current path>
  *
- * Keeps it to a single call per mount; the subsequent API calls either
+ * Keeps it to at most two calls per mount; subsequent API calls either
  * ride the session cookie or get 401 → UnauthorizedError, which the
  * callers surface as a banner.
  */
@@ -27,23 +27,32 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
 	useEffect(() => {
 		let cancelled = false;
 
-		fetchMe()
-			.then((me) => {
+		(async () => {
+			try {
+				const setup = await fetchSetupStatus();
 				if (cancelled) return;
-				if (!me.auth_enabled || me.authenticated) {
+				if (setup.needs_setup) {
+					setState("redirecting");
+					router.replace("/setup");
+					return;
+				}
+
+				const me = await fetchMe();
+				if (cancelled) return;
+				if (me.authenticated) {
 					setState("allowed");
 				} else {
 					setState("redirecting");
 					router.replace(`/login?next=${encodeURIComponent(pathname)}`);
 				}
-			})
-			.catch(() => {
+			} catch {
 				if (cancelled) return;
-				// If /me itself fails (server down), let the underlying
-				// page render its own error — don't trap the user in a
-				// loading state. Callers will surface the fetch error.
+				// /me or /setup/status fails (server down): let the
+				// underlying page render its own error — don't trap the
+				// user in a loading state.
 				setState("allowed");
-			});
+			}
+		})();
 
 		return () => {
 			cancelled = true;

--- a/packages/dashboard/lib/server/auth.ts
+++ b/packages/dashboard/lib/server/auth.ts
@@ -1,32 +1,58 @@
 /**
- * Auth API — login, logout, session introspection.
+ * Auth API — login, logout, session introspection, first-run setup.
  *
- * All three call the Python server's /api/auth/* routes. credentials:
- * "include" on the underlying apiFetch means the session cookie the
- * server sets on login comes back on subsequent calls.
+ * All of these call the Python server's /api/auth/* or /api/setup/*
+ * routes. credentials: "include" on the underlying apiFetch means the
+ * session cookie the server sets on login comes back on subsequent
+ * calls.
  */
 
 import { apiFetch } from "./client";
 
 export interface MeResponse {
 	authenticated: boolean;
-	user: string | null;
-	auth_enabled: boolean;
+	user_id: string | null;
+	email: string | null;
+	display_name: string | null;
+	is_operator: boolean;
 }
 
 export async function fetchMe(): Promise<MeResponse> {
 	return apiFetch<MeResponse>("/api/auth/me");
 }
 
-export async function login(user: string, password: string): Promise<void> {
+export async function login(email: string, password: string): Promise<void> {
 	await apiFetch<void>("/api/auth/login", {
 		method: "POST",
-		body: JSON.stringify({ user, password }),
+		body: JSON.stringify({ email, password }),
 	});
 }
 
 export async function logout(): Promise<void> {
 	await apiFetch<void>("/api/auth/logout", {
 		method: "POST",
+	});
+}
+
+// ─── First-run setup ───────────────────────────────────────────────────
+
+export interface SetupStatusResponse {
+	needs_setup: boolean;
+	token_active: boolean;
+}
+
+export async function fetchSetupStatus(): Promise<SetupStatusResponse> {
+	return apiFetch<SetupStatusResponse>("/api/setup/status");
+}
+
+export async function createFirstOperator(args: {
+	token: string;
+	email: string;
+	password: string;
+	display_name?: string;
+}): Promise<{ user_id: string; email: string }> {
+	return apiFetch<{ user_id: string; email: string }>("/api/setup/operator", {
+		method: "POST",
+		body: JSON.stringify(args),
 	});
 }

--- a/packages/dashboard/lib/server/index.ts
+++ b/packages/dashboard/lib/server/index.ts
@@ -14,7 +14,15 @@ export type {
 } from "@/lib/types";
 
 export { fetchAuditTrail } from "./audit";
-export { fetchMe, login, logout, type MeResponse } from "./auth";
+export {
+	createFirstOperator,
+	fetchMe,
+	fetchSetupStatus,
+	login,
+	logout,
+	type MeResponse,
+	type SetupStatusResponse,
+} from "./auth";
 export { apiFetch, UnauthorizedError } from "./client";
 export {
 	createEmailIdentity,

--- a/packages/python/awaithumans/cli/commands/bootstrap_operator.py
+++ b/packages/python/awaithumans/cli/commands/bootstrap_operator.py
@@ -1,0 +1,74 @@
+"""Create the first operator from the command line.
+
+Alternative to the `/setup` token flow — used when the server is
+running in a non-interactive environment (docker-compose, CI) where
+reading the setup URL from the server log and opening a browser
+isn't practical.
+
+Refuses if any user already exists. For subsequent operators, use
+`awaithumans add-user --operator` instead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import typer
+
+from awaithumans.cli.commands._session import with_session
+from awaithumans.server.services.exceptions import UserAlreadyExistsError
+from awaithumans.server.services.user_service import count_users, create_user
+
+
+def bootstrap_operator(
+    email: str = typer.Option(..., help="Operator's email address."),
+    password: str | None = typer.Option(
+        None,
+        help="Operator password. Omit to prompt interactively with confirmation.",
+    ),
+    display_name: str | None = typer.Option(None, help="Human-readable name."),
+) -> None:
+    """Create the first operator (only runs when users table is empty).
+
+    For automation. The `/setup` web flow is the recommended path for
+    interactive first-run — this command is the escape hatch when
+    operating headless.
+    """
+    # Prompt for password if not supplied — match the dashboard /setup UX.
+    if password is None:
+        password = typer.prompt(
+            "Operator password", hide_input=True, confirmation_prompt=True
+        )
+    if len(password) < 8:
+        raise typer.BadParameter("Password must be at least 8 characters.")
+
+    async def _run() -> None:
+        async with with_session() as session:
+            if await count_users(session) > 0:
+                typer.echo(
+                    "Error: setup has already been completed — use "
+                    "`add-user --operator` to grant additional operator "
+                    "access.",
+                    err=True,
+                )
+                raise typer.Exit(code=1)
+
+            try:
+                user = await create_user(
+                    session,
+                    email=email,
+                    display_name=display_name,
+                    is_operator=True,
+                    password=password,
+                )
+            except UserAlreadyExistsError as exc:
+                # Same email reused between a failed first attempt and
+                # this one, or a race with /setup. Same remediation —
+                # surface and exit.
+                typer.echo(f"Error: {exc.message}", err=True)
+                raise typer.Exit(code=1) from exc
+
+        typer.echo(f"Operator created: {user.email} ({user.id})")
+        typer.echo("Log in at the dashboard with these credentials.")
+
+    asyncio.run(_run())

--- a/packages/python/awaithumans/cli/commands/dev.py
+++ b/packages/python/awaithumans/cli/commands/dev.py
@@ -5,13 +5,47 @@ from __future__ import annotations
 import atexit
 import logging
 import os
+import secrets
 import socket
+from pathlib import Path
 
 import typer
 
 from awaithumans.utils.discovery import delete_discovery, write_discovery
 
 logger = logging.getLogger("awaithumans.cli")
+
+
+def _ensure_dev_payload_key(db_path: str) -> None:
+    """Generate a local PAYLOAD_KEY for dev if one isn't set in env.
+
+    PAYLOAD_KEY is now always required — it signs session cookies and
+    encrypts at-rest columns. For `awaithumans dev`, we don't want to
+    force every first-time user to run `python -c 'import secrets...'`
+    before the server starts.
+
+    Cached in `<.awaithumans dir>/payload.key` so sessions survive
+    restarts. File is 0600. Production must still set the env var
+    explicitly (this function only writes when env is unset).
+    """
+    if os.environ.get("AWAITHUMANS_PAYLOAD_KEY"):
+        return
+
+    key_path = Path(db_path).parent / "payload.key"
+    key_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if key_path.exists():
+        os.environ["AWAITHUMANS_PAYLOAD_KEY"] = key_path.read_text().strip()
+        return
+
+    key = secrets.token_urlsafe(32)
+    key_path.write_text(key)
+    try:
+        key_path.chmod(0o600)
+    except OSError:
+        pass  # Windows or exotic filesystems — best-effort
+    os.environ["AWAITHUMANS_PAYLOAD_KEY"] = key
+    logger.info("Generated dev PAYLOAD_KEY at %s (0600)", key_path)
 
 
 def _is_port_available(host: str, port: int) -> bool:
@@ -66,6 +100,9 @@ def dev(
     os.environ.setdefault("AWAITHUMANS_LOG_LEVEL", log_level)
     os.environ.setdefault("AWAITHUMANS_HOST", host)
     os.environ.setdefault("AWAITHUMANS_PORT", str(actual_port))
+
+    # Ensure a PAYLOAD_KEY exists for local dev (cached in .awaithumans/)
+    _ensure_dev_payload_key(db_path)
 
     # Write discovery file so SDKs and the dashboard can auto-find us
     write_discovery(host=host, port=actual_port)

--- a/packages/python/awaithumans/cli/main.py
+++ b/packages/python/awaithumans/cli/main.py
@@ -14,6 +14,7 @@ except ImportError:
     ) from None
 
 from awaithumans.cli.commands.add_user import add_user
+from awaithumans.cli.commands.bootstrap_operator import bootstrap_operator
 from awaithumans.cli.commands.dev import dev
 from awaithumans.cli.commands.list_users import list_users_cmd
 from awaithumans.cli.commands.remove_user import remove_user
@@ -27,6 +28,7 @@ app = typer.Typer(
 )
 
 app.command()(dev)
+app.command("bootstrap-operator")(bootstrap_operator)
 app.command("add-user")(add_user)
 app.command("list-users")(list_users_cmd)
 app.command("remove-user")(remove_user)

--- a/packages/python/awaithumans/server/app.py
+++ b/packages/python/awaithumans/server/app.py
@@ -22,8 +22,19 @@ from awaithumans.server.core.exceptions import exception_handlers
 from awaithumans.server.core.logging_config import setup_logging
 from awaithumans.server.core.middleware import RequestIDMiddleware
 from awaithumans.server.db.connection import close_db, init_db
-from awaithumans.server.routes import auth, email, health, slack, stats, status, tasks, users
+from awaithumans.server.routes import (
+    auth,
+    email,
+    health,
+    setup,
+    slack,
+    stats,
+    status,
+    tasks,
+    users,
+)
 from awaithumans.server.services.timeout_scheduler import run_timeout_scheduler
+from awaithumans.server.services.user_service import count_users
 
 logger = logging.getLogger("awaithumans.server")
 
@@ -34,6 +45,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     await init_db()
     logger.info("Database initialized")
 
+    await _emit_first_run_banner_if_empty()
+
     scheduler_task = asyncio.create_task(run_timeout_scheduler())
 
     yield
@@ -43,6 +56,22 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         await scheduler_task
     await close_db()
     logger.info("Server shut down")
+
+
+async def _emit_first_run_banner_if_empty() -> None:
+    """If zero users exist in the DB, generate a bootstrap token and
+    log the /setup URL so the operator can complete first-run setup."""
+    from awaithumans.server.core import bootstrap
+    from awaithumans.server.db.connection import get_async_session_factory
+
+    factory = get_async_session_factory()
+    async with factory() as session:
+        n = await count_users(session)
+
+    if n == 0:
+        token = bootstrap.ensure_token()
+        setup_url = f"{settings.PUBLIC_URL.rstrip('/')}/setup?token={token}"
+        bootstrap.log_setup_banner(setup_url)
 
 
 def create_app(*, serve_dashboard: bool = True) -> FastAPI:
@@ -79,15 +108,16 @@ def create_app(*, serve_dashboard: bool = True) -> FastAPI:
             "and set AWAITHUMANS_PAYLOAD_KEY."
         )
 
-    # Dashboard auth signs cookies with an HKDF-derived key from
-    # PAYLOAD_KEY. Without PAYLOAD_KEY, login() would crash on first
-    # call. Fail fast.
-    if settings.DASHBOARD_PASSWORD and not settings.PAYLOAD_KEY:
+    # Dashboard auth signs session cookies with an HKDF-derived key
+    # from PAYLOAD_KEY. Without it we'd either silently fall back to
+    # an insecure default (no) or crash on first login (surprising).
+    # Auth is always on in v1, so this is always required.
+    if not settings.PAYLOAD_KEY:
         raise RuntimeError(
-            "DASHBOARD_PASSWORD is set but PAYLOAD_KEY is not. Session "
-            "cookies can't be signed without PAYLOAD_KEY. Generate one "
-            "with: python -c 'import secrets; print(secrets.token_urlsafe(32))' "
-            "and set AWAITHUMANS_PAYLOAD_KEY."
+            "AWAITHUMANS_PAYLOAD_KEY is required — session cookies and "
+            "encrypted-at-rest columns both derive their keys from it. "
+            "Generate one with: python -c 'import secrets; "
+            "print(secrets.token_urlsafe(32))'"
         )
 
     # ── App ──────────────────────────────────────────────────────────
@@ -124,6 +154,7 @@ def create_app(*, serve_dashboard: bool = True) -> FastAPI:
     app.include_router(slack.router, prefix="/api")
     app.include_router(email.router, prefix="/api")
     app.include_router(users.router, prefix="/api")
+    app.include_router(setup.router, prefix="/api")
 
     # ── Dashboard static files ───────────────────────────────────────
     # The bundled dashboard lives inside the package

--- a/packages/python/awaithumans/server/core/admin_auth.py
+++ b/packages/python/awaithumans/server/core/admin_auth.py
@@ -1,12 +1,14 @@
-"""Shared admin-only guard — used by identity management routes.
+"""Admin-only guard — accepts either an operator session OR the
+admin bearer token.
 
-Clients pass `X-Admin-Token: <token>`; the server compares it against
-`AWAITHUMANS_ADMIN_API_TOKEN` in constant time. When the env is unset,
-all admin routes return 503 (feature explicitly disabled).
+Operators (logged-in users with `is_operator=True`) get dashboard
+access automatically. Automation (CI, ops scripts, migration tools)
+uses the `X-Admin-Token` bearer header. Either proves admin intent;
+the route doesn't care which.
 
-This is a pragmatic v1 gate. Multi-user auth with per-user roles is
-future work; today an operator generates one token and shares it with
-whoever needs to manage identities.
+When both `ADMIN_API_TOKEN` is unset AND the caller has no operator
+session, the route returns 403 (standard forbidden, not 503 —
+operators can still reach it via the dashboard login).
 """
 
 from __future__ import annotations
@@ -14,27 +16,40 @@ from __future__ import annotations
 import hmac
 import logging
 
-from fastapi import Header, HTTPException
+from fastapi import HTTPException, Request
 
+from awaithumans.server.core.auth import SessionClaims
 from awaithumans.server.core.config import settings
 
 logger = logging.getLogger("awaithumans.server.core.admin_auth")
 
 
-async def require_admin(
-    x_admin_token: str | None = Header(default=None, alias="X-Admin-Token"),
-) -> None:
-    """FastAPI dependency — raise 403/503 if the caller isn't an admin."""
+def _has_valid_admin_token(request: Request, header_value: str | None) -> bool:
+    """Accept both `X-Admin-Token: <token>` (legacy) and
+    `Authorization: Bearer <token>` (more standard). The dashboard
+    middleware already stripped the bearer form when `Bearer` matched
+    the admin token — in that case `request.state.auth_admin_token`
+    is set and we trust it."""
+    if getattr(request.state, "auth_admin_token", False):
+        return True
     if not settings.ADMIN_API_TOKEN:
-        raise HTTPException(
-            status_code=503,
-            detail=(
-                "Admin endpoints are disabled. Set AWAITHUMANS_ADMIN_API_TOKEN "
-                "to a high-entropy value (e.g. `python -c 'import secrets; "
-                "print(secrets.token_urlsafe(32))'`)."
-            ),
-        )
-    if not x_admin_token or not hmac.compare_digest(
-        x_admin_token, settings.ADMIN_API_TOKEN
-    ):
-        raise HTTPException(status_code=403, detail="Admin token required.")
+        return False
+    if not header_value:
+        return False
+    return hmac.compare_digest(header_value, settings.ADMIN_API_TOKEN)
+
+
+def _is_operator_session(request: Request) -> bool:
+    claims = getattr(request.state, "auth_claims", None)
+    return isinstance(claims, SessionClaims) and claims.is_operator
+
+
+async def require_admin(request: Request) -> None:
+    """FastAPI dependency — raise 403 if the caller isn't an operator
+    (by session) or an admin-token holder (by bearer header)."""
+    header_value = request.headers.get("x-admin-token")
+    if _has_valid_admin_token(request, header_value):
+        return
+    if _is_operator_session(request):
+        return
+    raise HTTPException(status_code=403, detail="Admin access required.")

--- a/packages/python/awaithumans/server/core/auth.py
+++ b/packages/python/awaithumans/server/core/auth.py
@@ -1,18 +1,30 @@
-"""Dashboard password auth — optional HMAC session cookies.
+"""Dashboard auth — DB-backed users + HMAC session cookies.
 
-Turned on by setting `AWAITHUMANS_DASHBOARD_PASSWORD`. When unset the
-middleware is a no-op and every route is public (operator is responsible
-for fronting the server with their own auth proxy).
+Always on. First-run state (zero users in the DB) is handled by the
+`/api/setup/*` routes which sit in the public-prefix list and gate
+themselves on an in-memory bootstrap token.
 
 Wire format: `cookie = base64url(hmac(body) || body)` where
-`body = json({u: user, e: expiry_unix})` — same shape as the email
-magic-link tokens. The HMAC key is HKDF-derived from PAYLOAD_KEY with
-a channel-scoped salt, so the same root key never signs two primitives.
+`body = json({u: user_id, o: is_operator, e: expiry_unix})`. The HMAC
+key is HKDF-derived from PAYLOAD_KEY with a channel-scoped salt, so
+the same root key never signs two primitives.
+
+Session validation is two-step:
+- `verify_session(cookie)` checks HMAC, expiry, and payload shape —
+  no DB hit. Returns a `SessionClaims` dataclass.
+- Routes that need fresh user data use the `require_session` FastAPI
+  dep, which looks up the user by ID (enabling later "invalidate on
+  password change" via a session_version field).
+
+An operator password change or row deletion doesn't invalidate
+outstanding sessions until they expire. Acceptable for v1. Post-launch
+we can add a `session_version` field and re-sign on password reset.
 
 The middleware enforces auth before routes run:
-- public paths (`/api/auth/*`, `/api/health`, static assets) skip the check
-- a valid `Authorization: Bearer <ADMIN_API_TOKEN>` acts as a skeleton key
-  (lets ops + the admin identity CRUD work without a session)
+- public paths (`/api/auth/*`, `/api/setup/*`, `/api/health`, static
+  assets) skip the check
+- a valid `Authorization: Bearer <ADMIN_API_TOKEN>` acts as a skeleton
+  key for automation (CI, ops scripts)
 - otherwise a valid session cookie is required, else 401
 """
 
@@ -24,7 +36,7 @@ import hmac
 import json
 import logging
 import time
-from typing import Any
+from dataclasses import dataclass
 
 from cryptography.hazmat.primitives.hashes import SHA256
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
@@ -45,19 +57,39 @@ from awaithumans.utils.constants import (
 logger = logging.getLogger("awaithumans.server.core.auth")
 
 
-# Paths that stay public even when auth is on. Auth routes (so the
-# login page can reach them), health probes, and the OAuth install
-# callbacks (signed by Slack, not us).
+# Paths that stay public even when auth is on:
+# - /api/auth/*        — login, logout, introspection
+# - /api/setup/*       — first-run bootstrap (gates itself on a token)
+# - /api/health        — readiness probes
+# - slack/email action — signed by their own HMAC, no session needed
 _PUBLIC_PREFIXES = (
     "/api/auth/",
+    "/api/setup/",
     "/api/health",
-    "/api/channels/slack/oauth/",   # Slack-signed state already gates these
-    "/api/channels/email/action/",  # magic links are self-signed
+    "/api/channels/slack/oauth/",           # Slack-signed state gates these
+    "/api/channels/slack/interactions",     # HMAC request signature gates this
+    "/api/channels/slack/events",           # HMAC request signature gates this
+    "/api/channels/email/action/",          # magic links are self-signed
 )
 
 
 class InvalidSessionError(Exception):
     """Session cookie failed HMAC, expiry, or format validation."""
+
+
+@dataclass(frozen=True)
+class SessionClaims:
+    """What the cookie tells us about the caller, without a DB hit.
+
+    `user_id` is the stable ID; email and display_name aren't signed
+    in to keep the cookie short and avoid stale display on rename.
+    `is_operator` is baked in so the middleware can make coarse
+    authz decisions (admin routes) without a DB query — fresh checks
+    still happen in route-level deps when a mutation is about to run.
+    """
+
+    user_id: str
+    is_operator: bool
 
 
 # ─── Key derivation ─────────────────────────────────────────────────────
@@ -76,21 +108,30 @@ def _hmac_key() -> bytes:
 # ─── Cookie sign/verify ─────────────────────────────────────────────────
 
 
-def _canonical(payload: dict[str, Any]) -> bytes:
+def _canonical(payload: dict[str, object]) -> bytes:
     return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
 
 
-def sign_session(*, user: str, ttl_seconds: int | None = None) -> str:
+def sign_session(
+    *, user_id: str, is_operator: bool, ttl_seconds: int | None = None
+) -> str:
     """Produce a signed session cookie value."""
     ttl = ttl_seconds if ttl_seconds is not None else DASHBOARD_SESSION_MAX_AGE_SECONDS
-    body = _canonical({"u": user, "e": int(time.time()) + ttl})
+    body = _canonical(
+        {
+            "u": user_id,
+            "o": bool(is_operator),
+            "e": int(time.time()) + ttl,
+        }
+    )
     mac = hmac.new(_hmac_key(), body, hashlib.sha256).digest()
     return base64.urlsafe_b64encode(mac + body).decode().rstrip("=")
 
 
-def verify_session(cookie: str) -> str:
-    """Decode + verify a session cookie. Returns the username. Raises
-    `InvalidSessionError` on any failure."""
+def verify_session(cookie: str) -> SessionClaims:
+    """Decode + verify a session cookie. Raises `InvalidSessionError`
+    on any failure. Does NOT touch the DB — caller should re-read the
+    User row if freshness matters."""
     if not cookie:
         raise InvalidSessionError("empty cookie")
 
@@ -110,7 +151,8 @@ def verify_session(cookie: str) -> str:
 
     try:
         payload = json.loads(body)
-        user = str(payload["u"])
+        user_id = str(payload["u"])
+        is_operator = bool(payload["o"])
         expires_at = int(payload["e"])
     except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
         raise InvalidSessionError(f"malformed body: {exc}") from exc
@@ -118,26 +160,7 @@ def verify_session(cookie: str) -> str:
     if time.time() > expires_at:
         raise InvalidSessionError("expired")
 
-    return user
-
-
-# ─── Password check ─────────────────────────────────────────────────────
-
-
-def verify_password(*, user: str, password: str) -> bool:
-    """Constant-time compare of submitted credentials against settings.
-
-    Auth is OFF when DASHBOARD_PASSWORD is unset; callers shouldn't
-    reach this function in that state. Returns False rather than
-    raising so login routes can return a uniform 401.
-    """
-    if not settings.DASHBOARD_PASSWORD:
-        return False
-    # Both branches run compare_digest so a mismatched username doesn't
-    # short-circuit faster than a wrong password (timing-leak defense).
-    user_ok = hmac.compare_digest(user, settings.DASHBOARD_USER)
-    pw_ok = hmac.compare_digest(password, settings.DASHBOARD_PASSWORD)
-    return user_ok and pw_ok
+    return SessionClaims(user_id=user_id, is_operator=is_operator)
 
 
 # ─── Middleware ─────────────────────────────────────────────────────────
@@ -148,29 +171,34 @@ def _is_public_path(path: str) -> bool:
 
 
 def _has_valid_admin_token(request: Request) -> bool:
-    """Bearer admin token acts as a skeleton key (ops use)."""
+    """Admin bearer token — automation escape hatch. Accepts either
+    `Authorization: Bearer <token>` (standard) or `X-Admin-Token:
+    <token>` (legacy header still used by the email identity CRUD)."""
     if not settings.ADMIN_API_TOKEN:
         return False
-    header = request.headers.get("authorization", "")
-    if not header.lower().startswith("bearer "):
+
+    supplied: str | None = None
+    auth_header = request.headers.get("authorization", "")
+    if auth_header.lower().startswith("bearer "):
+        supplied = auth_header.split(" ", 1)[1].strip()
+    else:
+        xadmin = request.headers.get("x-admin-token")
+        if xadmin:
+            supplied = xadmin
+
+    if not supplied:
         return False
-    supplied = header.split(" ", 1)[1].strip()
     return hmac.compare_digest(supplied, settings.ADMIN_API_TOKEN)
 
 
 class DashboardAuthMiddleware(BaseHTTPMiddleware):
-    """Gate the API behind the optional dashboard password."""
+    """Gate the API behind a logged-in user or the admin bearer token."""
 
     async def dispatch(self, request: Request, call_next):  # type: ignore[override]
-        # Auth off entirely — no password set.
-        if not settings.DASHBOARD_PASSWORD:
-            return await call_next(request)
-
         path = request.url.path
 
-        # Non-API requests (static assets served by the bundled
-        # dashboard, /docs, etc.) pass through. The dashboard itself
-        # enforces its own redirect via middleware.ts.
+        # Non-API requests (static assets, /docs, etc.) pass through.
+        # The dashboard enforces its own redirect via middleware.ts.
         if not path.startswith("/api/"):
             return await call_next(request)
 
@@ -178,12 +206,16 @@ class DashboardAuthMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 
         if _has_valid_admin_token(request):
+            # Bearer-token caller — mark the request so downstream deps
+            # can distinguish "logged-in operator" from "automation."
+            request.state.auth_admin_token = True
             return await call_next(request)
 
         cookie = request.cookies.get(DASHBOARD_SESSION_COOKIE_NAME)
         if cookie:
             try:
-                request.state.auth_user = verify_session(cookie)
+                claims = verify_session(cookie)
+                request.state.auth_claims = claims
                 return await call_next(request)
             except InvalidSessionError as exc:
                 logger.info("Rejected session cookie: %s", exc)
@@ -194,16 +226,24 @@ class DashboardAuthMiddleware(BaseHTTPMiddleware):
         )
 
 
-# ─── FastAPI dep (optional — most routes covered by middleware) ─────────
+# ─── FastAPI deps ───────────────────────────────────────────────────────
 
 
-def require_session(request: Request) -> str:
-    """Dep for routes that need the logged-in user name (not just "auth").
-
-    Routes covered by the middleware can rely on `request.state.auth_user`
-    being set. This dep is the typed accessor.
-    """
-    user = getattr(request.state, "auth_user", None)
-    if not user:
+def require_session(request: Request) -> SessionClaims:
+    """Dep for routes that need the caller's user_id. Covers cookie-auth
+    only — routes that accept the admin bearer token use `require_admin`
+    from `core/admin_auth.py` instead."""
+    claims = getattr(request.state, "auth_claims", None)
+    if not isinstance(claims, SessionClaims):
         raise HTTPException(status_code=401, detail="Authentication required.")
-    return user
+    return claims
+
+
+def require_operator_session(request: Request) -> SessionClaims:
+    """Dep for routes that require operator privileges via session auth
+    (not the admin bearer token). Admin routes typically use the looser
+    `require_admin` dep which accepts either."""
+    claims = require_session(request)
+    if not claims.is_operator:
+        raise HTTPException(status_code=403, detail="Operator privileges required.")
+    return claims

--- a/packages/python/awaithumans/server/core/bootstrap.py
+++ b/packages/python/awaithumans/server/core/bootstrap.py
@@ -1,0 +1,90 @@
+"""First-run bootstrap token.
+
+On startup, if the `users` table is empty, a random token is generated
+and logged prominently. The operator visits `/setup?token=<TOKEN>`,
+submits email + password, and becomes the first user (role=operator).
+After that, `/api/setup/*` routes always return 410 Gone — the
+bootstrap is a one-shot.
+
+Token lives only in process memory. Restarts regenerate it as long as
+no user exists yet; once setup completes, the token is cleared and
+stays cleared for the process lifetime.
+
+Why in-memory (not DB):
+- Bootstrap credentials shouldn't outlive a process crash. If the
+  operator walks away from setup, a restart gives them a fresh
+  token — no stale creds to recover.
+- Zero persistence ≠ zero operational burden: restart before setup
+  reveals the new token in the log.
+
+Why not email magic link:
+- Needs email transport configured, which is circular — email
+  identities are managed through the same admin API the operator
+  is about to set up.
+
+Concurrency:
+- Module-level `_lock` keeps the generator idempotent if two
+  startup paths call `ensure_token` concurrently. The token is
+  generated exactly once per empty-DB process.
+"""
+
+from __future__ import annotations
+
+import hmac
+import logging
+import secrets
+import threading
+
+logger = logging.getLogger("awaithumans.server.core.bootstrap")
+
+_BOOTSTRAP_TOKEN_BYTES = 32
+
+_lock = threading.Lock()
+_token: str | None = None
+_completed: bool = False
+
+
+def ensure_token() -> str:
+    """Return the current bootstrap token, generating one if needed.
+    Idempotent. Raises RuntimeError if setup has already completed."""
+    global _token
+    with _lock:
+        if _completed:
+            raise RuntimeError("Bootstrap already completed in this process.")
+        if _token is None:
+            _token = secrets.token_urlsafe(_BOOTSTRAP_TOKEN_BYTES)
+        return _token
+
+
+def verify_token(supplied: str) -> bool:
+    """Constant-time compare. Returns False if the token hasn't been
+    generated yet (setup not needed) or setup already completed."""
+    with _lock:
+        if _completed or _token is None:
+            return False
+        return hmac.compare_digest(supplied, _token)
+
+
+def mark_complete() -> None:
+    """Called after the first operator is created. Invalidates the
+    token permanently for this process."""
+    global _token, _completed
+    with _lock:
+        _completed = True
+        _token = None
+
+
+def is_active() -> bool:
+    """True when a token is live and can complete setup. False after
+    completion or before `ensure_token` runs."""
+    with _lock:
+        return _token is not None and not _completed
+
+
+def log_setup_banner(setup_url: str) -> None:
+    """Emit the first-run setup URL to the log in a visually loud
+    format. Called at startup when count_users == 0 so operators
+    can't miss it in the server output.
+    """
+    banner = "━" * 60
+    logger.warning("\n%s\nFirst-run setup:\n  → %s\n%s\n", banner, setup_url, banner)

--- a/packages/python/awaithumans/server/core/config.py
+++ b/packages/python/awaithumans/server/core/config.py
@@ -27,14 +27,10 @@ class Settings(BaseSettings):
     DB_PATH: str = ".awaithumans/dev.db"
 
     # ── Dashboard auth ────────────────────────────────────────────────
-    # If DASHBOARD_PASSWORD is unset, the dashboard has NO auth — the
-    # operator is expected to be running behind their own proxy or
-    # firewall. Setting a value turns on password auth: login page on
-    # the dashboard, HMAC-signed httponly session cookie, middleware
-    # that rejects unauthenticated API calls. HKDF-derived from
-    # PAYLOAD_KEY, so PAYLOAD_KEY must be set when auth is on.
-    DASHBOARD_USER: str = "admin"
-    DASHBOARD_PASSWORD: str | None = None
+    # Auth is always on. First-run state (empty users table) is handled
+    # by the /api/setup bootstrap flow; see server/core/bootstrap.py.
+    # All /api/* routes except the public prefix list require a valid
+    # session cookie or the admin bearer token.
 
     # ── CORS ──────────────────────────────────────────────────────────
     CORS_ORIGINS: str = "*"  # Comma-separated list, or "*" for all

--- a/packages/python/awaithumans/server/routes/auth.py
+++ b/packages/python/awaithumans/server/routes/auth.py
@@ -1,31 +1,33 @@
 """Dashboard auth routes — login, logout, session introspection.
 
-Public endpoints (auth is what these routes bootstrap):
+Public endpoints (these are what the rest of the API needs to be auth'd):
 
-    POST   /api/auth/login     { user, password }  → 204 + cookie
-    POST   /api/auth/logout                         → 204 + clear cookie
-    GET    /api/auth/me                             → { user, authenticated }
+    POST   /api/auth/login     { email, password }     → 204 + cookie
+    POST   /api/auth/logout                             → 204 + clear cookie
+    GET    /api/auth/me                                 → { authenticated, user }
 
-If `AWAITHUMANS_DASHBOARD_PASSWORD` is unset, login returns 503 —
-server is in no-auth mode, logging in would be meaningless. /me
-returns `{ authenticated: false }` so the dashboard can render a
-"no auth required" banner rather than a login page.
+No `auth_enabled: false` path anymore — auth is always on in v1. The
+dashboard uses `/api/setup/status` to distinguish first-run (show the
+`/setup` wizard) from normal (show the login form).
 """
 
 from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, HTTPException, Request, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from awaithumans.server.core.auth import (
     InvalidSessionError,
     sign_session,
-    verify_password,
     verify_session,
 )
 from awaithumans.server.core.config import settings
+from awaithumans.server.core.password import verify_password
+from awaithumans.server.db.connection import get_session
+from awaithumans.server.services.user_service import get_user, get_user_by_email
 from awaithumans.utils.constants import (
     DASHBOARD_SESSION_COOKIE_NAME,
     DASHBOARD_SESSION_MAX_AGE_SECONDS,
@@ -36,37 +38,43 @@ logger = logging.getLogger("awaithumans.server.routes.auth")
 
 
 class LoginRequest(BaseModel):
-    user: str = Field(min_length=1, max_length=100)
+    email: str = Field(min_length=1, max_length=320, description="User's email address.")
     password: str = Field(min_length=1, max_length=200)
 
 
 class MeResponse(BaseModel):
     authenticated: bool
-    user: str | None = None
-    # True when the operator has left the dashboard in no-auth mode
-    # (no DASHBOARD_PASSWORD). The dashboard shows a "running behind
-    # proxy — no password required" banner instead of a login form.
-    auth_enabled: bool
+    user_id: str | None = None
+    email: str | None = None
+    display_name: str | None = None
+    is_operator: bool = False
 
 
 @router.post("/login", status_code=status.HTTP_204_NO_CONTENT)
-async def login(body: LoginRequest, response: Response) -> Response:
-    """Verify credentials and set a signed session cookie."""
-    if not settings.DASHBOARD_PASSWORD:
-        raise HTTPException(
-            status_code=503,
-            detail=(
-                "Dashboard auth is not configured. "
-                "Set AWAITHUMANS_DASHBOARD_PASSWORD to enable login."
-            ),
-        )
+async def login(
+    body: LoginRequest,
+    response: Response,
+    session: AsyncSession = Depends(get_session),
+) -> Response:
+    """Verify credentials against the user directory and set a signed
+    session cookie.
 
-    if not verify_password(user=body.user, password=body.password):
-        # Log at info, not warning — brute-forcers will spam this.
-        logger.info("Failed login attempt for user=%s", body.user)
-        raise HTTPException(status_code=401, detail="Invalid credentials.")
+    Returns 401 for unknown email, inactive account, no password set,
+    or wrong password — uniform error so we don't leak which field
+    was wrong.
+    """
+    user = await get_user_by_email(session, body.email)
+    reject = HTTPException(status_code=401, detail="Invalid credentials.")
 
-    token = sign_session(user=body.user)
+    if user is None or not user.active or not user.password_hash:
+        logger.info("Failed login (no match / inactive / no password): %s", body.email)
+        raise reject
+
+    if not verify_password(body.password, user.password_hash):
+        logger.info("Failed login (wrong password): %s", body.email)
+        raise reject
+
+    token = sign_session(user_id=user.id, is_operator=user.is_operator)
     response.set_cookie(
         key=DASHBOARD_SESSION_COOKIE_NAME,
         value=token,
@@ -88,20 +96,33 @@ async def logout(response: Response) -> Response:
 
 
 @router.get("/me", response_model=MeResponse)
-async def me(request: Request) -> MeResponse:
-    """Session introspection. Dashboard calls this on mount to decide
-    whether to render the login page or the task queue."""
-    auth_enabled = bool(settings.DASHBOARD_PASSWORD)
-    if not auth_enabled:
-        return MeResponse(authenticated=False, auth_enabled=False)
-
+async def me(
+    request: Request,
+    session: AsyncSession = Depends(get_session),
+) -> MeResponse:
+    """Session introspection. Returns the current user record when
+    signed in, or `authenticated=false` otherwise. Dashboard mounts
+    call this to decide whether to render the queue or the login form."""
     cookie = request.cookies.get(DASHBOARD_SESSION_COOKIE_NAME)
     if not cookie:
-        return MeResponse(authenticated=False, auth_enabled=True)
+        return MeResponse(authenticated=False)
 
     try:
-        user = verify_session(cookie)
+        claims = verify_session(cookie)
     except InvalidSessionError:
-        return MeResponse(authenticated=False, auth_enabled=True)
+        return MeResponse(authenticated=False)
 
-    return MeResponse(authenticated=True, user=user, auth_enabled=True)
+    # Fresh read — if the user was deleted or deactivated, treat as
+    # logged out. The cookie's `is_operator` claim is overridden by
+    # the current DB value to keep role changes snappy.
+    user = await get_user(session, claims.user_id)
+    if user is None or not user.active:
+        return MeResponse(authenticated=False)
+
+    return MeResponse(
+        authenticated=True,
+        user_id=user.id,
+        email=user.email,
+        display_name=user.display_name,
+        is_operator=user.is_operator,
+    )

--- a/packages/python/awaithumans/server/routes/setup.py
+++ b/packages/python/awaithumans/server/routes/setup.py
@@ -1,0 +1,121 @@
+"""First-run setup routes — publicly reachable (gates itself on token).
+
+The middleware leaves `/api/setup/*` in the public prefix list so a
+brand-new server with zero users can be set up without an admin
+token. Authorization here is the single-shot in-memory bootstrap
+token (see `core/bootstrap.py`).
+
+    GET  /api/setup/status                       → is setup needed?
+    POST /api/setup/operator   { token, email,   → create first operator
+                                  password, name }
+
+`/api/setup/operator` is a one-shot — subsequent calls (even with a
+fresh token after a restart-before-completion) return 409 once any
+user exists in the DB.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from awaithumans.server.core import bootstrap
+from awaithumans.server.core.auth import sign_session
+from awaithumans.server.core.config import settings
+from awaithumans.server.db.connection import get_session
+from awaithumans.server.services.user_service import count_users, create_user
+from awaithumans.utils.constants import (
+    DASHBOARD_SESSION_COOKIE_NAME,
+    DASHBOARD_SESSION_MAX_AGE_SECONDS,
+)
+
+router = APIRouter(prefix="/setup", tags=["setup"])
+logger = logging.getLogger("awaithumans.server.routes.setup")
+
+
+class SetupStatusResponse(BaseModel):
+    """Tells the dashboard which landing page to show."""
+
+    needs_setup: bool
+    # `token_active` is true only on the server's own loopback — the
+    # actual token is never returned; operators read it from the server
+    # log. This field just lets the /setup page show a "server is
+    # ready, paste your token" state vs. "setup already done" state.
+    token_active: bool
+
+
+class CreateOperatorRequest(BaseModel):
+    token: str = Field(min_length=1)
+    email: str = Field(min_length=1, max_length=320)
+    password: str = Field(min_length=8)
+    display_name: str | None = None
+
+
+@router.get("/status", response_model=SetupStatusResponse)
+async def setup_status(
+    session: AsyncSession = Depends(get_session),
+) -> SetupStatusResponse:
+    user_count = await count_users(session)
+    return SetupStatusResponse(
+        needs_setup=user_count == 0,
+        token_active=bootstrap.is_active() and user_count == 0,
+    )
+
+
+@router.post(
+    "/operator",
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_first_operator(
+    body: CreateOperatorRequest,
+    response: Response,
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, str]:
+    """Create the first operator and issue their session in one shot.
+
+    The dashboard posts here after the operator pastes the setup token
+    and their desired credentials. On success, the response sets the
+    session cookie so the operator lands directly on the queue —
+    no redundant login step.
+    """
+    # Re-check on the DB rather than only trusting the bootstrap flag:
+    # two concurrent /setup posts could both see `_completed=False`
+    # before the row commits. The user service's unique constraints
+    # back-stop that, but this check catches the common case with a
+    # cleaner error.
+    if await count_users(session) > 0:
+        bootstrap.mark_complete()
+        raise HTTPException(
+            status_code=409,
+            detail="Setup has already been completed. Use /api/auth/login.",
+        )
+
+    if not bootstrap.verify_token(body.token):
+        logger.info("Rejected setup token (mismatch or already completed)")
+        raise HTTPException(status_code=403, detail="Invalid setup token.")
+
+    user = await create_user(
+        session,
+        email=body.email,
+        display_name=body.display_name,
+        is_operator=True,
+        password=body.password,
+    )
+    bootstrap.mark_complete()
+    logger.info("First-run setup complete: operator=%s (%s)", user.id, user.email)
+
+    # Sign them in immediately.
+    token = sign_session(user_id=user.id, is_operator=True)
+    response.set_cookie(
+        key=DASHBOARD_SESSION_COOKIE_NAME,
+        value=token,
+        max_age=DASHBOARD_SESSION_MAX_AGE_SECONDS,
+        httponly=True,
+        secure=settings.PUBLIC_URL.startswith("https://"),
+        samesite="lax",
+        path="/",
+    )
+    return {"user_id": user.id, "email": user.email or ""}

--- a/packages/python/awaithumans/server/routes/status.py
+++ b/packages/python/awaithumans/server/routes/status.py
@@ -5,7 +5,7 @@ which channels are configured, whether encryption is on, which mode of
 Slack is active. No secrets, no keys, no passwords ever leave the server.
 
 Gated by the dashboard auth middleware — probes from the public internet
-return 401 when `DASHBOARD_PASSWORD` is set.
+return 401 unless they carry a valid session cookie or admin bearer token.
 """
 
 from __future__ import annotations
@@ -28,11 +28,14 @@ def _slack_mode() -> str:
 
 @router.get("", response_model=SystemStatus)
 async def get_status() -> SystemStatus:
+    # `auth_enabled` stays in the payload (dashboard still reads it)
+    # but is always True now — we left it in place so the dashboard
+    # doesn't need redeployment just to drop a field.
     return SystemStatus(
         version="0.1.0",
         environment=settings.ENVIRONMENT,
         public_url=settings.PUBLIC_URL,
-        auth_enabled=bool(settings.DASHBOARD_PASSWORD),
+        auth_enabled=True,
         payload_encryption_enabled=bool(settings.PAYLOAD_KEY),
         admin_token_enabled=bool(settings.ADMIN_API_TOKEN),
         slack_mode=_slack_mode(),

--- a/packages/python/tests/auth/conftest.py
+++ b/packages/python/tests/auth/conftest.py
@@ -1,7 +1,13 @@
-"""Per-test installation of PAYLOAD_KEY + DASHBOARD_PASSWORD + isolated DB."""
+"""Per-test isolated SQLite + PAYLOAD_KEY + seeded operator user.
+
+After PR A3 the dashboard auth is DB-backed — every auth test needs a
+real User row to log in against. The `operator_user` fixture inserts
+one via the user service so tests look like the production path.
+"""
 
 from __future__ import annotations
 
+import asyncio
 import secrets
 import tempfile
 from collections.abc import Iterator
@@ -9,21 +15,22 @@ from pathlib import Path
 
 import pytest
 
-from awaithumans.server import db as db_module
 from awaithumans.server.core import encryption
 from awaithumans.server.core.config import settings
+from awaithumans.server.db.models import User
+
+
+# Default operator credentials used across the auth test suite.
+OPERATOR_EMAIL = "operator@example.com"
+OPERATOR_PASSWORD = "correct-horse-battery-staple"
 
 
 @pytest.fixture(autouse=True)
 def _isolated_db() -> Iterator[None]:
-    """Route every test in this module to a fresh SQLite tempfile.
-
-    Without this, the TestClient-based tests hit the project's default
-    `.awaithumans/dev.db` which may carry stale schema from earlier runs.
-    """
+    """Route every test in this module to a fresh SQLite tempfile."""
     import awaithumans.server.db.connection as conn
+    from awaithumans.server.core import bootstrap
 
-    # Snapshot
     original_db_path = settings.DB_PATH
     original_db_url = settings.DATABASE_URL
     original_engine = conn._async_engine
@@ -35,6 +42,11 @@ def _isolated_db() -> Iterator[None]:
     conn._async_engine = None
     conn._async_session_factory = None
 
+    # The bootstrap flag is module state — reset it so each test
+    # starts from "no setup token generated yet."
+    bootstrap._token = None
+    bootstrap._completed = False
+
     yield
 
     settings.DB_PATH = original_db_path
@@ -43,27 +55,48 @@ def _isolated_db() -> Iterator[None]:
     conn._async_session_factory = original_factory
 
 
-@pytest.fixture
-def auth_enabled() -> Iterator[None]:
-    """Set a valid PAYLOAD_KEY + DASHBOARD_PASSWORD for the test."""
-    original_key = settings.PAYLOAD_KEY
-    original_pw = settings.DASHBOARD_PASSWORD
-    original_user = settings.DASHBOARD_USER
+@pytest.fixture(autouse=True)
+def _payload_key() -> Iterator[None]:
+    """Every auth test needs PAYLOAD_KEY — sessions and encrypted columns
+    both derive their keys from it."""
+    original = settings.PAYLOAD_KEY
     settings.PAYLOAD_KEY = secrets.token_urlsafe(32)
-    settings.DASHBOARD_PASSWORD = "correct-horse-battery-staple"
-    settings.DASHBOARD_USER = "admin"
     encryption.reset_key_cache()
     yield
-    settings.PAYLOAD_KEY = original_key
-    settings.DASHBOARD_PASSWORD = original_pw
-    settings.DASHBOARD_USER = original_user
+    settings.PAYLOAD_KEY = original
     encryption.reset_key_cache()
 
 
 @pytest.fixture
-def auth_disabled() -> Iterator[None]:
-    """Explicit no-auth mode — DASHBOARD_PASSWORD unset."""
-    original = settings.DASHBOARD_PASSWORD
-    settings.DASHBOARD_PASSWORD = None
-    yield
-    settings.DASHBOARD_PASSWORD = original
+def operator_user() -> Iterator[User]:
+    """Insert a fresh operator into the test DB and return the row.
+
+    Runs migrations + creates the user in one short-lived loop so tests
+    can log in via `POST /api/auth/login` immediately after."""
+    from awaithumans.server.db.connection import (
+        close_db,
+        get_async_session_factory,
+        init_db,
+    )
+    from awaithumans.server.services.user_service import create_user
+
+    async def _seed() -> User:
+        await init_db()
+        factory = get_async_session_factory()
+        async with factory() as session:
+            return await create_user(
+                session,
+                email=OPERATOR_EMAIL,
+                display_name="Test Operator",
+                is_operator=True,
+                password=OPERATOR_PASSWORD,
+            )
+
+    user = asyncio.new_event_loop().run_until_complete(_seed())
+
+    yield user
+
+    async def _teardown() -> None:
+        await close_db()
+
+    asyncio.new_event_loop().run_until_complete(_teardown())

--- a/packages/python/tests/auth/test_auth_routes.py
+++ b/packages/python/tests/auth/test_auth_routes.py
@@ -1,4 +1,4 @@
-"""Auth routes + DashboardAuthMiddleware — live HTTP through FastAPI TestClient."""
+"""Auth routes + DashboardAuthMiddleware — DB-backed login via real TestClient."""
 
 from __future__ import annotations
 
@@ -8,18 +8,15 @@ import pytest
 from fastapi.testclient import TestClient
 
 from awaithumans.server.app import create_app
+from awaithumans.server.db.models import User
 from awaithumans.utils.constants import DASHBOARD_SESSION_COOKIE_NAME
 
-
-@pytest.fixture
-def client(auth_enabled) -> Iterator[TestClient]:
-    app = create_app(serve_dashboard=False)
-    with TestClient(app) as c:
-        yield c
+from .conftest import OPERATOR_EMAIL, OPERATOR_PASSWORD
 
 
 @pytest.fixture
-def no_auth_client(auth_disabled) -> Iterator[TestClient]:
+def client(operator_user: User) -> Iterator[TestClient]:
+    """App + DB migrations + seeded operator — ready to log in against."""
     app = create_app(serve_dashboard=False)
     with TestClient(app) as c:
         yield c
@@ -28,19 +25,27 @@ def no_auth_client(auth_disabled) -> Iterator[TestClient]:
 # ─── /api/auth/me ───────────────────────────────────────────────────────
 
 
-def test_me_when_auth_disabled(no_auth_client: TestClient) -> None:
-    resp = no_auth_client.get("/api/auth/me")
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data == {"authenticated": False, "user": None, "auth_enabled": False}
-
-
-def test_me_when_auth_enabled_but_not_logged_in(client: TestClient) -> None:
+def test_me_when_not_logged_in(client: TestClient) -> None:
     resp = client.get("/api/auth/me")
     assert resp.status_code == 200
-    data = resp.json()
-    assert data["auth_enabled"] is True
-    assert data["authenticated"] is False
+    body = resp.json()
+    assert body["authenticated"] is False
+
+
+def test_me_after_login_returns_user(client: TestClient, operator_user: User) -> None:
+    login = client.post(
+        "/api/auth/login",
+        json={"email": OPERATOR_EMAIL, "password": OPERATOR_PASSWORD},
+    )
+    assert login.status_code == 204
+
+    resp = client.get("/api/auth/me")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["authenticated"] is True
+    assert body["email"] == OPERATOR_EMAIL
+    assert body["user_id"] == operator_user.id
+    assert body["is_operator"] is True
 
 
 # ─── /api/auth/login ────────────────────────────────────────────────────
@@ -49,7 +54,7 @@ def test_me_when_auth_enabled_but_not_logged_in(client: TestClient) -> None:
 def test_login_success_sets_cookie(client: TestClient) -> None:
     resp = client.post(
         "/api/auth/login",
-        json={"user": "admin", "password": "correct-horse-battery-staple"},
+        json={"email": OPERATOR_EMAIL, "password": OPERATOR_PASSWORD},
     )
     assert resp.status_code == 204
     assert DASHBOARD_SESSION_COOKIE_NAME in resp.cookies
@@ -58,46 +63,32 @@ def test_login_success_sets_cookie(client: TestClient) -> None:
 def test_login_wrong_password_401(client: TestClient) -> None:
     resp = client.post(
         "/api/auth/login",
-        json={"user": "admin", "password": "wrong"},
+        json={"email": OPERATOR_EMAIL, "password": "wrong"},
     )
     assert resp.status_code == 401
     assert DASHBOARD_SESSION_COOKIE_NAME not in resp.cookies
 
 
-def test_login_wrong_user_401(client: TestClient) -> None:
+def test_login_unknown_email_401(client: TestClient) -> None:
     resp = client.post(
         "/api/auth/login",
-        json={"user": "hacker", "password": "correct-horse-battery-staple"},
+        json={"email": "nobody@example.com", "password": OPERATOR_PASSWORD},
     )
     assert resp.status_code == 401
-
-
-def test_login_when_auth_disabled_503(no_auth_client: TestClient) -> None:
-    """Login makes no sense when no password is configured."""
-    resp = no_auth_client.post(
-        "/api/auth/login",
-        json={"user": "admin", "password": "admin"},
-    )
-    assert resp.status_code == 503
 
 
 # ─── /api/auth/logout ───────────────────────────────────────────────────
 
 
 def test_logout_clears_cookie(client: TestClient) -> None:
-    # First log in.
-    login = client.post(
+    client.post(
         "/api/auth/login",
-        json={"user": "admin", "password": "correct-horse-battery-staple"},
+        json={"email": OPERATOR_EMAIL, "password": OPERATOR_PASSWORD},
     )
-    assert login.status_code == 204
-
     resp = client.post("/api/auth/logout")
     assert resp.status_code == 204
-    # Server sets a zero-age cookie to expire it — TestClient clears it.
-    # Verify /me now reports unauthenticated.
+
     me = client.get("/api/auth/me")
-    assert me.status_code == 200
     assert me.json()["authenticated"] is False
 
 
@@ -112,7 +103,7 @@ def test_protected_route_without_session_401(client: TestClient) -> None:
 def test_protected_route_with_session_200(client: TestClient) -> None:
     login = client.post(
         "/api/auth/login",
-        json={"user": "admin", "password": "correct-horse-battery-staple"},
+        json={"email": OPERATOR_EMAIL, "password": OPERATOR_PASSWORD},
     )
     assert login.status_code == 204
     resp = client.get("/api/tasks")
@@ -125,19 +116,22 @@ def test_protected_route_with_bogus_cookie_401(client: TestClient) -> None:
     assert resp.status_code == 401
 
 
-def test_health_is_public_even_when_auth_on(client: TestClient) -> None:
+def test_health_is_public(client: TestClient) -> None:
     resp = client.get("/api/health")
     assert resp.status_code == 200
 
 
-def test_auth_routes_reachable_without_cookie(client: TestClient) -> None:
-    """Login endpoint can't require a cookie — it's the bootstrap."""
-    resp = client.get("/api/auth/me")
+def test_setup_routes_are_public(client: TestClient) -> None:
+    """Even with a user in the DB, /api/setup/* routes skip the auth
+    middleware — they gate themselves."""
+    resp = client.get("/api/setup/status")
     assert resp.status_code == 200
+    # With a user already present, setup is no longer needed.
+    assert resp.json()["needs_setup"] is False
 
 
 def test_admin_token_bypasses_session(client: TestClient, monkeypatch) -> None:
-    """Bearer ADMIN_API_TOKEN is the ops skeleton key — no session needed."""
+    """Bearer ADMIN_API_TOKEN is the automation escape hatch."""
     from awaithumans.server.core.config import settings
 
     monkeypatch.setattr(settings, "ADMIN_API_TOKEN", "top-secret-ops-token")
@@ -159,7 +153,29 @@ def test_admin_token_wrong_value_401(client: TestClient, monkeypatch) -> None:
     assert resp.status_code == 401
 
 
-def test_no_auth_mode_lets_everything_through(no_auth_client: TestClient) -> None:
-    """When DASHBOARD_PASSWORD is unset the middleware is a no-op."""
-    resp = no_auth_client.get("/api/tasks")
-    assert resp.status_code == 200
+def test_inactive_user_cannot_login(client: TestClient, monkeypatch) -> None:
+    """Deactivating a user blocks new logins (existing sessions keep
+    working until expiry — tradeoff for no DB hit per request)."""
+    import asyncio
+
+    from awaithumans.server.db.connection import get_async_session_factory
+    from awaithumans.server.services.user_service import update_user
+
+    factory = get_async_session_factory()
+
+    async def _deactivate() -> None:
+        async with factory() as session:
+            # Look the user up by email and flip active=False.
+            from awaithumans.server.services.user_service import get_user_by_email
+
+            u = await get_user_by_email(session, OPERATOR_EMAIL)
+            assert u is not None
+            await update_user(session, u.id, active=False)
+
+    asyncio.get_event_loop().run_until_complete(_deactivate())
+
+    resp = client.post(
+        "/api/auth/login",
+        json={"email": OPERATOR_EMAIL, "password": OPERATOR_PASSWORD},
+    )
+    assert resp.status_code == 401

--- a/packages/python/tests/auth/test_session_tokens.py
+++ b/packages/python/tests/auth/test_session_tokens.py
@@ -1,101 +1,103 @@
-"""Session-cookie HMAC — signing, verify, tamper, expiry."""
+"""Session-cookie HMAC — signing, verify, tamper, expiry.
+
+Tests the low-level token machinery independent of DB state. The
+`_payload_key` fixture from conftest.py seeds PAYLOAD_KEY for each
+test so HMAC derivation works.
+"""
 
 from __future__ import annotations
 
 import base64
-import json
 import time
 
 import pytest
 
 from awaithumans.server.core.auth import (
     InvalidSessionError,
+    SessionClaims,
     sign_session,
-    verify_password,
     verify_session,
 )
-from awaithumans.server.core.config import settings
 from awaithumans.utils.constants import HMAC_SHA256_DIGEST_BYTES
 
 
-def test_roundtrip(auth_enabled) -> None:
-    token = sign_session(user="admin")
-    assert verify_session(token) == "admin"
+# Stable user ID to sign tokens against — matches the format new_id()
+# produces (32 hex chars). Not inserted in DB; these tests stay at the
+# cookie layer.
+USER_ID = "deadbeef" * 4
 
 
-def test_sessions_vary_by_time(auth_enabled) -> None:
-    """Two sessions minted at different times must differ (expiry is signed)."""
-    a = sign_session(user="admin")
+def test_roundtrip() -> None:
+    token = sign_session(user_id=USER_ID, is_operator=True)
+    claims = verify_session(token)
+    assert isinstance(claims, SessionClaims)
+    assert claims.user_id == USER_ID
+    assert claims.is_operator is True
+
+
+def test_operator_flag_round_trips() -> None:
+    op_token = sign_session(user_id=USER_ID, is_operator=True)
+    non_op_token = sign_session(user_id=USER_ID, is_operator=False)
+    assert verify_session(op_token).is_operator is True
+    assert verify_session(non_op_token).is_operator is False
+
+
+def test_sessions_vary_by_time() -> None:
+    a = sign_session(user_id=USER_ID, is_operator=False)
     time.sleep(1.1)  # tokens embed int(time.time()) so 1s resolution
-    b = sign_session(user="admin")
+    b = sign_session(user_id=USER_ID, is_operator=False)
     assert a != b
 
 
-def test_tampered_body_rejected(auth_enabled) -> None:
-    token = sign_session(user="admin")
+def test_tampered_body_rejected() -> None:
+    token = sign_session(user_id=USER_ID, is_operator=False)
     raw = bytearray(base64.urlsafe_b64decode(token + "=" * (-len(token) % 4)))
-    raw[-1] ^= 0x01  # flip a bit in the body
+    raw[-1] ^= 0x01
     tampered = base64.urlsafe_b64encode(bytes(raw)).decode().rstrip("=")
     with pytest.raises(InvalidSessionError):
         verify_session(tampered)
 
 
-def test_tampered_mac_rejected(auth_enabled) -> None:
-    token = sign_session(user="admin")
+def test_tampered_mac_rejected() -> None:
+    token = sign_session(user_id=USER_ID, is_operator=False)
     raw = bytearray(base64.urlsafe_b64decode(token + "=" * (-len(token) % 4)))
-    raw[0] ^= 0x01  # flip a bit in the mac
+    raw[0] ^= 0x01
     tampered = base64.urlsafe_b64encode(bytes(raw)).decode().rstrip("=")
     with pytest.raises(InvalidSessionError):
         verify_session(tampered)
 
 
-def test_expired_rejected(auth_enabled) -> None:
-    token = sign_session(user="admin", ttl_seconds=-1)
+def test_expired_rejected() -> None:
+    token = sign_session(user_id=USER_ID, is_operator=False, ttl_seconds=-1)
     with pytest.raises(InvalidSessionError, match="expired"):
         verify_session(token)
 
 
-def test_empty_rejected(auth_enabled) -> None:
+def test_empty_rejected() -> None:
     with pytest.raises(InvalidSessionError):
         verify_session("")
 
 
-def test_bad_base64_rejected(auth_enabled) -> None:
+def test_bad_base64_rejected() -> None:
     with pytest.raises(InvalidSessionError):
         verify_session("!!!not base64!!!")
 
 
-def test_too_short_rejected(auth_enabled) -> None:
+def test_too_short_rejected() -> None:
     short = base64.urlsafe_b64encode(b"x" * (HMAC_SHA256_DIGEST_BYTES - 1)).decode()
     with pytest.raises(InvalidSessionError):
         verify_session(short)
 
 
-def test_malformed_body_rejected(auth_enabled) -> None:
-    """Valid HMAC but body isn't the expected {u, e} shape."""
-    from awaithumans.server.core.auth import _hmac_key
+def test_malformed_body_rejected() -> None:
+    """Valid HMAC but body isn't the expected {u, o, e} shape."""
     import hashlib
     import hmac as hmac_mod
+
+    from awaithumans.server.core.auth import _hmac_key
 
     body = b'{"not": "our shape"}'
     mac = hmac_mod.new(_hmac_key(), body, hashlib.sha256).digest()
     token = base64.urlsafe_b64encode(mac + body).decode().rstrip("=")
     with pytest.raises(InvalidSessionError, match="malformed"):
         verify_session(token)
-
-
-def test_password_check_correct(auth_enabled) -> None:
-    assert verify_password(user="admin", password="correct-horse-battery-staple")
-
-
-def test_password_check_wrong_password(auth_enabled) -> None:
-    assert not verify_password(user="admin", password="wrong")
-
-
-def test_password_check_wrong_user(auth_enabled) -> None:
-    assert not verify_password(user="somebody-else", password="correct-horse-battery-staple")
-
-
-def test_password_check_auth_disabled(auth_disabled) -> None:
-    """When DASHBOARD_PASSWORD is unset, verify_password always rejects."""
-    assert not verify_password(user="admin", password="admin")

--- a/packages/python/tests/auth/test_setup_bootstrap.py
+++ b/packages/python/tests/auth/test_setup_bootstrap.py
@@ -1,0 +1,151 @@
+"""First-run /setup bootstrap — token flow + one-shot semantics."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from awaithumans.server.app import create_app
+from awaithumans.server.core import bootstrap
+from awaithumans.utils.constants import DASHBOARD_SESSION_COOKIE_NAME
+
+
+@pytest_asyncio.fixture
+async def blank_client() -> AsyncGenerator[AsyncClient, None]:
+    """App with a fresh empty DB — no operator seeded.
+
+    `_isolated_db` + `_payload_key` autouse fixtures from conftest.py
+    handle DB + crypto setup.
+    """
+    app = create_app(serve_dashboard=False)
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport, base_url="http://testserver", follow_redirects=False
+        ) as c:
+            yield c
+
+
+@pytest.mark.asyncio
+async def test_status_reports_needs_setup_on_empty_db(
+    blank_client: AsyncClient,
+) -> None:
+    resp = await blank_client.get("/api/setup/status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["needs_setup"] is True
+    assert body["token_active"] is True
+
+
+@pytest.mark.asyncio
+async def test_status_reports_complete_once_user_exists(
+    blank_client: AsyncClient,
+) -> None:
+    """Bootstrap a user via the /setup flow itself, then re-check
+    status — should flip to needs_setup=false."""
+    token = bootstrap.ensure_token()
+    r = await blank_client.post(
+        "/api/setup/operator",
+        json={
+            "token": token,
+            "email": "op@example.com",
+            "password": "hunter2a",
+            "display_name": "Op",
+        },
+    )
+    assert r.status_code == 201
+
+    resp = await blank_client.get("/api/setup/status")
+    assert resp.json()["needs_setup"] is False
+
+
+@pytest.mark.asyncio
+async def test_create_first_operator_requires_token(
+    blank_client: AsyncClient,
+) -> None:
+    bootstrap.ensure_token()  # active token in memory
+    resp = await blank_client.post(
+        "/api/setup/operator",
+        json={
+            "token": "definitely-not-the-right-token",
+            "email": "op@example.com",
+            "password": "hunter2a",
+        },
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_create_first_operator_issues_session(
+    blank_client: AsyncClient,
+) -> None:
+    """Successful bootstrap logs the operator in immediately — no
+    redundant login step."""
+    token = bootstrap.ensure_token()
+    resp = await blank_client.post(
+        "/api/setup/operator",
+        json={
+            "token": token,
+            "email": "op@example.com",
+            "password": "hunter2a",
+        },
+    )
+    assert resp.status_code == 201
+    assert DASHBOARD_SESSION_COOKIE_NAME in resp.cookies
+
+
+@pytest.mark.asyncio
+async def test_second_bootstrap_attempt_409s(blank_client: AsyncClient) -> None:
+    """One-shot: after the first operator exists, the endpoint 409s
+    regardless of whether the caller still has a valid token."""
+    token = bootstrap.ensure_token()
+    r1 = await blank_client.post(
+        "/api/setup/operator",
+        json={"token": token, "email": "op1@example.com", "password": "hunter2a"},
+    )
+    assert r1.status_code == 201
+
+    r2 = await blank_client.post(
+        "/api/setup/operator",
+        json={"token": token, "email": "op2@example.com", "password": "hunter2b"},
+    )
+    assert r2.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_setup_routes_bypass_auth_middleware(
+    blank_client: AsyncClient,
+) -> None:
+    """No session cookie, no admin token → still reaches /setup/*
+    (that's the whole point — it's the bootstrap)."""
+    resp = await blank_client.get("/api/setup/status")
+    assert resp.status_code == 200
+
+
+def test_bootstrap_module_is_idempotent() -> None:
+    """`ensure_token` called twice returns the same token until
+    `mark_complete` runs."""
+    import awaithumans.server.core.bootstrap as b
+
+    b._token = None
+    b._completed = False
+    t1 = b.ensure_token()
+    t2 = b.ensure_token()
+    assert t1 == t2
+
+    b.mark_complete()
+    assert not b.is_active()
+
+
+def test_bootstrap_verify_rejects_after_complete() -> None:
+    import awaithumans.server.core.bootstrap as b
+
+    b._token = None
+    b._completed = False
+    t = b.ensure_token()
+    assert b.verify_token(t) is True
+    b.mark_complete()
+    assert b.verify_token(t) is False

--- a/packages/python/tests/auth/test_status_and_installations.py
+++ b/packages/python/tests/auth/test_status_and_installations.py
@@ -13,13 +13,15 @@ from awaithumans.server.services.slack_installation_service import upsert_instal
 
 
 @pytest.fixture
-def client(auth_enabled) -> Iterator[TestClient]:
+def client(operator_user) -> Iterator[TestClient]:
+    from .conftest import OPERATOR_EMAIL, OPERATOR_PASSWORD
+
     app = create_app(serve_dashboard=False)
     with TestClient(app) as c:
         # Log in once so subsequent calls ride the cookie.
         c.post(
             "/api/auth/login",
-            json={"user": "admin", "password": "correct-horse-battery-staple"},
+            json={"email": OPERATOR_EMAIL, "password": OPERATOR_PASSWORD},
         )
         yield c
 
@@ -63,7 +65,7 @@ def test_status_never_leaks_secrets(client: TestClient) -> None:
         assert forbidden not in body, f"/status leaked {forbidden}"
 
 
-def test_status_auth_required(auth_enabled) -> None:
+def test_status_auth_required(operator_user) -> None:
     """Without a session, /status returns 401 (middleware gate)."""
     app = create_app(serve_dashboard=False)
     with TestClient(app) as c:
@@ -103,7 +105,7 @@ def test_status_slack_mode_off_when_unconfigured(client: TestClient, monkeypatch
 
 @pytest.mark.asyncio
 async def test_list_installations_returns_public_shape(
-    client: TestClient, auth_enabled
+    client: TestClient, operator_user
 ) -> None:
     """Seed one installation directly and verify bot_token is never in the response."""
     # Use a fresh session to write the fixture — the TestClient's session
@@ -134,7 +136,7 @@ async def test_list_installations_returns_public_shape(
     assert "xoxb" not in resp.text
 
 
-def test_list_installations_requires_auth(auth_enabled) -> None:
+def test_list_installations_requires_auth(operator_user) -> None:
     app = create_app(serve_dashboard=False)
     with TestClient(app) as c:
         resp = c.get("/api/channels/slack/installations")
@@ -142,7 +144,7 @@ def test_list_installations_requires_auth(auth_enabled) -> None:
 
 
 @pytest.mark.asyncio
-async def test_uninstall_removes_row(client: TestClient, auth_enabled) -> None:
+async def test_uninstall_removes_row(client: TestClient, operator_user) -> None:
     from awaithumans.server.db.connection import get_async_session_factory
 
     factory = get_async_session_factory()

--- a/packages/python/tests/email/test_admin_and_action_routes.py
+++ b/packages/python/tests/email/test_admin_and_action_routes.py
@@ -67,8 +67,12 @@ async def client() -> AsyncGenerator[AsyncClient, None]:
 
 @pytest.mark.asyncio
 async def test_admin_endpoint_rejects_missing_token(client: AsyncClient) -> None:
+    """No session, no admin token → middleware 401. Post-A3 the same
+    401 covers both "not logged in" and "wrong admin token" — admin is
+    reachable either by session (operator) or bearer, but not both
+    missing."""
     resp = await client.get("/api/channels/email/identities")
-    assert resp.status_code == 403
+    assert resp.status_code == 401
 
 
 @pytest.mark.asyncio
@@ -77,11 +81,15 @@ async def test_admin_endpoint_rejects_wrong_token(client: AsyncClient) -> None:
         "/api/channels/email/identities",
         headers={"X-Admin-Token": "nope"},
     )
-    assert resp.status_code == 403
+    assert resp.status_code == 401
 
 
 @pytest.mark.asyncio
-async def test_admin_endpoint_503_when_token_unset(client: AsyncClient) -> None:
+async def test_admin_endpoint_401_when_token_unset(client: AsyncClient) -> None:
+    """When ADMIN_API_TOKEN is unset, the admin bearer path is off —
+    but operator-session auth remains. An anonymous caller still gets
+    401 (middleware), not 503 (the old "feature-disabled" semantics
+    disappear since operators can always reach admin via login)."""
     orig = settings.ADMIN_API_TOKEN
     settings.ADMIN_API_TOKEN = None
     try:
@@ -89,7 +97,7 @@ async def test_admin_endpoint_503_when_token_unset(client: AsyncClient) -> None:
             "/api/channels/email/identities",
             headers={"X-Admin-Token": "anything"},
         )
-        assert resp.status_code == 503
+        assert resp.status_code == 401
     finally:
         settings.ADMIN_API_TOKEN = orig
 

--- a/packages/python/tests/users/test_admin_routes.py
+++ b/packages/python/tests/users/test_admin_routes.py
@@ -28,8 +28,15 @@ AUTH = {"X-Admin-Token": ADMIN_TOKEN}
 
 @pytest_asyncio.fixture
 async def client() -> AsyncGenerator[AsyncClient, None]:
-    orig = settings.ADMIN_API_TOKEN
+    import secrets
+
+    from awaithumans.server.core import encryption
+
+    orig_admin = settings.ADMIN_API_TOKEN
+    orig_key = settings.PAYLOAD_KEY
     settings.ADMIN_API_TOKEN = ADMIN_TOKEN
+    settings.PAYLOAD_KEY = secrets.token_urlsafe(32)
+    encryption.reset_key_cache()
 
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
@@ -50,7 +57,9 @@ async def client() -> AsyncGenerator[AsyncClient, None]:
         yield c
 
     await engine.dispose()
-    settings.ADMIN_API_TOKEN = orig
+    settings.ADMIN_API_TOKEN = orig_admin
+    settings.PAYLOAD_KEY = orig_key
+    encryption.reset_key_cache()
 
 
 # ─── Auth gate ─────────────────────────────────────────────────────────
@@ -58,8 +67,9 @@ async def client() -> AsyncGenerator[AsyncClient, None]:
 
 @pytest.mark.asyncio
 async def test_list_requires_admin_token(client: AsyncClient) -> None:
+    """No session and no admin token → middleware 401."""
     resp = await client.get("/api/admin/users")
-    assert resp.status_code == 403
+    assert resp.status_code == 401
 
 
 @pytest.mark.asyncio
@@ -67,7 +77,7 @@ async def test_wrong_token_rejected(client: AsyncClient) -> None:
     resp = await client.get(
         "/api/admin/users", headers={"X-Admin-Token": "nope"}
     )
-    assert resp.status_code == 403
+    assert resp.status_code == 401
 
 
 # ─── Create ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Replaces the single-operator `AWAITHUMANS_DASHBOARD_PASSWORD` env var with per-user dashboard login backed by the User table. First-run is handled by a one-shot bootstrap token printed to the server log, with a CLI escape hatch for headless installs.

Clean break — no backward-compat with the old env-var path.

## Session model

Cookies carry `{u: user_id, o: is_operator, e: expiry}`. Two-step validation: middleware verifies HMAC + expiry (no DB hit) and stashes claims on `request.state`; route-level deps look up the fresh user when freshness matters (role changes, deactivation).

Admin bearer tokens (`X-Admin-Token` / `Authorization: Bearer`) still work as the automation escape hatch.

## Bootstrap flow

- `core/bootstrap.py` — in-memory single-use token. Generated on startup iff `count_users == 0`. Lifespan hook logs a loud banner with the setup URL. Tokens don't persist across restarts.
- `GET /api/setup/status` — `needs_setup`, `token_active`
- `POST /api/setup/operator` — creates first operator, invalidates token, signs them in
- One-shot: 409s once any user exists, even with a valid token
- CLI: `awaithumans bootstrap-operator --email --password` for headless installs

## Login

  - `POST /api/auth/login { email, password }` → session cookie
  - `POST /api/auth/logout` → clear cookie
  - `GET /api/auth/me` → full user record (fresh from DB, overrides cookie's is_operator claim)

Uniform 401 for unknown email / inactive / no password / wrong password — no oracle for "does this email exist."

## Admin API gate (`require_admin`)

Accepts either operator session OR admin bearer token. Old 503 "admin disabled" path gone — operators can always reach admin via login.

## Dashboard

- `/login` — posts `{email, password}`; redirects to `/setup` when server has no users
- `/setup` — new first-run wizard. Token pre-filled from `?token=...` (matches server log banner URL). Creates operator + signs them in; lands on `/`.
- `AuthGuard` — routes unauthenticated users to `/setup` when needed, `/login` otherwise

## Public prefix additions

- `/api/setup/*` — bootstrap flow (gates itself on token)
- `/api/channels/slack/interactions` + `/events` — HMAC sig auth, not session

Slack's request-signing replaces session auth for its webhooks. Previously gated by the middleware which broke tests and would've broken Slack entirely once the env-var password was removed.

## Dev-mode PAYLOAD_KEY

`awaithumans dev` now auto-generates `<db dir>/payload.key` (0600) when `AWAITHUMANS_PAYLOAD_KEY` is unset, so zero-config `awaithumans dev` still works post-env-var-removal. Production must set the env var explicitly.

## Env var removal

Dropped: `AWAITHUMANS_DASHBOARD_USER`, `AWAITHUMANS_DASHBOARD_PASSWORD`. `PAYLOAD_KEY` is now always required.

## Test plan

- [x] 8 setup/bootstrap tests (needs_setup, token-active, one-shot, token mismatch, session issued on create)
- [x] 11 session-token tests (sign/verify, operator flag roundtrip, tamper detection, expiry, malformed body)
- [x] 15 auth-route + middleware tests (login success/wrong-password/unknown-email, logout, session-gated routes, admin token bypass, inactive user can't log in, setup routes are public)
- [x] Updated email + users admin route tests (403→401 for middleware-rejected cases, 503→401 for "admin disabled" removal)
- [x] Full suite: **271 passing** (234 → 271, +37 across A2+A3)
- [x] CLI smoke: bootstrap-operator creates + refuses second, list-users shows operator, PAYLOAD_KEY auto-generated in dev mode
- [x] Dashboard typechecks cleanly

## Next PRs

- **A4** — task router (Option C: least-recently-assigned, transactional)
- **A5** — dashboard Settings UI for users
- **B** — Slack broadcast + workspace member picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)