### PR TITLE
fix(security): login timing + last-operator guard + Slack response_url

### DIFF
--- a/packages/python/awaithumans/server/core/password.py
+++ b/packages/python/awaithumans/server/core/password.py
@@ -11,6 +11,10 @@ Usage:
     h = hash_password("s3cret")
     verify_password("s3cret", h)        # True
     verify_password("wrong", h)         # False
+
+Also exposes `dummy_verify()` for timing-equalizing the login path when
+a user isn't found — argon2's ~100ms cost is easily measurable, and
+fast-failing on unknown emails would leak account existence.
 """
 
 from __future__ import annotations
@@ -25,6 +29,12 @@ logger = logging.getLogger("awaithumans.server.core.password")
 # Module-level singleton — `PasswordHasher` is threadsafe and cheap to
 # keep around. Expensive to construct on every call.
 _hasher = PasswordHasher()
+
+# Pre-computed dummy hash. Generated once at import; `dummy_verify`
+# verifies any password against this so the unknown-user login path
+# costs the same CPU as the known-user path. The hash is for a random
+# unknown string — no real user can ever match it.
+_DUMMY_HASH = _hasher.hash("*timing-equalization-sentinel*")
 
 
 def hash_password(password: str) -> str:
@@ -42,3 +52,19 @@ def verify_password(password: str, stored_hash: str) -> bool:
     except Exception as exc:  # malformed hash, unexpected algorithm, etc.
         logger.warning("password verify failed (treated as mismatch): %s", exc)
         return False
+
+
+def dummy_verify(password: str) -> None:
+    """Run argon2 verify against a pre-computed dummy hash.
+
+    Use on the "user not found" branch of login so unknown emails cost
+    the same CPU time as known ones. Without this, a timing probe can
+    distinguish registered accounts by response latency (argon2 adds
+    ~100ms per attempt, an easily-measurable delta).
+
+    Result is discarded — this function only exists to spend CPU.
+    """
+    try:
+        _hasher.verify(_DUMMY_HASH, password)
+    except Exception:  # noqa: BLE001 — any outcome is fine; we just wanted the CPU spend
+        pass

--- a/packages/python/awaithumans/server/routes/auth.py
+++ b/packages/python/awaithumans/server/routes/auth.py
@@ -24,7 +24,7 @@ from awaithumans.server.core.auth import (
     verify_session,
 )
 from awaithumans.server.core.config import settings
-from awaithumans.server.core.password import verify_password
+from awaithumans.server.core.password import dummy_verify, verify_password
 from awaithumans.server.db.connection import get_session
 from awaithumans.server.schemas.auth import LoginRequest, MeResponse
 from awaithumans.server.services.user_service import get_user, get_user_by_email
@@ -53,7 +53,12 @@ async def login(
     user = await get_user_by_email(session, body.email)
     reject = HTTPException(status_code=401, detail="Invalid credentials.")
 
+    # Timing equalization: without this, the unknown-user path skips
+    # argon2 and returns ~100ms faster than the known-user path,
+    # letting an attacker probe for registered emails. Burn the same
+    # CPU budget either way.
     if user is None or not user.active or not user.password_hash:
+        dummy_verify(body.password)
         logger.info("Failed login (no match / inactive / no password): %s", body.email)
         raise reject
 

--- a/packages/python/awaithumans/server/routes/slack/interactions.py
+++ b/packages/python/awaithumans/server/routes/slack/interactions.py
@@ -324,18 +324,25 @@ async def _ephemeral_reply(
 ) -> None:
     """Post an ephemeral message to the clicker.
 
-    Uses response_url when we have it (works even without chat:write to
-    the channel) and falls back to chat.postEphemeral for private
-    channels where response_url isn't useful.
+    Slack's interaction payloads include a short-lived `response_url`
+    that accepts a plain JSON POST from anywhere — no bot token or
+    channel membership needed. We hit it directly with `httpx`
+    (already a runtime dep) because `AsyncWebClient.api_call` only
+    targets `https://slack.com/api/<method>` and can't override the
+    URL. Falls back to `chat.postEphemeral` (requires `chat:write`
+    scope + bot membership in the channel) for edges where the
+    response_url isn't present.
     """
+    import httpx
+
     if response_url:
         try:
-            await client.api_call(
-                "",
-                http_verb="POST",
-                json={"response_type": "ephemeral", "text": text},
-                url=response_url,
-            )
+            async with httpx.AsyncClient(timeout=5.0) as http:
+                resp = await http.post(
+                    response_url,
+                    json={"response_type": "ephemeral", "text": text},
+                )
+                resp.raise_for_status()
             return
         except Exception as exc:  # noqa: BLE001
             logger.warning("ephemeral via response_url failed: %s", exc)

--- a/packages/python/awaithumans/server/services/exceptions.py
+++ b/packages/python/awaithumans/server/services/exceptions.py
@@ -151,3 +151,24 @@ class InvalidSetupTokenError(ServiceError):
             "Invalid setup token. The token is printed to the server log on "
             "startup; restart the server to generate a fresh one."
         )
+
+
+class LastOperatorError(ServiceError):
+    """Tried to delete / demote / deactivate the only active operator.
+
+    Prevents locking everyone out of dashboard admin — the last
+    operator standing has to stay reachable. Recovery from a full
+    lockout requires CLI (bootstrap-operator on empty DB) or the
+    admin bearer token, both of which are operator-level already."""
+
+    status_code = 409
+    error_code = "LAST_OPERATOR"
+    docs_path = "last-operator"
+
+    def __init__(self, action: str) -> None:
+        self.action = action
+        super().__init__(
+            f"Can't {action} the last active operator — at least one "
+            "operator must remain so the dashboard stays manageable. "
+            "Promote another user to operator first."
+        )

--- a/packages/python/awaithumans/server/services/user_service.py
+++ b/packages/python/awaithumans/server/services/user_service.py
@@ -22,6 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from awaithumans.server.core.password import hash_password
 from awaithumans.server.db.models import User
 from awaithumans.server.services.exceptions import (
+    LastOperatorError,
     UserAlreadyExistsError,
     UserNoAddressError,
     UserNotFoundError,
@@ -164,10 +165,23 @@ async def update_user(
     (service never stores plaintext). Pass `password_hash=<str>`
     directly at your peril — that's an escape hatch for migrations,
     not normal use.
+
+    Refuses to demote (`is_operator=False`) or deactivate
+    (`active=False`) the last active operator; see `LastOperatorError`.
     """
     row = await get_user(session, user_id)
     if row is None:
         raise UserNotFoundError(user_id)
+
+    # Pre-flight last-operator guard. Run BEFORE applying the changes
+    # so we don't mutate the row and then refuse to commit — leaves
+    # the session in a clean state for the caller's next query.
+    if row.is_operator and row.active:
+        demoting = changes.get("is_operator") is False
+        deactivating = changes.get("active") is False
+        if demoting or deactivating:
+            action = "demote" if demoting else "deactivate"
+            await _ensure_not_last_active_operator(session, row.id, action=action)
 
     if "password" in changes:
         pw = changes.pop("password")
@@ -210,7 +224,18 @@ async def set_password(
 
 
 async def delete_user(session: AsyncSession, user_id: str) -> bool:
-    """Hard delete. Returns True if a row was removed, False if not found."""
+    """Hard delete. Returns True if a row was removed, False if not found.
+
+    Refuses to remove the last active operator (see `LastOperatorError`).
+    Without this guard a well-meaning operator could lock themselves
+    out of the dashboard."""
+    row = await get_user(session, user_id)
+    if row is None:
+        return False
+
+    if row.is_operator and row.active:
+        await _ensure_not_last_active_operator(session, row.id, action="delete")
+
     result = await session.execute(delete(User).where(User.id == user_id))
     await session.commit()
     return result.rowcount > 0
@@ -223,3 +248,26 @@ async def count_users(session: AsyncSession) -> int:
 
     result = await session.execute(select(func.count()).select_from(User))
     return int(result.scalar_one())
+
+
+async def _count_active_operators(session: AsyncSession) -> int:
+    from sqlalchemy import func
+
+    result = await session.execute(
+        select(func.count())
+        .select_from(User)
+        .where(User.is_operator == True)  # noqa: E712 — SQLAlchemy idiom
+        .where(User.active == True)  # noqa: E712
+    )
+    return int(result.scalar_one())
+
+
+async def _ensure_not_last_active_operator(
+    session: AsyncSession, user_id: str, *, action: str
+) -> None:
+    """Raise `LastOperatorError` if removing/demoting this user would
+    leave zero active operators. Used by `delete_user` + `update_user`
+    to prevent accidental full lockout."""
+    active_ops = await _count_active_operators(session)
+    if active_ops <= 1:
+        raise LastOperatorError(action)

--- a/packages/python/tests/auth/test_auth_routes.py
+++ b/packages/python/tests/auth/test_auth_routes.py
@@ -155,27 +155,34 @@ def test_admin_token_wrong_value_401(client: TestClient, monkeypatch) -> None:
 
 def test_inactive_user_cannot_login(client: TestClient, monkeypatch) -> None:
     """Deactivating a user blocks new logins (existing sessions keep
-    working until expiry — tradeoff for no DB hit per request)."""
+    working until expiry — tradeoff for no DB hit per request).
+
+    Uses a non-operator user since the last-active-operator guard
+    (post-security-audit) refuses to deactivate the only operator.
+    """
     import asyncio
 
     from awaithumans.server.db.connection import get_async_session_factory
-    from awaithumans.server.services.user_service import update_user
+    from awaithumans.server.services.user_service import create_user, update_user
 
     factory = get_async_session_factory()
+    other_email = "regular@example.com"
+    other_password = "other-password-xyz"
 
-    async def _deactivate() -> None:
+    async def _seed_and_deactivate() -> None:
         async with factory() as session:
-            # Look the user up by email and flip active=False.
-            from awaithumans.server.services.user_service import get_user_by_email
-
-            u = await get_user_by_email(session, OPERATOR_EMAIL)
-            assert u is not None
+            u = await create_user(
+                session,
+                email=other_email,
+                display_name="Regular user",
+                password=other_password,
+            )
             await update_user(session, u.id, active=False)
 
-    asyncio.get_event_loop().run_until_complete(_deactivate())
+    asyncio.get_event_loop().run_until_complete(_seed_and_deactivate())
 
     resp = client.post(
         "/api/auth/login",
-        json={"email": OPERATOR_EMAIL, "password": OPERATOR_PASSWORD},
+        json={"email": other_email, "password": other_password},
     )
     assert resp.status_code == 401

--- a/packages/python/tests/users/test_security_guards.py
+++ b/packages/python/tests/users/test_security_guards.py
@@ -1,0 +1,150 @@
+"""Security audit regression tests.
+
+Pins:
+  - last-operator delete / demote / deactivate refused
+  - login timing-equalized (unknown user takes ~same CPU as known)
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from awaithumans.server.core.password import dummy_verify, hash_password, verify_password
+from awaithumans.server.services.exceptions import LastOperatorError
+from awaithumans.server.services.user_service import (
+    create_user,
+    delete_user,
+    update_user,
+)
+
+
+# ─── Last-operator guard ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_last_operator_refused(session: AsyncSession) -> None:
+    op = await create_user(
+        session, email="op@example.com", is_operator=True, password="hunter2a"
+    )
+
+    with pytest.raises(LastOperatorError) as exc:
+        await delete_user(session, op.id)
+    assert exc.value.action == "delete"
+
+
+@pytest.mark.asyncio
+async def test_delete_operator_ok_when_another_exists(session: AsyncSession) -> None:
+    op1 = await create_user(
+        session, email="op1@example.com", is_operator=True, password="pass1234"
+    )
+    await create_user(
+        session, email="op2@example.com", is_operator=True, password="pass2345"
+    )
+
+    ok = await delete_user(session, op1.id)
+    assert ok is True
+
+
+@pytest.mark.asyncio
+async def test_delete_non_operator_always_ok(session: AsyncSession) -> None:
+    """Regular user delete is unaffected by the operator guard."""
+    await create_user(session, email="op@example.com", is_operator=True, password="pass")
+    reg = await create_user(session, email="reg@example.com", role="reviewer")
+
+    assert await delete_user(session, reg.id) is True
+
+
+@pytest.mark.asyncio
+async def test_demote_last_operator_refused(session: AsyncSession) -> None:
+    op = await create_user(
+        session, email="op@example.com", is_operator=True, password="hunter2a"
+    )
+
+    with pytest.raises(LastOperatorError) as exc:
+        await update_user(session, op.id, is_operator=False)
+    assert exc.value.action == "demote"
+
+
+@pytest.mark.asyncio
+async def test_deactivate_last_operator_refused(session: AsyncSession) -> None:
+    op = await create_user(
+        session, email="op@example.com", is_operator=True, password="hunter2a"
+    )
+
+    with pytest.raises(LastOperatorError) as exc:
+        await update_user(session, op.id, active=False)
+    assert exc.value.action == "deactivate"
+
+
+@pytest.mark.asyncio
+async def test_demote_operator_ok_when_another_exists(session: AsyncSession) -> None:
+    op1 = await create_user(
+        session, email="op1@example.com", is_operator=True, password="pass1234"
+    )
+    await create_user(
+        session, email="op2@example.com", is_operator=True, password="pass2345"
+    )
+
+    updated = await update_user(session, op1.id, is_operator=False)
+    assert updated.is_operator is False
+
+
+@pytest.mark.asyncio
+async def test_last_operator_guard_ignores_inactive_operators(
+    session: AsyncSession,
+) -> None:
+    """An inactive operator doesn't count toward the "at least one"
+    requirement — deleting the only active operator is still refused
+    even if inactive operator rows exist."""
+    # Create one active operator + one inactive operator.
+    active = await create_user(
+        session, email="active@example.com", is_operator=True, password="pass1234"
+    )
+    await create_user(
+        session,
+        email="inactive@example.com",
+        is_operator=True,
+        password="pass2345",
+        active=False,
+    )
+
+    with pytest.raises(LastOperatorError):
+        await delete_user(session, active.id)
+
+
+# ─── Login timing equalization ────────────────────────────────────────
+
+
+def test_dummy_verify_takes_comparable_time_to_real_verify() -> None:
+    """dummy_verify must spend ~the same wall-clock time as a real
+    argon2 verify; otherwise the login unknown-user path leaks
+    account existence via timing."""
+    real_hash = hash_password("a-real-password-abc")
+
+    # Warm up argon2 so first-call overhead doesn't skew results.
+    verify_password("a-real-password-abc", real_hash)
+    dummy_verify("anything")
+
+    t0 = time.perf_counter()
+    for _ in range(3):
+        verify_password("wrong-password", real_hash)
+    real_duration = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    for _ in range(3):
+        dummy_verify("wrong-password")
+    dummy_duration = time.perf_counter() - t0
+
+    # Allow 2x tolerance — CI machines are noisy. The point is that
+    # dummy_verify is not *orders of magnitude* faster than the real
+    # path (which is what an attacker would exploit).
+    ratio = max(real_duration, dummy_duration) / max(
+        min(real_duration, dummy_duration), 1e-6
+    )
+    assert ratio < 2.0, (
+        f"dummy_verify timing drift: real={real_duration:.3f}s, "
+        f"dummy={dummy_duration:.3f}s (ratio={ratio:.2f})"
+    )


### PR DESCRIPTION
## Summary

Three fixes from a post-landing security audit of the user-directory series.

### 1. Login user-enumeration via timing 🔴

**What:** `routes/auth.py::login` fast-failed the unknown-user path without calling argon2 — known accounts took ~100ms (one argon2 verify), unknown accounts returned in ~10ms (DB lookup only).

**Why it matters:** An attacker can measure the delta and probe for registered emails via response latency.

**Fix:** New `core/password.py::dummy_verify()` runs argon2 against a pre-computed sentinel hash. Login now calls it on the unknown/inactive/no-password branch so every rejection costs the same CPU. Pinned by a regression test that asserts the timing ratio stays < 2x.

### 2. Slack ephemeral reply used the wrong SDK method 🔴

**What:** `_ephemeral_reply` called `client.api_call(url=response_url, …)` — but `AsyncWebClient.api_call` has no `url=` param. The response_url was silently dropped; calls hit `https://slack.com/api/` (empty method) and errored, got swallowed by the except, fell through to `chat.postEphemeral`.

**Why it matters:** (1) Every broadcast channel now requires `chat:write` scope (code comment explicitly claimed otherwise). (2) Ephemerals fail entirely in channels the bot isn't a member of.

**Fix:** POST directly to `response_url` via `httpx` (already a runtime dep). The `chat.postEphemeral` fallback stays for edges where `response_url` isn't present.

### 3. No safeguards on operator deletion / demotion 🔴

**What:** `delete_user` / `update_user` had no guard against removing or demoting the last active operator.

**Why it matters:** An operator could delete themselves or flip `is_operator=False` / `active=False` on the only operator row, locking everyone out of the dashboard admin surface.

**Fix:** New `LastOperatorError` (409, `LAST_OPERATOR`) raised when delete/demote/deactivate would leave zero active operators. Counts only active operators — inactive rows don't satisfy the \"at least one\" requirement. 7 regression tests covering every edge.

## Deferred (documented in the commit)
- No login rate limiting — needs sliding-window limiter with Redis
- No session invalidation on password change — documented v1 tradeoff; needs `session_version` field
- Production HTTPS check warns but doesn't fail-fast

## Test plan
- [x] **306 tests passing** (298 → 306, +8 security regression tests)
- [x] Existing `test_inactive_user_cannot_login` updated to use a non-operator user (old version deactivated the seeded operator, which now correctly triggers `LastOperatorError`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)