### PR TITLE
refactor: clean-code review fixes from A-series audit

### DIFF
--- a/packages/dashboard/components/settings/user-form.tsx
+++ b/packages/dashboard/components/settings/user-form.tsx
@@ -40,13 +40,20 @@ export function UserForm({
 	onSaved: () => Promise<void>;
 	onError: (msg: string) => void;
 }) {
+	// ── Form state ──
 	const [displayName, setDisplayName] = useState(editing?.display_name ?? "");
 	const [email, setEmail] = useState(editing?.email ?? "");
 	const [slackTeamId, setSlackTeamId] = useState(editing?.slack_team_id ?? "");
 	const [slackUserId, setSlackUserId] = useState(editing?.slack_user_id ?? "");
+	const [role, setRole] = useState(editing?.role ?? "");
+	const [accessLevel, setAccessLevel] = useState(editing?.access_level ?? "");
+	const [pool, setPool] = useState(editing?.pool ?? "");
+	const [isOperator, setIsOperator] = useState(editing?.is_operator ?? false);
+	const [password, setPassword] = useState("");
+	const [submitting, setSubmitting] = useState(false);
 
-	// Slack workspace picker — loaded lazily on mount; silently disabled
-	// if no workspaces are installed.
+	// ── Slack workspace picker — loaded lazily on mount; silently
+	// disabled if no workspaces are installed. ──
 	const [installations, setInstallations] = useState<SlackInstallation[]>([]);
 	const [members, setMembers] = useState<SlackMember[] | null>(null);
 	const [loadingMembers, setLoadingMembers] = useState(false);
@@ -77,12 +84,6 @@ export function UserForm({
 			)
 			.finally(() => setLoadingMembers(false));
 	}, [slackTeamId, installations]);
-	const [role, setRole] = useState(editing?.role ?? "");
-	const [accessLevel, setAccessLevel] = useState(editing?.access_level ?? "");
-	const [pool, setPool] = useState(editing?.pool ?? "");
-	const [isOperator, setIsOperator] = useState(editing?.is_operator ?? false);
-	const [password, setPassword] = useState("");
-	const [submitting, setSubmitting] = useState(false);
 
 	const hasEmail = email.trim().length > 0;
 	const hasSlackTeam = slackTeamId.trim().length > 0;

--- a/packages/dashboard/lib/types.ts
+++ b/packages/dashboard/lib/types.ts
@@ -19,6 +19,7 @@ export interface Task {
 	status: TaskStatus;
 	assign_to: Record<string, unknown> | null;
 	assigned_to_email: string | null;
+	assigned_to_user_id: string | null;
 	response: Record<string, unknown> | null;
 	verifier_result: Record<string, unknown> | null;
 	verification_attempt: number;

--- a/packages/python/awaithumans/server/channels/slack/notifier.py
+++ b/packages/python/awaithumans/server/channels/slack/notifier.py
@@ -50,7 +50,10 @@ async def notify_task(
         return
 
     form = _parse_form(form_definition)
-    review_url = f"{settings.PUBLIC_URL.rstrip('/')}/tasks/{task_id}"
+    # The dashboard moved to `/task?id=…` for static-export compatibility
+    # (dynamic segments don't survive `output: "export"`). Old `/tasks/{id}`
+    # 404s.
+    review_url = f"{settings.PUBLIC_URL.rstrip('/')}/task?id={task_id}"
     offenders = unsupported_fields(form, "slack") if form is not None else None
     fallback_text = f"New task: {task_title}"
 

--- a/packages/python/awaithumans/server/core/auth.py
+++ b/packages/python/awaithumans/server/core/auth.py
@@ -12,9 +12,9 @@ the same root key never signs two primitives.
 Session validation is two-step:
 - `verify_session(cookie)` checks HMAC, expiry, and payload shape —
   no DB hit. Returns a `SessionClaims` dataclass.
-- Routes that need fresh user data use the `require_session` FastAPI
-  dep, which looks up the user by ID (enabling later "invalidate on
-  password change" via a session_version field).
+- Routes that need fresh user data read `request.state.auth_claims` and
+  call the user service. The admin API gate (`core/admin_auth.py`)
+  already handles operator-vs-bearer resolution.
 
 An operator password change or row deletion doesn't invalidate
 outstanding sessions until they expire. Acceptable for v1. Post-launch
@@ -40,7 +40,7 @@ from dataclasses import dataclass
 
 from cryptography.hazmat.primitives.hashes import SHA256
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
-from fastapi import HTTPException, Request, status
+from fastapi import Request, status
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
 
@@ -226,24 +226,3 @@ class DashboardAuthMiddleware(BaseHTTPMiddleware):
         )
 
 
-# ─── FastAPI deps ───────────────────────────────────────────────────────
-
-
-def require_session(request: Request) -> SessionClaims:
-    """Dep for routes that need the caller's user_id. Covers cookie-auth
-    only — routes that accept the admin bearer token use `require_admin`
-    from `core/admin_auth.py` instead."""
-    claims = getattr(request.state, "auth_claims", None)
-    if not isinstance(claims, SessionClaims):
-        raise HTTPException(status_code=401, detail="Authentication required.")
-    return claims
-
-
-def require_operator_session(request: Request) -> SessionClaims:
-    """Dep for routes that require operator privileges via session auth
-    (not the admin bearer token). Admin routes typically use the looser
-    `require_admin` dep which accepts either."""
-    claims = require_session(request)
-    if not claims.is_operator:
-        raise HTTPException(status_code=403, detail="Operator privileges required.")
-    return claims

--- a/packages/python/awaithumans/server/routes/auth.py
+++ b/packages/python/awaithumans/server/routes/auth.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
-from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from awaithumans.server.core.auth import (
@@ -27,6 +26,7 @@ from awaithumans.server.core.auth import (
 from awaithumans.server.core.config import settings
 from awaithumans.server.core.password import verify_password
 from awaithumans.server.db.connection import get_session
+from awaithumans.server.schemas.auth import LoginRequest, MeResponse
 from awaithumans.server.services.user_service import get_user, get_user_by_email
 from awaithumans.utils.constants import (
     DASHBOARD_SESSION_COOKIE_NAME,
@@ -35,19 +35,6 @@ from awaithumans.utils.constants import (
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 logger = logging.getLogger("awaithumans.server.routes.auth")
-
-
-class LoginRequest(BaseModel):
-    email: str = Field(min_length=1, max_length=320, description="User's email address.")
-    password: str = Field(min_length=1, max_length=200)
-
-
-class MeResponse(BaseModel):
-    authenticated: bool
-    user_id: str | None = None
-    email: str | None = None
-    display_name: str | None = None
-    is_operator: bool = False
 
 
 @router.post("/login", status_code=status.HTTP_204_NO_CONTENT)

--- a/packages/python/awaithumans/server/routes/setup.py
+++ b/packages/python/awaithumans/server/routes/setup.py
@@ -18,14 +18,22 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
-from pydantic import BaseModel, Field
+from fastapi import APIRouter, Depends, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from awaithumans.server.core import bootstrap
 from awaithumans.server.core.auth import sign_session
 from awaithumans.server.core.config import settings
 from awaithumans.server.db.connection import get_session
+from awaithumans.server.schemas.setup import (
+    CreateOperatorRequest,
+    CreateOperatorResponse,
+    SetupStatusResponse,
+)
+from awaithumans.server.services.exceptions import (
+    InvalidSetupTokenError,
+    SetupAlreadyCompletedError,
+)
 from awaithumans.server.services.user_service import count_users, create_user
 from awaithumans.utils.constants import (
     DASHBOARD_SESSION_COOKIE_NAME,
@@ -34,24 +42,6 @@ from awaithumans.utils.constants import (
 
 router = APIRouter(prefix="/setup", tags=["setup"])
 logger = logging.getLogger("awaithumans.server.routes.setup")
-
-
-class SetupStatusResponse(BaseModel):
-    """Tells the dashboard which landing page to show."""
-
-    needs_setup: bool
-    # `token_active` is true only on the server's own loopback — the
-    # actual token is never returned; operators read it from the server
-    # log. This field just lets the /setup page show a "server is
-    # ready, paste your token" state vs. "setup already done" state.
-    token_active: bool
-
-
-class CreateOperatorRequest(BaseModel):
-    token: str = Field(min_length=1)
-    email: str = Field(min_length=1, max_length=320)
-    password: str = Field(min_length=8)
-    display_name: str | None = None
 
 
 @router.get("/status", response_model=SetupStatusResponse)
@@ -67,13 +57,14 @@ async def setup_status(
 
 @router.post(
     "/operator",
+    response_model=CreateOperatorResponse,
     status_code=status.HTTP_201_CREATED,
 )
 async def create_first_operator(
     body: CreateOperatorRequest,
     response: Response,
     session: AsyncSession = Depends(get_session),
-) -> dict[str, str]:
+) -> CreateOperatorResponse:
     """Create the first operator and issue their session in one shot.
 
     The dashboard posts here after the operator pastes the setup token
@@ -88,14 +79,11 @@ async def create_first_operator(
     # cleaner error.
     if await count_users(session) > 0:
         bootstrap.mark_complete()
-        raise HTTPException(
-            status_code=409,
-            detail="Setup has already been completed. Use /api/auth/login.",
-        )
+        raise SetupAlreadyCompletedError()
 
     if not bootstrap.verify_token(body.token):
         logger.info("Rejected setup token (mismatch or already completed)")
-        raise HTTPException(status_code=403, detail="Invalid setup token.")
+        raise InvalidSetupTokenError()
 
     user = await create_user(
         session,
@@ -118,4 +106,4 @@ async def create_first_operator(
         samesite="lax",
         path="/",
     )
-    return {"user_id": user.id, "email": user.email or ""}
+    return CreateOperatorResponse(user_id=user.id, email=user.email or "")

--- a/packages/python/awaithumans/server/routes/slack/installations.py
+++ b/packages/python/awaithumans/server/routes/slack/installations.py
@@ -10,12 +10,14 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Path
 from fastapi.responses import Response
-from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from awaithumans.server.channels.slack.client import get_client_for_team
 from awaithumans.server.db.connection import get_session
-from awaithumans.server.schemas.slack import SlackInstallationResponse
+from awaithumans.server.schemas.slack import (
+    SlackInstallationResponse,
+    SlackMemberResponse,
+)
 from awaithumans.server.services.slack_installation_service import (
     delete_installation,
     list_installations,
@@ -23,19 +25,6 @@ from awaithumans.server.services.slack_installation_service import (
 
 router = APIRouter()
 logger = logging.getLogger("awaithumans.server.routes.slack.installations")
-
-
-class SlackMemberResponse(BaseModel):
-    """A member of a Slack workspace — enough to render a picker.
-
-    We deliberately don't forward the full Slack profile; dashboard
-    only needs enough to label the row and record the stable ID."""
-
-    id: str            # Slack user ID (U… / W…)
-    name: str          # @handle ("alice")
-    real_name: str | None
-    display_name: str | None
-    is_admin: bool
 
 
 def _to_public(row) -> SlackInstallationResponse:

--- a/packages/python/awaithumans/server/routes/slack/interactions.py
+++ b/packages/python/awaithumans/server/routes/slack/interactions.py
@@ -18,10 +18,13 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.ext.asyncio import AsyncSession
+
+if TYPE_CHECKING:  # pragma: no cover
+    from slack_sdk.web.async_client import AsyncWebClient
 
 from awaithumans.forms import FormDefinition
 from awaithumans.server.channels.slack.blocks import (
@@ -241,6 +244,7 @@ async def _handle_claim(
             task_id=task_id,
             user_id=directory_user.id,
             user_email=directory_user.email,
+            claimed_via_channel="slack",
         )
     except TaskAlreadyClaimedError as exc:
         claimer_display = await _display_for_user_id(session, exc.claimed_by_user_id)
@@ -271,7 +275,7 @@ async def _handle_claim(
         if slack_user_id
         else directory_user.display_name or directory_user.email or "a user"
     )
-    review_url = f"{settings.PUBLIC_URL.rstrip('/')}/tasks/{task.id}"
+    review_url = f"{settings.PUBLIC_URL.rstrip('/')}/task?id={task.id}"
     if channel and message_ts:
         try:
             await client.chat_update(
@@ -312,7 +316,7 @@ async def _display_for_user_id(
 
 async def _ephemeral_reply(
     *,
-    client: Any,
+    client: AsyncWebClient,
     channel: str | None,
     user_id: str,
     response_url: str | None,

--- a/packages/python/awaithumans/server/routes/users.py
+++ b/packages/python/awaithumans/server/routes/users.py
@@ -9,12 +9,13 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Query
 from fastapi.responses import Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from awaithumans.server.core.admin_auth import require_admin
 from awaithumans.server.db.connection import get_session
+from awaithumans.server.db.models import User
 from awaithumans.server.schemas.users import (
     SetPasswordRequest,
     UserCreateRequest,
@@ -35,27 +36,25 @@ router = APIRouter(prefix="/admin/users", tags=["admin"])
 logger = logging.getLogger("awaithumans.server.routes.users")
 
 
-def _to_public(row: object) -> UserResponse:
-    """Convert a User model row to its public view. Computes
-    `has_password` from the hash presence so callers can tell
-    whether the user can log in without seeing the hash."""
-    # `row` is a User but typed loosely so the module doesn't import
-    # the model unnecessarily — we only read attributes.
+def _to_public(row: User) -> UserResponse:
+    """Convert a User model row to its public view. `has_password` is
+    derived from the hash presence so callers can tell whether the
+    user can log in without seeing the hash itself."""
     return UserResponse(
-        id=row.id,  # type: ignore[attr-defined]
-        display_name=row.display_name,  # type: ignore[attr-defined]
-        email=row.email,  # type: ignore[attr-defined]
-        slack_team_id=row.slack_team_id,  # type: ignore[attr-defined]
-        slack_user_id=row.slack_user_id,  # type: ignore[attr-defined]
-        role=row.role,  # type: ignore[attr-defined]
-        access_level=row.access_level,  # type: ignore[attr-defined]
-        pool=row.pool,  # type: ignore[attr-defined]
-        is_operator=row.is_operator,  # type: ignore[attr-defined]
-        has_password=bool(row.password_hash),  # type: ignore[attr-defined]
-        active=row.active,  # type: ignore[attr-defined]
-        last_assigned_at=row.last_assigned_at,  # type: ignore[attr-defined]
-        created_at=row.created_at,  # type: ignore[attr-defined]
-        updated_at=row.updated_at,  # type: ignore[attr-defined]
+        id=row.id,
+        display_name=row.display_name,
+        email=row.email,
+        slack_team_id=row.slack_team_id,
+        slack_user_id=row.slack_user_id,
+        role=row.role,
+        access_level=row.access_level,
+        pool=row.pool,
+        is_operator=row.is_operator,
+        has_password=bool(row.password_hash),
+        active=row.active,
+        last_assigned_at=row.last_assigned_at,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
     )
 
 

--- a/packages/python/awaithumans/server/schemas/auth.py
+++ b/packages/python/awaithumans/server/schemas/auth.py
@@ -1,0 +1,21 @@
+"""Auth API request/response schemas.
+
+Split out from routes/auth.py so routes carry handlers only.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class LoginRequest(BaseModel):
+    email: str = Field(min_length=1, max_length=320, description="User's email address.")
+    password: str = Field(min_length=1, max_length=200)
+
+
+class MeResponse(BaseModel):
+    authenticated: bool
+    user_id: str | None = None
+    email: str | None = None
+    display_name: str | None = None
+    is_operator: bool = False

--- a/packages/python/awaithumans/server/schemas/setup.py
+++ b/packages/python/awaithumans/server/schemas/setup.py
@@ -1,0 +1,31 @@
+"""First-run setup API request/response schemas.
+
+Split out from routes/setup.py so routes carry handlers only.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class SetupStatusResponse(BaseModel):
+    """Tells the dashboard which landing page to show."""
+
+    needs_setup: bool
+    # `token_active` is true only while a bootstrap token exists in the
+    # server's memory. The actual token is never returned; operators read
+    # it from the server log. This field just lets the /setup page
+    # distinguish "server is ready, paste your token" from "already done."
+    token_active: bool
+
+
+class CreateOperatorRequest(BaseModel):
+    token: str = Field(min_length=1)
+    email: str = Field(min_length=1, max_length=320)
+    password: str = Field(min_length=8)
+    display_name: str | None = None
+
+
+class CreateOperatorResponse(BaseModel):
+    user_id: str
+    email: str

--- a/packages/python/awaithumans/server/schemas/slack.py
+++ b/packages/python/awaithumans/server/schemas/slack.py
@@ -21,3 +21,16 @@ class SlackInstallationResponse(BaseModel):
     updated_at: str
 
     model_config = {"from_attributes": True}
+
+
+class SlackMemberResponse(BaseModel):
+    """A member of a Slack workspace — enough to render a picker.
+
+    We deliberately don't forward the full Slack profile; dashboard
+    only needs enough to label the row and record the stable ID."""
+
+    id: str            # Slack user ID (U… / W…)
+    name: str          # @handle ("alice")
+    real_name: str | None
+    display_name: str | None
+    is_admin: bool

--- a/packages/python/awaithumans/server/services/exceptions.py
+++ b/packages/python/awaithumans/server/services/exceptions.py
@@ -120,3 +120,34 @@ class UserNoAddressError(ServiceError):
             "or a (slack_team_id, slack_user_id) pair. Rows with neither "
             "can't be reached by any channel."
         )
+
+
+# ─── Setup / bootstrap errors ─────────────────────────────────────────
+
+
+class SetupAlreadyCompletedError(ServiceError):
+    """Tried to run /setup after a user already exists. One-shot."""
+
+    status_code = 409
+    error_code = "SETUP_ALREADY_COMPLETED"
+    docs_path = "setup-already-completed"
+
+    def __init__(self) -> None:
+        super().__init__(
+            "First-run setup has already been completed. Sign in with your "
+            "operator credentials via /api/auth/login instead."
+        )
+
+
+class InvalidSetupTokenError(ServiceError):
+    """Bootstrap token didn't match the in-memory value."""
+
+    status_code = 403
+    error_code = "INVALID_SETUP_TOKEN"
+    docs_path = "invalid-setup-token"
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Invalid setup token. The token is printed to the server log on "
+            "startup; restart the server to generate a fresh one."
+        )

--- a/packages/python/awaithumans/server/services/task_service.py
+++ b/packages/python/awaithumans/server/services/task_service.py
@@ -137,6 +137,7 @@ async def claim_task(
     task_id: str,
     user_id: str,
     user_email: str | None = None,
+    claimed_via_channel: str | None = None,
 ) -> Task:
     """Claim a broadcast task (first-writer-wins).
 
@@ -145,6 +146,10 @@ async def claim_task(
     assigned_to_user_id IS NULL` — second clicker sees
     `TaskAlreadyClaimedError` and the caller surfaces an ephemeral
     "already claimed by X" to them.
+
+    `claimed_via_channel` is a free-form string ("slack", "dashboard",
+    "email") mirroring `completed_via_channel` so audit trails stay
+    consistent across lifecycle events.
 
     Raises `TaskNotFoundError` if no such task, `TaskAlreadyTerminalError`
     if it's already completed/cancelled/timed-out (a stale message from
@@ -191,7 +196,7 @@ async def claim_task(
         action="claimed",
         actor_type="human",
         actor_email=user_email,
-        channel="slack",
+        channel=claimed_via_channel,
         extra_data={"user_id": user_id},
     )
     session.add(audit)


### PR DESCRIPTION
## Summary

Post-landing audit of PRs #19/20/21/22/23/24 against CLAUDE.md's Code Review Checklist surfaced 10 violations. Fixing them all without changing behavior.

## Critical bugs caught (both latent)

1. **Broken review_url** — `notifier.py` + `interactions.py` built URLs as `/tasks/{task_id}`, but the dashboard's static-export refactor moved the task detail route to `/task?id=…`. Every \"Review in dashboard\" link from Slack would have 404'd. Swapped both sites to query-param form.

2. **Task type drift** — `packages/dashboard/lib/types.ts::Task` was missing the `assigned_to_user_id` field added in PR A4. Cross-language consistency violation (Checklist #7). Added the field.

## Structure — Pydantic models out of route files

Checklist #1 violations: schemas belong in `server/schemas/{domain}.py`.

- `routes/auth.py` → new `schemas/auth.py` (`LoginRequest`, `MeResponse`)
- `routes/setup.py` → new `schemas/setup.py` (`SetupStatusResponse`, `CreateOperatorRequest`, `CreateOperatorResponse` — the route was returning a bare dict, now properly typed)
- `routes/slack/installations.py` → `SlackMemberResponse` moved into the existing `schemas/slack.py`

## Exceptions — HTTPException → ServiceError

Checklist #3: `routes/setup.py` was raising `HTTPException(409, …)` / `HTTPException(403, …)`. Replaced with two new `ServiceError` subclasses (`SetupAlreadyCompletedError`, `InvalidSetupTokenError`). The centralized handler picks them up — no per-exception wiring.

## Dead code

`core/auth.py` had `require_session()` + `require_operator_session()` defined but never imported anywhere. Premature abstraction from PR A3 — removed. Middleware + `require_admin` (in `core/admin_auth.py`) carry the whole auth surface.

## Type safety

- `routes/users.py::_to_public` had 13 `# type: ignore[attr-defined]` — typed `row: User` and dropped every one.
- `routes/slack/interactions.py::_ephemeral_reply` had `client: Any` — replaced with `AsyncWebClient` under `TYPE_CHECKING`.

## Consistency

- `services/task_service.py::claim_task` hardcoded `channel=\"slack\"` on its audit entry. Added a `claimed_via_channel` parameter mirroring `complete_task`'s `completed_via_channel`.
- `user-form.tsx` had useState/useEffect interleaved — regrouped into state-then-hooks blocks.

## Verification
- [x] Full backend: **298 passing** (no regressions)
- [x] Dashboard typecheck: clean
- [x] `scripts/build-bundled.sh` — 93 files, 8 pages
- [x] Zero new `# type: ignore` in any route / schema / service file

🤖 Generated with [Claude Code](https://claude.com/claude-code)