### PR TITLE
feat(slack): broadcast-to-channel claim + workspace member picker (PR B)

### DIFF
--- a/packages/dashboard/components/settings/user-form.tsx
+++ b/packages/dashboard/components/settings/user-form.tsx
@@ -1,12 +1,16 @@
 "use client";
 
 import { X } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Eyebrow } from "@/components/eyebrow";
 import {
 	createUser,
+	fetchSlackInstallations,
+	fetchSlackWorkspaceMembers,
 	type CreateUserRequest,
+	type SlackInstallation,
+	type SlackMember,
 	type User,
 	updateUser,
 } from "@/lib/server";
@@ -40,6 +44,39 @@ export function UserForm({
 	const [email, setEmail] = useState(editing?.email ?? "");
 	const [slackTeamId, setSlackTeamId] = useState(editing?.slack_team_id ?? "");
 	const [slackUserId, setSlackUserId] = useState(editing?.slack_user_id ?? "");
+
+	// Slack workspace picker — loaded lazily on mount; silently disabled
+	// if no workspaces are installed.
+	const [installations, setInstallations] = useState<SlackInstallation[]>([]);
+	const [members, setMembers] = useState<SlackMember[] | null>(null);
+	const [loadingMembers, setLoadingMembers] = useState(false);
+	const [memberLoadError, setMemberLoadError] = useState<string | null>(null);
+
+	useEffect(() => {
+		fetchSlackInstallations()
+			.then(setInstallations)
+			.catch(() => setInstallations([]));
+	}, []);
+
+	// When the operator picks a team from the dropdown, fetch its
+	// members so the user ID field becomes a combobox of real people
+	// rather than a free-text paste box.
+	useEffect(() => {
+		if (!slackTeamId || !installations.some((i) => i.team_id === slackTeamId)) {
+			setMembers(null);
+			return;
+		}
+		setLoadingMembers(true);
+		setMemberLoadError(null);
+		fetchSlackWorkspaceMembers(slackTeamId)
+			.then(setMembers)
+			.catch((err: unknown) =>
+				setMemberLoadError(
+					err instanceof Error ? err.message : "Failed to load members",
+				),
+			)
+			.finally(() => setLoadingMembers(false));
+	}, [slackTeamId, installations]);
 	const [role, setRole] = useState(editing?.role ?? "");
 	const [accessLevel, setAccessLevel] = useState(editing?.access_level ?? "");
 	const [pool, setPool] = useState(editing?.pool ?? "");
@@ -139,24 +176,77 @@ export function UserForm({
 				</Field>
 
 				<Field
-					label="Slack team ID"
-					hint="Slack user IDs are workspace-scoped. Set the pair together."
+					label="Slack workspace"
+					hint={
+						installations.length === 0
+							? "No Slack workspaces installed. Add one from Settings → Slack."
+							: "Pick a workspace the app is installed in, or paste a team ID manually."
+					}
 				>
-					<input
-						value={slackTeamId}
-						onChange={(e) => setSlackTeamId(e.target.value)}
-						className={cn(inputClass, "font-mono")}
-						placeholder="T01ABC234"
-					/>
+					{installations.length > 0 ? (
+						<select
+							value={slackTeamId}
+							onChange={(e) => {
+								setSlackTeamId(e.target.value);
+								// Clear the user ID when workspace changes — IDs
+								// are team-scoped so the previous U… wouldn't resolve.
+								setSlackUserId("");
+							}}
+							className={inputClass}
+						>
+							<option value="">—</option>
+							{installations.map((i) => (
+								<option key={i.team_id} value={i.team_id}>
+									{i.team_name || i.team_id}
+								</option>
+							))}
+						</select>
+					) : (
+						<input
+							value={slackTeamId}
+							onChange={(e) => setSlackTeamId(e.target.value)}
+							className={cn(inputClass, "font-mono")}
+							placeholder="T01ABC234"
+						/>
+					)}
 				</Field>
 
-				<Field label="Slack user ID">
-					<input
-						value={slackUserId}
-						onChange={(e) => setSlackUserId(e.target.value)}
-						className={cn(inputClass, "font-mono")}
-						placeholder="U01XYZ789"
-					/>
+				<Field
+					label="Slack member"
+					hint={
+						memberLoadError
+							? memberLoadError
+							: loadingMembers
+								? "Loading members…"
+								: members && members.length === 0
+									? "No members found."
+									: "Pick from the workspace, or paste a user ID."
+					}
+				>
+					{members && members.length > 0 ? (
+						<select
+							value={slackUserId}
+							onChange={(e) => setSlackUserId(e.target.value)}
+							className={inputClass}
+						>
+							<option value="">—</option>
+							{members.map((m) => (
+								<option key={m.id} value={m.id}>
+									{m.real_name
+										? `${m.real_name} (@${m.name})`
+										: `@${m.name}`}
+								</option>
+							))}
+						</select>
+					) : (
+						<input
+							value={slackUserId}
+							onChange={(e) => setSlackUserId(e.target.value)}
+							className={cn(inputClass, "font-mono")}
+							placeholder="U01XYZ789"
+							disabled={loadingMembers}
+						/>
+					)}
 				</Field>
 
 				<Field

--- a/packages/dashboard/lib/server/index.ts
+++ b/packages/dashboard/lib/server/index.ts
@@ -35,8 +35,10 @@ export {
 export { fetchHealth } from "./health";
 export {
 	fetchSlackInstallations,
+	fetchSlackWorkspaceMembers,
 	uninstallSlackWorkspace,
 	type SlackInstallation,
+	type SlackMember,
 } from "./slack";
 export {
 	fetchTaskStats,

--- a/packages/dashboard/lib/server/slack.ts
+++ b/packages/dashboard/lib/server/slack.ts
@@ -25,3 +25,24 @@ export async function uninstallSlackWorkspace(teamId: string): Promise<void> {
 		{ method: "DELETE" },
 	);
 }
+
+export interface SlackMember {
+	id: string;
+	name: string;
+	real_name: string | null;
+	display_name: string | null;
+	is_admin: boolean;
+}
+
+/**
+ * Fetch active, human members of a Slack workspace. Powers the "pick a
+ * Slack member" dropdown in the user-form — operators don't have to
+ * remember or paste U... IDs.
+ */
+export async function fetchSlackWorkspaceMembers(
+	teamId: string,
+): Promise<SlackMember[]> {
+	return apiFetch<SlackMember[]>(
+		`/api/channels/slack/installations/${encodeURIComponent(teamId)}/members`,
+	);
+}

--- a/packages/python/awaithumans/server/channels/slack/blocks/__init__.py
+++ b/packages/python/awaithumans/server/channels/slack/blocks/__init__.py
@@ -11,12 +11,14 @@ from __future__ import annotations
 
 from awaithumans.server.channels.slack.blocks.helpers import UnrenderableInSlackError
 from awaithumans.server.channels.slack.blocks.surfaces import (
+    claimed_message_blocks,
     form_to_modal,
     open_review_message_blocks,
 )
 
 __all__ = [
     "UnrenderableInSlackError",
+    "claimed_message_blocks",
     "form_to_modal",
     "open_review_message_blocks",
 ]

--- a/packages/python/awaithumans/server/channels/slack/blocks/surfaces.py
+++ b/packages/python/awaithumans/server/channels/slack/blocks/surfaces.py
@@ -124,12 +124,20 @@ def open_review_message_blocks(
     review_url: str,
     open_button_action_id: str,
     unsupported_fields: list[str] | None = None,
+    broadcast: bool = False,
+    claim_button_action_id: str | None = None,
 ) -> list[dict[str, Any]]:
     """Initial message posted to a channel/user when a task is created.
 
     Always includes a "Review in dashboard" link-out. If the form is
     fully Slack-renderable, also includes an "Open in Slack" button
     that triggers the interactivity webhook to open a modal.
+
+    When `broadcast=True` (notify targets a channel, not a DM), adds a
+    "Claim this task" button as the primary call-to-action. The claim
+    handler atomically assigns the task to the clicker and opens the
+    modal for them. Later clickers get an ephemeral "already claimed"
+    response — see routes/slack/interactions.py.
     """
     text = f"*New task to review:* {truncate(task_title, _MESSAGE_TITLE_MAX)}"
     if unsupported_fields:
@@ -139,7 +147,19 @@ def open_review_message_blocks(
         )
 
     elements: list[dict[str, Any]] = []
-    if not unsupported_fields:
+    if broadcast and claim_button_action_id:
+        # Broadcast: claim is the primary action. We skip the separate
+        # "Open in Slack" button — clicking claim both assigns AND
+        # opens the modal in one step (modal flow is downstream of the
+        # atomic claim).
+        elements.append({
+            "type": "button",
+            "text": {"type": "plain_text", "text": "Claim this task"},
+            "style": "primary",
+            "action_id": claim_button_action_id,
+            "value": task_id,
+        })
+    elif not unsupported_fields:
         elements.append({
             "type": "button",
             "text": {"type": "plain_text", "text": "Open in Slack"},
@@ -157,6 +177,35 @@ def open_review_message_blocks(
     return [
         {"type": "section", "text": {"type": "mrkdwn", "text": text}},
         {"type": "actions", "elements": elements},
+    ]
+
+
+def claimed_message_blocks(
+    *,
+    task_title: str,
+    review_url: str,
+    claimed_by_display: str,
+) -> list[dict[str, Any]]:
+    """Replacement blocks posted via chat.update after a successful
+    claim. Shows who claimed the task and keeps a dashboard link for
+    observers."""
+    text = (
+        f"*Claimed by {claimed_by_display}:* "
+        f"{truncate(task_title, _MESSAGE_TITLE_MAX)}"
+    )
+    return [
+        {"type": "section", "text": {"type": "mrkdwn", "text": text}},
+        {
+            "type": "actions",
+            "elements": [
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "View in dashboard"},
+                    "url": review_url,
+                    "action_id": "awaithumans.open_dashboard",
+                }
+            ],
+        },
     ]
 
 

--- a/packages/python/awaithumans/server/channels/slack/notifier.py
+++ b/packages/python/awaithumans/server/channels/slack/notifier.py
@@ -25,7 +25,10 @@ from awaithumans.server.channels.slack.client import (
 )
 from awaithumans.server.core.config import settings
 from awaithumans.server.db.connection import get_async_session_factory
-from awaithumans.utils.constants import SLACK_ACTION_OPEN_REVIEW
+from awaithumans.utils.constants import (
+    SLACK_ACTION_CLAIM_TASK,
+    SLACK_ACTION_OPEN_REVIEW,
+)
 
 if TYPE_CHECKING:  # pragma: no cover
     from slack_sdk.web.async_client import AsyncWebClient
@@ -49,19 +52,28 @@ async def notify_task(
     form = _parse_form(form_definition)
     review_url = f"{settings.PUBLIC_URL.rstrip('/')}/tasks/{task_id}"
     offenders = unsupported_fields(form, "slack") if form is not None else None
-
-    blocks = open_review_message_blocks(
-        task_id=task_id,
-        task_title=task_title,
-        review_url=review_url,
-        open_button_action_id=SLACK_ACTION_OPEN_REVIEW,
-        unsupported_fields=offenders if offenders else None,
-    )
     fallback_text = f"New task: {task_title}"
 
     factory = get_async_session_factory()
     async with factory() as session:
         for route in routes:
+            # Broadcast: route target starts with `#` → posting to a
+            # channel where anyone could pick it up. Swap the "Open in
+            # Slack" button for "Claim this task" — first clicker wins.
+            # DM targets (`@user` / `U123456`) stay on the direct-open
+            # flow since the recipient is already implied.
+            broadcast = _is_channel_target(route.target)
+
+            blocks = open_review_message_blocks(
+                task_id=task_id,
+                task_title=task_title,
+                review_url=review_url,
+                open_button_action_id=SLACK_ACTION_OPEN_REVIEW,
+                unsupported_fields=offenders if offenders else None,
+                broadcast=broadcast,
+                claim_button_action_id=SLACK_ACTION_CLAIM_TASK,
+            )
+
             client = await _resolve_client(session, route)
             if client is None:
                 logger.warning(
@@ -77,10 +89,11 @@ async def notify_task(
                     blocks=blocks,
                 )
                 logger.info(
-                    "Slack notification sent for task %s → %s%s",
+                    "Slack notification sent for task %s → %s%s%s",
                     task_id,
                     route.target,
                     f" (team={route.identity})" if route.identity else "",
+                    " [broadcast]" if broadcast else "",
                 )
             except Exception as exc:  # noqa: BLE001
                 logger.error(
@@ -89,6 +102,23 @@ async def notify_task(
                     route.target,
                     exc,
                 )
+
+
+def _is_channel_target(target: str) -> bool:
+    """`#channel` names are broadcasts; `@user` and raw user IDs are DMs.
+
+    Slack uses `#` as the channel sigil across chat and the API. Raw
+    channel IDs (`C01ABC234`) are also broadcasts; we detect those
+    conservatively by checking the first char — `C` (public/private
+    channel) or `G` (group DM). User IDs start with `U` or `W`.
+    """
+    if not target:
+        return False
+    if target.startswith("#"):
+        return True
+    if target.startswith(("C", "G")):
+        return True
+    return False
 
 
 async def _resolve_client(

--- a/packages/python/awaithumans/server/routes/slack/installations.py
+++ b/packages/python/awaithumans/server/routes/slack/installations.py
@@ -1,4 +1,4 @@
-"""Slack installations CRUD — list + uninstall.
+"""Slack installations CRUD — list + uninstall + workspace members.
 
 Public shape never includes `bot_token` (encrypted, stays server-side).
 Dashboard Settings page lists these and offers per-row uninstall.
@@ -10,8 +10,10 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Path
 from fastapi.responses import Response
+from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from awaithumans.server.channels.slack.client import get_client_for_team
 from awaithumans.server.db.connection import get_session
 from awaithumans.server.schemas.slack import SlackInstallationResponse
 from awaithumans.server.services.slack_installation_service import (
@@ -21,6 +23,19 @@ from awaithumans.server.services.slack_installation_service import (
 
 router = APIRouter()
 logger = logging.getLogger("awaithumans.server.routes.slack.installations")
+
+
+class SlackMemberResponse(BaseModel):
+    """A member of a Slack workspace — enough to render a picker.
+
+    We deliberately don't forward the full Slack profile; dashboard
+    only needs enough to label the row and record the stable ID."""
+
+    id: str            # Slack user ID (U… / W…)
+    name: str          # @handle ("alice")
+    real_name: str | None
+    display_name: str | None
+    is_admin: bool
 
 
 def _to_public(row) -> SlackInstallationResponse:
@@ -60,3 +75,69 @@ async def uninstall_slack_workspace(
         raise HTTPException(status_code=404, detail="Installation not found.")
     logger.info("Uninstalled Slack workspace team_id=%s", team_id)
     return Response(status_code=204)
+
+
+@router.get(
+    "/installations/{team_id}/members",
+    response_model=list[SlackMemberResponse],
+)
+async def list_workspace_members(
+    team_id: str = Path(..., min_length=1, max_length=50),
+    session: AsyncSession = Depends(get_session),
+) -> list[SlackMemberResponse]:
+    """List non-bot, active members of a Slack workspace.
+
+    Powers the dashboard's "pick a Slack member" picker when adding a
+    user to the directory. Calls Slack's `users.list` via the stored
+    bot token — requires `users:read` scope on the installation.
+
+    Returns 404 if we don't have an installation for the team. 502 if
+    Slack rejects the API call (missing scope, token revoked) —
+    operator needs to reinstall. Bots, deactivated accounts, and the
+    Slackbot pseudo-user are filtered out so the picker only shows
+    humans the operator can actually assign tasks to.
+    """
+    client = await get_client_for_team(session, team_id)
+    if client is None:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"No Slack installation for team '{team_id}'. "
+                "Install the awaithumans app to this workspace first."
+            ),
+        )
+
+    try:
+        resp = await client.users_list()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "Slack users.list failed for team_id=%s: %s", team_id, exc
+        )
+        raise HTTPException(
+            status_code=502,
+            detail=(
+                "Slack rejected users.list. The installation may be "
+                "missing the 'users:read' scope, or the token was "
+                "revoked. Reinstall the workspace from Settings → Slack."
+            ),
+        ) from exc
+
+    out: list[SlackMemberResponse] = []
+    for m in resp.data.get("members", []):  # type: ignore[attr-defined]
+        if m.get("deleted") or m.get("is_bot") or m.get("id") == "USLACKBOT":
+            continue
+        profile = m.get("profile") or {}
+        out.append(
+            SlackMemberResponse(
+                id=m["id"],
+                name=m.get("name") or "",
+                real_name=profile.get("real_name") or m.get("real_name"),
+                display_name=profile.get("display_name") or None,
+                is_admin=bool(m.get("is_admin") or m.get("is_owner")),
+            )
+        )
+
+    # Stable sort — real_name, falling back to handle. Keeps the UI
+    # order predictable across refetches.
+    out.sort(key=lambda u: (u.real_name or u.name or u.id).lower())
+    return out

--- a/packages/python/awaithumans/server/routes/slack/interactions.py
+++ b/packages/python/awaithumans/server/routes/slack/interactions.py
@@ -26,6 +26,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from awaithumans.forms import FormDefinition
 from awaithumans.server.channels.slack.blocks import (
     UnrenderableInSlackError,
+    claimed_message_blocks,
     form_to_modal,
 )
 from awaithumans.server.channels.slack.client import get_client_for_team
@@ -33,8 +34,20 @@ from awaithumans.server.channels.slack.coerce import slack_values_to_response
 from awaithumans.server.channels.slack.signing import verify_signature
 from awaithumans.server.core.config import settings
 from awaithumans.server.db.connection import get_session
-from awaithumans.server.services.task_service import complete_task, get_task
-from awaithumans.utils.constants import SLACK_ACTION_OPEN_REVIEW
+from awaithumans.server.services.exceptions import (
+    TaskAlreadyClaimedError,
+    TaskAlreadyTerminalError,
+)
+from awaithumans.server.services.task_service import (
+    claim_task,
+    complete_task,
+    get_task,
+)
+from awaithumans.server.services.user_service import get_user, get_user_by_slack
+from awaithumans.utils.constants import (
+    SLACK_ACTION_CLAIM_TASK,
+    SLACK_ACTION_OPEN_REVIEW,
+)
 
 router = APIRouter()
 logger = logging.getLogger("awaithumans.server.routes.slack.interactions")
@@ -87,6 +100,19 @@ async def _handle_block_actions(
     session: AsyncSession,
 ) -> None:
     actions = payload.get("actions") or []
+
+    # Claim-first path: broadcast-to-channel messages show a "Claim"
+    # button. First clicker wins atomically, then the modal opens for
+    # them. Claim has priority over open-review so a broadcast message
+    # with both buttons is disambiguated.
+    claim_action = next(
+        (a for a in actions if a.get("action_id") == SLACK_ACTION_CLAIM_TASK),
+        None,
+    )
+    if claim_action:
+        await _handle_claim(payload, claim_action, session)
+        return
+
     open_action = next(
         (a for a in actions if a.get("action_id") == SLACK_ACTION_OPEN_REVIEW),
         None,
@@ -101,6 +127,26 @@ async def _handle_block_actions(
         logger.warning("block_actions: missing task_id or trigger_id.")
         return
 
+    await _open_modal_for_task(
+        session=session,
+        task_id=task_id,
+        trigger_id=trigger_id,
+        team_id=team_id,
+    )
+
+
+async def _open_modal_for_task(
+    *,
+    session: AsyncSession,
+    task_id: str,
+    trigger_id: str,
+    team_id: str | None,
+) -> None:
+    """Load the task, build the modal, open it via `views.open`.
+
+    Shared between the direct "Open in Slack" button (DM flow) and the
+    post-claim modal pop (channel broadcast flow).
+    """
     task = await get_task(session, task_id)
     if task.form_definition is None:
         logger.warning("Task %s has no form_definition; cannot open modal.", task_id)
@@ -128,6 +174,175 @@ async def _handle_block_actions(
         return
 
     await client.views_open(trigger_id=trigger_id, view=view)
+
+
+async def _handle_claim(
+    payload: dict[str, Any],
+    action: dict[str, Any],
+    session: AsyncSession,
+) -> None:
+    """Handle a "Claim this task" click from a broadcast channel message.
+
+    Flow:
+      1. Resolve the Slack user to a directory user (by team_id + slack_user_id).
+         Users who aren't in the directory get an ephemeral "ask your operator
+         to add you" reply — enforces directory hygiene so claims correlate
+         cleanly with the routing model.
+      2. Atomic claim on the task — first click wins. Second click gets an
+         ephemeral "already claimed by ..." reply.
+      3. Update the channel message to show who claimed it (hides the
+         button for everyone else).
+      4. Open the response modal for the claimer.
+    """
+    task_id = action.get("value")
+    trigger_id = payload.get("trigger_id")
+    team = payload.get("team") or {}
+    team_id = team.get("id")
+    user = payload.get("user") or {}
+    slack_user_id = user.get("id")
+    slack_username = user.get("username") or user.get("name")
+    response_url = payload.get("response_url")
+    channel = (payload.get("channel") or {}).get("id")
+    message = payload.get("message") or {}
+    message_ts = message.get("ts")
+
+    if not task_id or not trigger_id or not team_id or not slack_user_id:
+        logger.warning(
+            "claim: missing field (task_id=%s, trigger_id=%s, team=%s, user=%s)",
+            task_id, trigger_id, team_id, slack_user_id,
+        )
+        return
+
+    client = await get_client_for_team(session, team_id)
+    if client is None:
+        logger.error("claim: no client for team_id=%s", team_id)
+        return
+
+    directory_user = await get_user_by_slack(
+        session, slack_team_id=team_id, slack_user_id=slack_user_id
+    )
+    if directory_user is None or not directory_user.active:
+        await _ephemeral_reply(
+            client=client,
+            channel=channel,
+            user_id=slack_user_id,
+            response_url=response_url,
+            text=(
+                "You're not in this server's user directory. "
+                "Ask your operator to add you via Settings → Users, "
+                "then try claiming again."
+            ),
+        )
+        return
+
+    try:
+        task = await claim_task(
+            session,
+            task_id=task_id,
+            user_id=directory_user.id,
+            user_email=directory_user.email,
+        )
+    except TaskAlreadyClaimedError as exc:
+        claimer_display = await _display_for_user_id(session, exc.claimed_by_user_id)
+        await _ephemeral_reply(
+            client=client,
+            channel=channel,
+            user_id=slack_user_id,
+            response_url=response_url,
+            text=f"Already claimed by {claimer_display}.",
+        )
+        return
+    except TaskAlreadyTerminalError:
+        await _ephemeral_reply(
+            client=client,
+            channel=channel,
+            user_id=slack_user_id,
+            response_url=response_url,
+            text="This task is already completed or cancelled.",
+        )
+        return
+
+    # Message update: swap the card for a "Claimed by X" state so the
+    # button vanishes for the rest of the channel. Best-effort — if
+    # chat.update fails (lost permissions, message deleted) we still
+    # pop the modal for the claimer.
+    claimer_display = (
+        f"<@{slack_user_id}>"
+        if slack_user_id
+        else directory_user.display_name or directory_user.email or "a user"
+    )
+    review_url = f"{settings.PUBLIC_URL.rstrip('/')}/tasks/{task.id}"
+    if channel and message_ts:
+        try:
+            await client.chat_update(
+                channel=channel,
+                ts=message_ts,
+                text=f"Claimed by {slack_username or 'a user'}: {task.task}",
+                blocks=claimed_message_blocks(
+                    task_title=task.task,
+                    review_url=review_url,
+                    claimed_by_display=claimer_display,
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("chat.update after claim failed: %s", exc)
+
+    # Pop the modal for the claimer so they can complete it immediately.
+    await _open_modal_for_task(
+        session=session,
+        task_id=task.id,
+        trigger_id=trigger_id,
+        team_id=team_id,
+    )
+
+
+async def _display_for_user_id(
+    session: AsyncSession, user_id: str | None
+) -> str:
+    """Human-readable label for the user who won a claim race."""
+    if not user_id:
+        return "another user"
+    user = await get_user(session, user_id)
+    if user is None:
+        return "another user"
+    if user.slack_user_id:
+        return f"<@{user.slack_user_id}>"
+    return user.display_name or user.email or "another user"
+
+
+async def _ephemeral_reply(
+    *,
+    client: Any,
+    channel: str | None,
+    user_id: str,
+    response_url: str | None,
+    text: str,
+) -> None:
+    """Post an ephemeral message to the clicker.
+
+    Uses response_url when we have it (works even without chat:write to
+    the channel) and falls back to chat.postEphemeral for private
+    channels where response_url isn't useful.
+    """
+    if response_url:
+        try:
+            await client.api_call(
+                "",
+                http_verb="POST",
+                json={"response_type": "ephemeral", "text": text},
+                url=response_url,
+            )
+            return
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("ephemeral via response_url failed: %s", exc)
+
+    if channel:
+        try:
+            await client.chat_postEphemeral(
+                channel=channel, user=user_id, text=text
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("chat.postEphemeral failed: %s", exc)
 
 
 # ─── view_submission — complete the task ────────────────────────────────

--- a/packages/python/awaithumans/server/services/exceptions.py
+++ b/packages/python/awaithumans/server/services/exceptions.py
@@ -91,6 +91,21 @@ class UserAlreadyExistsError(ServiceError):
         )
 
 
+class TaskAlreadyClaimedError(ServiceError):
+    """Another user claimed the task first (broadcast-to-channel flow)."""
+
+    status_code = 409
+    error_code = "TASK_ALREADY_CLAIMED"
+    docs_path = "task-already-claimed"
+
+    def __init__(self, task_id: str, claimed_by_user_id: str | None) -> None:
+        self.task_id = task_id
+        self.claimed_by_user_id = claimed_by_user_id
+        super().__init__(
+            f"Task '{task_id}' was already claimed by another user."
+        )
+
+
 class UserNoAddressError(ServiceError):
     """At least one delivery address (email or slack pair) must be set —
     a user with neither is unreachable and useless for routing."""

--- a/packages/python/awaithumans/server/services/task_service.py
+++ b/packages/python/awaithumans/server/services/task_service.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from awaithumans.server.db.models import AuditEntry, Task, TaskStatus
 from awaithumans.server.services.exceptions import (
+    TaskAlreadyClaimedError,
     TaskAlreadyTerminalError,
     TaskNotFoundError,
 )
@@ -128,6 +129,76 @@ async def list_tasks(
         query = query.where(Task.assigned_to_email == assigned_to_email)
     result = await session.execute(query)
     return list(result.scalars().all())
+
+
+async def claim_task(
+    session: AsyncSession,
+    *,
+    task_id: str,
+    user_id: str,
+    user_email: str | None = None,
+) -> Task:
+    """Claim a broadcast task (first-writer-wins).
+
+    Used when a task was posted to a channel with no specific assignee
+    and a human clicked "Claim." Atomic `UPDATE ... WHERE
+    assigned_to_user_id IS NULL` — second clicker sees
+    `TaskAlreadyClaimedError` and the caller surfaces an ephemeral
+    "already claimed by X" to them.
+
+    Raises `TaskNotFoundError` if no such task, `TaskAlreadyTerminalError`
+    if it's already completed/cancelled/timed-out (a stale message from
+    before a completion on another channel), `TaskAlreadyClaimedError`
+    if another user beat us to it.
+    """
+    task = await get_task(session, task_id)
+
+    if task.status in TERMINAL_STATUSES_SET:
+        raise TaskAlreadyTerminalError(task_id, task.status)
+
+    # Fast-path: already claimed by someone.
+    if task.assigned_to_user_id is not None:
+        raise TaskAlreadyClaimedError(task_id, task.assigned_to_user_id)
+
+    now = datetime.now(timezone.utc)
+    result = await session.execute(
+        update(Task)
+        .where(Task.id == task_id)
+        .where(Task.assigned_to_user_id.is_(None))
+        .where(Task.status.notin_(list(TERMINAL_STATUSES_SET)))
+        .values(
+            assigned_to_user_id=user_id,
+            assigned_to_email=user_email,
+            updated_at=now,
+        )
+    )
+
+    if result.rowcount == 0:
+        # Race: another claimer committed between our SELECT and UPDATE.
+        # Re-read to tell the loser who actually won.
+        await session.refresh(task)
+        if task.assigned_to_user_id is not None:
+            raise TaskAlreadyClaimedError(task_id, task.assigned_to_user_id)
+        if task.status in TERMINAL_STATUSES_SET:
+            raise TaskAlreadyTerminalError(task_id, task.status)
+        # Shouldn't happen, but don't leave the caller guessing.
+        raise TaskAlreadyClaimedError(task_id, None)
+
+    audit = AuditEntry(
+        task_id=task_id,
+        from_status=task.status.value,
+        to_status=task.status.value,  # claim doesn't change status
+        action="claimed",
+        actor_type="human",
+        actor_email=user_email,
+        channel="slack",
+        extra_data={"user_id": user_id},
+    )
+    session.add(audit)
+    await session.commit()
+
+    await session.refresh(task)
+    return task
 
 
 async def complete_task(

--- a/packages/python/awaithumans/utils/constants.py
+++ b/packages/python/awaithumans/utils/constants.py
@@ -56,6 +56,10 @@ SLACK_SIGNATURE_MAX_AGE_SECONDS = 300  # 5 minutes
 # Block Kit action_id for the "Review" button in the initial notification.
 SLACK_ACTION_OPEN_REVIEW = "awaithumans.open_review"
 
+# Block Kit action_id for the "Claim" button on broadcast messages posted
+# to a channel (notify=["slack:#ops"]). First clicker gets the task.
+SLACK_ACTION_CLAIM_TASK = "awaithumans.claim_task"
+
 # Block Kit callback_id for the review modal (matches on view_submission).
 SLACK_MODAL_CALLBACK_ID = "awaithumans.review_modal"
 

--- a/packages/python/tests/slack/test_claim_broadcast_e2e.py
+++ b/packages/python/tests/slack/test_claim_broadcast_e2e.py
@@ -1,0 +1,447 @@
+"""Broadcast-to-channel claim flow — end-to-end through the interactions
+webhook.
+
+Covers:
+  - First click on "Claim this task" assigns the task + opens the modal
+  - Second clicker gets an ephemeral "already claimed by X" message
+  - Unknown Slack user (not in directory) gets an ephemeral "ask your
+    operator to add you" message without claiming
+  - Claim on an already-terminal task → ephemeral "already completed"
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import secrets
+import time
+import urllib.parse
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+from awaithumans.server.app import create_app
+from awaithumans.server.channels.slack import client as client_module
+from awaithumans.server.core import encryption
+from awaithumans.server.core.config import settings
+from awaithumans.server.db.connection import get_session
+from awaithumans.server.db.models import (  # noqa: F401 — register
+    AuditEntry,
+    EmailSenderIdentity,
+    SlackInstallation,
+    Task,
+    User,
+)
+from awaithumans.server.services.task_service import complete_task, create_task
+from awaithumans.server.services.user_service import create_user
+from awaithumans.utils.constants import SLACK_ACTION_CLAIM_TASK
+
+SIGNING_SECRET = "test-signing-secret"
+
+
+class FakeSlackClient:
+    """Recorder. Implements every call the claim handler makes."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def views_open(self, *, trigger_id: str, view: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append({"method": "views_open", "trigger_id": trigger_id, "view": view})
+        return {"ok": True}
+
+    async def chat_update(
+        self, *, channel: str, ts: str, text: str, blocks: list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {
+                "method": "chat_update",
+                "channel": channel,
+                "ts": ts,
+                "text": text,
+                "blocks": blocks,
+            }
+        )
+        return {"ok": True}
+
+    async def chat_postEphemeral(
+        self, *, channel: str, user: str, text: str
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {"method": "chat_postEphemeral", "channel": channel, "user": user, "text": text}
+        )
+        return {"ok": True}
+
+    async def api_call(
+        self,
+        _method_name: str = "",
+        *,
+        http_verb: str = "POST",
+        json: dict[str, Any] | None = None,
+        url: str | None = None,
+    ) -> dict[str, Any]:
+        # response_url-based ephemeral posts come through here.
+        self.calls.append(
+            {"method": "api_call", "http_verb": http_verb, "json": json, "url": url}
+        )
+        return {"ok": True}
+
+
+@pytest_asyncio.fixture
+async def slack_ctx() -> AsyncGenerator[tuple[AsyncClient, FakeSlackClient], None]:
+    orig_signing = settings.SLACK_SIGNING_SECRET
+    orig_payload = settings.PAYLOAD_KEY
+    settings.SLACK_SIGNING_SECRET = SIGNING_SECRET
+    settings.PAYLOAD_KEY = secrets.token_urlsafe(32)
+    encryption.reset_key_cache()
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_session() -> AsyncGenerator[AsyncSession, None]:
+        async with factory() as s:
+            yield s
+
+    fake = FakeSlackClient()
+    orig_resolver = client_module.get_client_for_team
+
+    async def fake_resolver(session: AsyncSession, team_id: str | None):
+        return fake
+
+    from awaithumans.server.routes.slack import interactions as interactions_route
+
+    client_module.get_client_for_team = fake_resolver  # type: ignore[assignment]
+    interactions_route.get_client_for_team = fake_resolver  # type: ignore[assignment]
+
+    app = create_app(serve_dashboard=False)
+    app.dependency_overrides[get_session] = override_session
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://testserver", follow_redirects=False
+    ) as c:
+        yield c, fake
+
+    client_module.get_client_for_team = orig_resolver  # type: ignore[assignment]
+    interactions_route.get_client_for_team = orig_resolver  # type: ignore[assignment]
+    await engine.dispose()
+    settings.SLACK_SIGNING_SECRET = orig_signing
+    settings.PAYLOAD_KEY = orig_payload
+    encryption.reset_key_cache()
+
+
+# ─── Slack signature helpers (match test_interactions_e2e.py) ──────────
+
+
+def _sign(body: bytes) -> dict[str, str]:
+    ts = str(int(time.time()))
+    base = f"v0:{ts}:".encode() + body
+    sig = "v0=" + hmac.new(
+        SIGNING_SECRET.encode(), base, hashlib.sha256
+    ).hexdigest()
+    return {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "X-Slack-Request-Timestamp": ts,
+        "X-Slack-Signature": sig,
+    }
+
+
+def _form_body(payload: dict[str, Any]) -> bytes:
+    return urllib.parse.urlencode({"payload": json.dumps(payload)}).encode()
+
+
+def _switch_form() -> dict[str, Any]:
+    return {
+        "version": 1,
+        "fields": [
+            {
+                "kind": "switch",
+                "required": True,
+                "default": None,
+                "true_label": "Yes",
+                "false_label": "No",
+                "name": "approved",
+                "label": "Approve?",
+                "hint": None,
+            },
+        ],
+    }
+
+
+async def _seed_task_and_user(
+    client: AsyncClient,
+    *,
+    slack_team_id: str,
+    slack_user_id: str,
+) -> tuple[str, str]:
+    """Create a directory user + broadcast-eligible task. Returns
+    (task_id, user_id)."""
+    override = client._transport.app.dependency_overrides[get_session]  # type: ignore[attr-defined]
+    async for s in override():
+        user = await create_user(
+            s,
+            slack_team_id=slack_team_id,
+            slack_user_id=slack_user_id,
+            display_name="Alice",
+            role="reviewer",
+        )
+        task = await create_task(
+            s,
+            task="Approve refund",
+            payload={"amount": 100},
+            payload_schema={},
+            response_schema={},
+            timeout_seconds=900,
+            idempotency_key=f"claim-{secrets.token_hex(4)}",
+            form_definition=_switch_form(),
+        )
+        return task.id, user.id
+    raise RuntimeError("session override did not yield")
+
+
+def _claim_payload(
+    *,
+    task_id: str,
+    team_id: str,
+    slack_user_id: str,
+    slack_username: str = "alice",
+    trigger_id: str = "trigger-xyz",
+    channel: str = "C_OPS",
+    message_ts: str = "1234567890.0001",
+) -> dict[str, Any]:
+    return {
+        "type": "block_actions",
+        "trigger_id": trigger_id,
+        "team": {"id": team_id},
+        "user": {"id": slack_user_id, "username": slack_username},
+        "channel": {"id": channel},
+        "message": {"ts": message_ts},
+        "response_url": f"https://hooks.slack.example/{secrets.token_hex(6)}",
+        "actions": [
+            {"action_id": SLACK_ACTION_CLAIM_TASK, "value": task_id},
+        ],
+    }
+
+
+# ─── Tests ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_claim_assigns_task_and_opens_modal(
+    slack_ctx: tuple[AsyncClient, FakeSlackClient],
+) -> None:
+    client, fake = slack_ctx
+    task_id, user_id = await _seed_task_and_user(
+        client, slack_team_id="T_ACME", slack_user_id="U_ALICE"
+    )
+
+    body = _form_body(
+        _claim_payload(
+            task_id=task_id,
+            team_id="T_ACME",
+            slack_user_id="U_ALICE",
+        )
+    )
+    resp = await client.post(
+        "/api/channels/slack/interactions", content=body, headers=_sign(body)
+    )
+    assert resp.status_code == 200
+
+    # Expected calls: chat_update (hide claim button) + views_open (modal).
+    methods = [c["method"] for c in fake.calls]
+    assert "chat_update" in methods
+    assert "views_open" in methods
+
+    # Task row should now be assigned to the claimer.
+    override = client._transport.app.dependency_overrides[get_session]
+    async for s in override():
+        from awaithumans.server.services.task_service import get_task
+
+        t = await get_task(s, task_id)
+        assert t.assigned_to_user_id == user_id
+        break
+
+
+@pytest.mark.asyncio
+async def test_second_claim_is_ephemeral_error(
+    slack_ctx: tuple[AsyncClient, FakeSlackClient],
+) -> None:
+    client, fake = slack_ctx
+
+    # Seed BOTH users + the task in one session context — creating
+    # users across separate session-override iterations tripped a
+    # "Could not refresh instance" error (detached row).
+    override = client._transport.app.dependency_overrides[get_session]
+    async for s in override():
+        await create_user(
+            s,
+            slack_team_id="T_ACME",
+            slack_user_id="U_ALICE",
+            display_name="Alice",
+            role="reviewer",
+        )
+        await create_user(
+            s,
+            slack_team_id="T_ACME",
+            slack_user_id="U_BOB",
+            display_name="Bob",
+            role="reviewer",
+        )
+        task = await create_task(
+            s,
+            task="Approve refund",
+            payload={},
+            payload_schema={},
+            response_schema={},
+            timeout_seconds=900,
+            idempotency_key="concurrent-claim",
+            form_definition=_switch_form(),
+        )
+        task_id = task.id
+        break
+
+    # First click — succeeds.
+    body1 = _form_body(
+        _claim_payload(task_id=task_id, team_id="T_ACME", slack_user_id="U_ALICE")
+    )
+    r1 = await client.post(
+        "/api/channels/slack/interactions", content=body1, headers=_sign(body1)
+    )
+    assert r1.status_code == 200
+
+    calls_after_first = len(fake.calls)
+
+    # Second click by a different user — gets ephemeral reply.
+    body2 = _form_body(
+        _claim_payload(
+            task_id=task_id,
+            team_id="T_ACME",
+            slack_user_id="U_BOB",
+            slack_username="bob",
+            trigger_id="trigger-2",
+        )
+    )
+    r2 = await client.post(
+        "/api/channels/slack/interactions", content=body2, headers=_sign(body2)
+    )
+    assert r2.status_code == 200
+
+    # Second click should NOT have opened another modal or updated the message.
+    new_calls = fake.calls[calls_after_first:]
+    methods = [c["method"] for c in new_calls]
+    assert "views_open" not in methods
+    assert "chat_update" not in methods
+
+    # Exactly one ephemeral-style reply — either response_url api_call
+    # or chat.postEphemeral fallback.
+    ephemeral_calls = [
+        c for c in new_calls if c["method"] in ("api_call", "chat_postEphemeral")
+    ]
+    assert len(ephemeral_calls) == 1
+    reply_text = (
+        ephemeral_calls[0].get("json", {}).get("text")
+        or ephemeral_calls[0].get("text", "")
+    )
+    assert "already claimed" in reply_text.lower()
+
+
+@pytest.mark.asyncio
+async def test_claim_by_user_not_in_directory_ephemeral_error(
+    slack_ctx: tuple[AsyncClient, FakeSlackClient],
+) -> None:
+    """A Slack user not registered in the directory can't claim.
+    Enforces directory hygiene — an operator should `add-user` them
+    first (or use the member picker in Settings → Users)."""
+    client, fake = slack_ctx
+    # Seed a task but no matching user for the clicker below.
+    override = client._transport.app.dependency_overrides[get_session]
+    async for s in override():
+        task = await create_task(
+            s,
+            task="Approve refund",
+            payload={},
+            payload_schema={},
+            response_schema={},
+            timeout_seconds=900,
+            idempotency_key="no-user",
+            form_definition=_switch_form(),
+        )
+        task_id = task.id
+        break
+
+    body = _form_body(
+        _claim_payload(
+            task_id=task_id,
+            team_id="T_ACME",
+            slack_user_id="U_STRANGER",
+        )
+    )
+    r = await client.post(
+        "/api/channels/slack/interactions", content=body, headers=_sign(body)
+    )
+    assert r.status_code == 200
+
+    methods = [c["method"] for c in fake.calls]
+    assert "views_open" not in methods
+    assert "chat_update" not in methods
+
+    # Task should still be unassigned.
+    async for s in override():
+        from awaithumans.server.services.task_service import get_task
+
+        t = await get_task(s, task_id)
+        assert t.assigned_to_user_id is None
+        break
+
+
+@pytest.mark.asyncio
+async def test_claim_on_terminal_task_ephemeral_error(
+    slack_ctx: tuple[AsyncClient, FakeSlackClient],
+) -> None:
+    """Stale broadcast message posted before the task was completed on
+    another channel. Claim should soft-fail with an ephemeral."""
+    client, fake = slack_ctx
+    task_id, _ = await _seed_task_and_user(
+        client, slack_team_id="T_ACME", slack_user_id="U_ALICE"
+    )
+
+    # Flip the task to COMPLETED directly (simulating completion via
+    # a different channel).
+    override = client._transport.app.dependency_overrides[get_session]
+    async for s in override():
+        await complete_task(
+            s,
+            task_id=task_id,
+            response={"approved": True},
+            completed_via_channel="dashboard",
+        )
+        break
+
+    body = _form_body(
+        _claim_payload(task_id=task_id, team_id="T_ACME", slack_user_id="U_ALICE")
+    )
+    r = await client.post(
+        "/api/channels/slack/interactions", content=body, headers=_sign(body)
+    )
+    assert r.status_code == 200
+
+    methods = [c["method"] for c in fake.calls]
+    assert "views_open" not in methods
+
+    ephemeral_calls = [
+        c for c in fake.calls if c["method"] in ("api_call", "chat_postEphemeral")
+    ]
+    assert len(ephemeral_calls) == 1
+    text = (
+        ephemeral_calls[0].get("json", {}).get("text")
+        or ephemeral_calls[0].get("text", "")
+    )
+    assert "completed" in text.lower() or "cancelled" in text.lower()

--- a/packages/python/tests/slack/test_workspace_members_route.py
+++ b/packages/python/tests/slack/test_workspace_members_route.py
@@ -1,0 +1,245 @@
+"""GET /api/channels/slack/installations/{team_id}/members — Slack
+workspace member picker backend.
+
+Patches `get_client_for_team` to return a fake that yields a known
+users.list payload, then asserts the route transforms/filters correctly.
+"""
+
+from __future__ import annotations
+
+import secrets
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+from awaithumans.server.app import create_app
+from awaithumans.server.channels.slack import client as client_module
+from awaithumans.server.core import encryption
+from awaithumans.server.core.config import settings
+from awaithumans.server.core.password import hash_password
+from awaithumans.server.db.connection import get_session
+from awaithumans.server.db.models import (  # noqa: F401 — register
+    AuditEntry,
+    EmailSenderIdentity,
+    SlackInstallation,
+    Task,
+    User,
+)
+from awaithumans.server.services.user_service import create_user
+
+
+class _UsersListResp:
+    def __init__(self, members: list[dict[str, Any]]) -> None:
+        self.data = {"ok": True, "members": members}
+
+
+class FakeClient:
+    """Just enough to satisfy the members route."""
+
+    def __init__(self, members: list[dict[str, Any]]) -> None:
+        self._members = members
+
+    async def users_list(self) -> _UsersListResp:
+        return _UsersListResp(self._members)
+
+
+class FailingClient:
+    """Simulates Slack rejecting users.list (e.g. missing scope)."""
+
+    async def users_list(self) -> Any:
+        raise RuntimeError("missing_scope: users:read")
+
+
+# Canonical sample of users.list shape — real Slack response fields,
+# trimmed to what the route actually reads.
+SAMPLE_MEMBERS: list[dict[str, Any]] = [
+    {
+        "id": "U_ALICE",
+        "name": "alice",
+        "real_name": "Alice Singh",
+        "is_bot": False,
+        "is_admin": True,
+        "deleted": False,
+        "profile": {"real_name": "Alice Singh", "display_name": "alice.s"},
+    },
+    {
+        "id": "U_BOB",
+        "name": "bob",
+        "real_name": "Bob",
+        "is_bot": False,
+        "is_admin": False,
+        "deleted": False,
+        "profile": {"real_name": "Bob", "display_name": ""},
+    },
+    {
+        "id": "USLACKBOT",
+        "name": "slackbot",
+        "real_name": "Slackbot",
+        "is_bot": False,
+        "is_admin": False,
+        "deleted": False,
+        "profile": {"real_name": "Slackbot"},
+    },
+    {
+        "id": "B_HOOK",
+        "name": "hookbot",
+        "real_name": "Hook Bot",
+        "is_bot": True,
+        "is_admin": False,
+        "deleted": False,
+        "profile": {"real_name": "Hook Bot"},
+    },
+    {
+        "id": "U_GONE",
+        "name": "gone",
+        "real_name": "Former Employee",
+        "is_bot": False,
+        "is_admin": False,
+        "deleted": True,
+        "profile": {"real_name": "Former Employee"},
+    },
+]
+
+
+@pytest_asyncio.fixture
+async def logged_in_client() -> AsyncGenerator[tuple[AsyncClient, AsyncSession], None]:
+    """Operator-session-authed client. The members route is admin-only."""
+    orig_payload = settings.PAYLOAD_KEY
+    settings.PAYLOAD_KEY = secrets.token_urlsafe(32)
+    encryption.reset_key_cache()
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_session() -> AsyncGenerator[AsyncSession, None]:
+        async with factory() as s:
+            yield s
+
+    app = create_app(serve_dashboard=False)
+    app.dependency_overrides[get_session] = override_session
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://testserver", follow_redirects=False
+    ) as c:
+        # Seed an operator and log them in so subsequent requests ride
+        # the session cookie.
+        async with factory() as s:
+            await create_user(
+                s,
+                email="op@example.com",
+                is_operator=True,
+                password="hunter2a",
+            )
+
+        resp = await c.post(
+            "/api/auth/login",
+            json={"email": "op@example.com", "password": "hunter2a"},
+        )
+        assert resp.status_code == 204
+
+        yield c, factory
+
+    await engine.dispose()
+    settings.PAYLOAD_KEY = orig_payload
+    encryption.reset_key_cache()
+
+
+def _patch_resolver(client_fn):
+    """Patch the resolver in both the client module AND the
+    installations route (which imported by name)."""
+    from awaithumans.server.routes.slack import installations as inst
+
+    orig_module = client_module.get_client_for_team
+    orig_route = inst.get_client_for_team
+    client_module.get_client_for_team = client_fn  # type: ignore[assignment]
+    inst.get_client_for_team = client_fn  # type: ignore[assignment]
+
+    def restore() -> None:
+        client_module.get_client_for_team = orig_module  # type: ignore[assignment]
+        inst.get_client_for_team = orig_route  # type: ignore[assignment]
+
+    return restore
+
+
+# ─── Tests ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_members_filters_bots_deactivated_and_slackbot(
+    logged_in_client: tuple[AsyncClient, Any],
+) -> None:
+    c, _ = logged_in_client
+
+    async def fake_resolver(session, team_id):
+        return FakeClient(SAMPLE_MEMBERS)
+
+    restore = _patch_resolver(fake_resolver)
+    try:
+        resp = await c.get("/api/channels/slack/installations/T_ACME/members")
+        assert resp.status_code == 200
+        rows = resp.json()
+    finally:
+        restore()
+
+    ids = [r["id"] for r in rows]
+    assert "U_ALICE" in ids
+    assert "U_BOB" in ids
+    assert "USLACKBOT" not in ids
+    assert "B_HOOK" not in ids
+    assert "U_GONE" not in ids
+
+    # Alphabetical order — Alice before Bob.
+    assert ids == ["U_ALICE", "U_BOB"]
+
+    alice = next(r for r in rows if r["id"] == "U_ALICE")
+    assert alice["name"] == "alice"
+    assert alice["real_name"] == "Alice Singh"
+    assert alice["display_name"] == "alice.s"
+    assert alice["is_admin"] is True
+
+
+@pytest.mark.asyncio
+async def test_members_404_when_no_installation(
+    logged_in_client: tuple[AsyncClient, Any],
+) -> None:
+    c, _ = logged_in_client
+
+    async def fake_resolver(session, team_id):
+        return None
+
+    restore = _patch_resolver(fake_resolver)
+    try:
+        resp = await c.get("/api/channels/slack/installations/T_MISSING/members")
+    finally:
+        restore()
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_members_502_when_slack_rejects(
+    logged_in_client: tuple[AsyncClient, Any],
+) -> None:
+    c, _ = logged_in_client
+
+    async def fake_resolver(session, team_id):
+        return FailingClient()
+
+    restore = _patch_resolver(fake_resolver)
+    try:
+        resp = await c.get("/api/channels/slack/installations/T_ACME/members")
+    finally:
+        restore()
+
+    assert resp.status_code == 502
+    body = resp.json()
+    assert "users:read" in body.get("detail", "") or "Slack" in body.get("detail", "")


### PR DESCRIPTION
## Summary

Final PR in the user-directory series. Two Slack-integration features that round out the original ask:

**1. Broadcast-to-channel with first-to-claim.** `notify=[\"slack:#ops\"]` now posts a task card to the channel with a \"Claim this task\" button as the primary CTA. First clicker gets it atomically; later clickers get an ephemeral \"already claimed by X\". Channel-vs-DM detection in the notifier (`#` prefix + Slack's channel ID sigils `C`/`G`). DMs keep the existing direct-open flow.

**2. Slack workspace member picker.** Dashboard's user-add form no longer needs operators to paste `T01ABC234` / `U01XYZ789`. They pick from a dropdown of installed workspaces, then another dropdown of workspace members (with real names). Falls back to free-text inputs when no workspaces are installed.

## Atomic claim primitive

Mirrors the `complete_task` first-writer-wins pattern in `services/task_service.py::claim_task`:

```
UPDATE tasks
   SET assigned_to_user_id=:user, assigned_to_email=:email
 WHERE id=:task_id
   AND assigned_to_user_id IS NULL
   AND status NOT IN (terminal)
```

`rowcount == 0` → re-read and distinguish \"claimed by someone\" (`TaskAlreadyClaimedError`, 409) vs \"already completed\" (`TaskAlreadyTerminalError`). Adds an audit entry with `action=\"claimed\"`.

## Claim handler flow

1. Look up the clicker by `(slack_team_id, slack_user_id)` in the User directory. **Unknown users get an ephemeral \"ask your operator to add you\"** — enforces directory hygiene so claims correlate with routing. The member picker in Feature 2 makes adding them a two-click operation.
2. Atomic claim via `task_service`.
3. `chat.update` to swap the channel message for a \"Claimed by @user\" card, hiding the button for everyone else.
4. `views.open` with the response modal for the claimer.

Ephemeral errors go through `response_url` when available and fall back to `chat.postEphemeral`.

## Member picker endpoint

  `GET /api/channels/slack/installations/{team_id}/members`

Calls `users.list` via the stored bot token (requires `users:read` scope), filters bots + deactivated + Slackbot, sorts by real name. 404 when no install for team; 502 when Slack rejects (actionable error telling operator to reinstall).

## Test plan

- [x] **4 claim e2e tests** — happy path (assigns + opens modal), second claim (ephemeral), unknown Slack user (ephemeral, no claim), claim on terminal task (ephemeral)
- [x] **3 members route tests** — filter/sort, 404 no install, 502 Slack rejection
- [x] **Full suite: 298 passing** (291 → 298, +7)
- [x] Dashboard typecheck: clean
- [x] `scripts/build-bundled.sh` — all 8 pages build; new Users section renders correctly

## The full series (closed)

| # | Scope | PR |
|---|---|---|
| A1 | alembic + User model + single-head CI | #19 |
| A2 | password hashing + user service + admin API + CLI | #20 |
| A3 | auth overhaul + /setup bootstrap | #21 |
| A4 | task router (Option C) | #22 |
| A5 | Settings UI for users | #23 |
| B | **this** — Slack broadcast + member picker | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)