### PR TITLE
Slack: notify by @handle, fix Slack-only user display

### DIFF
--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -82,9 +82,13 @@ OAuth installs are stored encrypted at rest (AES-GCM keyed off `PAYLOAD_KEY`).
 
 ```python
 notify=["slack:#approvals"]                # broadcast to channel — first claim wins
-notify=["slack:@U01ABC1234"]               # DM a specific Slack user
+notify=["slack:@alice"]                    # DM by Slack handle (auto-resolved)
+notify=["slack:@U01ABC1234"]               # DM by raw user ID (also works)
+notify=["slack:alice@acme.com"]            # DM by email (uses users.lookupByEmail)
 notify=["slack:#approvals", "email:..."]   # multi-channel
 ```
+
+The middle three forms can target the same person — pick whichever's easiest. Handles (`@alice`) are resolved via `users.list` once per workspace per process, then cached. Emails use Slack's dedicated `users.lookupByEmail`. Raw user IDs pass through unchanged.
 
 ### Broadcast (channel)
 
@@ -96,7 +100,15 @@ Posts a message with a "Claim this task" button. First clicker wins atomically. 
 
 ### Direct (user)
 
-DMs the Slack user. They see "Open in Slack" and click straight into the modal. The user must be in your awaithumans directory (Settings → Users) for the modal to open — operators add them with their `slack_user_id`.
+DMs the Slack user. They see "Open in Slack" and click straight into the modal. The user must be in your awaithumans directory (Settings → Users) for the modal to open.
+
+For the `notify=` string you can use any of:
+
+- `slack:@alice` — Slack handle (most natural)
+- `slack:alice@acme.com` — email (when you only know that)
+- `slack:@U01ABC1234` — raw user ID (always works, no API call)
+
+For the directory entry (Settings → Users), the dashboard's "Slack member" picker pulls the workspace member list — operators pick from a dropdown rather than copy-pasting `U…` strings.
 
 ## Modal form
 

--- a/examples/slack-native/README.md
+++ b/examples/slack-native/README.md
@@ -157,7 +157,7 @@ That's the whole interface. The `notify=` string is what makes it Slack-native; 
 
 ## Why broadcast + claim instead of direct DM?
 
-You could have used `notify=["slack:@U_ALICE"]` to DM Alice directly. We picked broadcast for the demo because:
+You could have used `notify=["slack:@alice"]` to DM Alice directly (or `slack:alice@acme.com`, or `slack:@U_ALICE_ID` — all three resolve to the same person). We picked broadcast for the demo because:
 
 - It shows what makes Slack-native compelling: anyone watching the channel can pick up the task. No need to know up-front who's online or available.
 - The atomic-claim model is easy to demo and easy to reason about — first clicker wins, message updates so others stop trying.

--- a/packages/dashboard/components/settings/user-form.tsx
+++ b/packages/dashboard/components/settings/user-form.tsx
@@ -277,7 +277,25 @@ export function UserForm({
 					{members && members.length > 0 ? (
 						<select
 							value={slackUserId}
-							onChange={(e) => setSlackUserId(e.target.value)}
+							onChange={(e) => {
+								const id = e.target.value;
+								setSlackUserId(id);
+								// Auto-fill display_name from the picked member
+								// when the operator hasn't typed one yet. Without
+								// this the Users list falls back to the row ID
+								// for Slack-only directory users — terrible UX.
+								if (id && !displayName.trim()) {
+									const picked = members.find((m) => m.id === id);
+									if (picked) {
+										setDisplayName(
+											picked.real_name ||
+												picked.display_name ||
+												picked.name ||
+												"",
+										);
+									}
+								}
+							}}
 							className={inputClass}
 						>
 							<option value="">—</option>

--- a/packages/dashboard/components/settings/users.tsx
+++ b/packages/dashboard/components/settings/users.tsx
@@ -129,7 +129,18 @@ function UserRow({
 	onEdit: () => void;
 	onDelete: () => void;
 }) {
-	const primaryLabel = u.display_name || u.email || u.id;
+	// Headline fallback chain. The row ID (last resort) is a 32-char
+	// hex string — it's never useful to humans, so we exhaust every
+	// human-friendly option first: the operator's display name, then
+	// their email, then a recognisable Slack reference like
+	// `@U_ALICE`. Only if all of those are missing do we land on the
+	// raw row ID (and even then the addressLine below repeats the
+	// Slack ID so the operator can see what's going on).
+	const primaryLabel =
+		u.display_name ||
+		u.email ||
+		(u.slack_user_id ? `@${u.slack_user_id}` : null) ||
+		u.id;
 	const addressLine = [
 		u.email,
 		u.slack_user_id ? `slack:${u.slack_user_id}` : null,

--- a/packages/python/awaithumans/server/channels/slack/notifier.py
+++ b/packages/python/awaithumans/server/channels/slack/notifier.py
@@ -5,6 +5,15 @@ Parses the task's `notify` list for Slack routes, resolves the workspace
 `slack+T123456:#channel` to disambiguate multi-workspace setups), and
 posts the initial message.
 
+DM target resolution (`slack:@alice`):
+  Slack's `chat.postMessage` only accepts a real user ID (`U…` / `W…`)
+  in the `channel` argument; it doesn't resolve handles. So when the
+  notify entry is `slack:@alice` we hit `users.list` once, find the
+  member by handle, and post to their user_id. Cached per-team for
+  the process lifetime so a high-traffic queue doesn't burn the
+  `users.list` rate limit. Fallback to `users.lookupByEmail` when
+  the target looks like an email.
+
 Runs in a FastAPI BackgroundTask after the response is sent, so a slow
 Slack API call never blocks task creation and a Slack outage doesn't
 fail a successful task write. The notifier acquires its own DB session
@@ -14,6 +23,7 @@ because the caller's session has already been released by the time we run.
 from __future__ import annotations
 
 import logging
+import re
 from typing import TYPE_CHECKING, Any
 
 from awaithumans.forms import FormDefinition, unsupported_fields
@@ -35,6 +45,18 @@ if TYPE_CHECKING:  # pragma: no cover
     from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger("awaithumans.server.channels.slack.notifier")
+
+# Slack user IDs are `U…` (regular user) or `W…` (Enterprise Grid).
+# Anything else after a `@` is treated as a handle and resolved.
+_USER_ID_RE = re.compile(r"^[UW][A-Z0-9]{5,}$")
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+# Per-team cache of (handle → user_id) lookups. Populated lazily on
+# first miss; persists for the process lifetime. Slack's user list
+# changes rarely; rotating staff is fine — a stale entry just means
+# the DM goes to the right person who happens to have a new handle.
+# Process restart clears the cache, which is the right invalidation.
+_HANDLE_CACHE: dict[str, dict[str, str]] = {}
 
 
 async def notify_task(
@@ -85,9 +107,25 @@ async def notify_task(
                     route.identity,
                 )
                 continue
+
+            # Resolve `@handle` / `email` to a real user_id before
+            # posting. Slack's chat.postMessage doesn't do handle
+            # resolution itself — sending to `@alice` silently fails.
+            target = await _resolve_target(
+                client=client,
+                target=route.target,
+                team_id=route.identity,
+            )
+            if target is None:
+                logger.warning(
+                    "Slack route %s → could not resolve to a user/channel; "
+                    "skipping. Check the handle exists in this workspace.",
+                    route.target,
+                )
+                continue
             try:
                 await client.chat_postMessage(
-                    channel=route.target,
+                    channel=target,
                     text=fallback_text,
                     blocks=blocks,
                 )
@@ -119,9 +157,7 @@ def _is_channel_target(target: str) -> bool:
         return False
     if target.startswith("#"):
         return True
-    if target.startswith(("C", "G")):
-        return True
-    return False
+    return target.startswith(("C", "G"))
 
 
 async def _resolve_client(
@@ -141,3 +177,146 @@ def _parse_form(form_definition: dict[str, Any] | None) -> FormDefinition | None
     except Exception as exc:  # noqa: BLE001
         logger.warning("Invalid form_definition on task: %s", exc)
         return None
+
+
+async def _resolve_target(
+    *,
+    client: AsyncWebClient,
+    target: str,
+    team_id: str | None,
+) -> str | None:
+    """Resolve a notify target to something `chat.postMessage` accepts.
+
+    Channel sigils (`#general`, raw `C…` / `G…` IDs) pass through
+    unchanged. User IDs (`@U…`, `U…`) pass through with the leading
+    `@` stripped — Slack doesn't want it in the channel argument.
+    Anything else after `@` is a handle (`@alice`) and gets resolved
+    via `users.list`. Email-shaped targets use `users.lookupByEmail`.
+
+    Returns None when resolution fails (handle not in workspace,
+    Slack rejected the call, etc.) — the caller logs and skips."""
+    # Channel sigil — broadcast targets pass through unchanged.
+    if target.startswith("#"):
+        return target
+
+    # Strip the leading `@` if present so we can match against IDs /
+    # handles uniformly.
+    body = target.removeprefix("@")
+
+    # Already a real user ID? (`U…` / `W…` followed by alnum)
+    if _USER_ID_RE.match(body):
+        return body
+
+    # Raw channel-ID shape — public, private, or group DM.
+    if body.startswith(("C", "G")) and body[1:].isalnum():
+        return body
+
+    # Email shape — Slack has a dedicated lookup for that.
+    if _EMAIL_RE.match(body):
+        return await _resolve_by_email(client=client, email=body, team_id=team_id)
+
+    # Falls through to handle lookup via users.list.
+    return await _resolve_by_handle(client=client, handle=body, team_id=team_id)
+
+
+async def _resolve_by_email(
+    *, client: AsyncWebClient, email: str, team_id: str | None
+) -> str | None:
+    """Use Slack's `users.lookupByEmail` for email-shaped targets.
+
+    Cheaper than walking `users.list` and uses a dedicated endpoint
+    that doesn't count against the bulk-list rate limit."""
+    try:
+        from slack_sdk.errors import SlackApiError
+
+        try:
+            resp = await client.users_lookupByEmail(email=email)
+        except SlackApiError as exc:
+            logger.warning(
+                "users.lookupByEmail failed for %s (team=%s): %s",
+                email,
+                team_id,
+                exc.response.get("error", exc),
+            )
+            return None
+    except ImportError:
+        logger.error("slack_sdk not installed; can't resolve %s", email)
+        return None
+
+    user = resp.get("user") or {}
+    user_id = user.get("id")
+    return user_id if isinstance(user_id, str) else None
+
+
+async def _resolve_by_handle(
+    *, client: AsyncWebClient, handle: str, team_id: str | None
+) -> str | None:
+    """Resolve a Slack handle (e.g. `alice`, `alice.singh`) to a user_id.
+
+    Compares against `name`, `profile.display_name`, and
+    `profile.real_name` (case-insensitive) so any of the three
+    "names" the operator might know works. Caches the lookup table
+    per-team for the process lifetime — `users.list` is rate-limited
+    and the team rarely changes during a single deploy."""
+    cache_key = team_id or "__default__"
+    cached = _HANDLE_CACHE.get(cache_key)
+
+    if cached is None:
+        cached = await _build_handle_index(client=client, cache_key=cache_key)
+        if cached is None:
+            return None  # API call failed; logged in helper
+
+    # Match case-insensitively, both with and without leading `@`.
+    needle = handle.lstrip("@").lower()
+    return cached.get(needle)
+
+
+async def _build_handle_index(
+    *, client: AsyncWebClient, cache_key: str
+) -> dict[str, str] | None:
+    """Walk `users.list` once, build a {handle_lower: user_id} map.
+
+    Skips bots, deleted users, and the Slackbot pseudo-user. Indexes
+    each member by every name field they have so the operator can
+    use whichever's familiar."""
+    try:
+        from slack_sdk.errors import SlackApiError
+
+        try:
+            resp = await client.users_list()
+        except SlackApiError as exc:
+            logger.warning(
+                "users.list failed for team=%s: %s",
+                cache_key,
+                exc.response.get("error", exc),
+            )
+            return None
+    except ImportError:
+        logger.error("slack_sdk not installed; handle resolution unavailable")
+        return None
+
+    index: dict[str, str] = {}
+    for m in resp.get("members", []) or []:
+        if m.get("deleted") or m.get("is_bot") or m.get("id") == "USLACKBOT":
+            continue
+        user_id = m.get("id")
+        if not isinstance(user_id, str):
+            continue
+        # `name` (the @handle), plus the two display fields a user
+        # might have set. Case-insensitive lookup so `@Alice` and
+        # `@alice` both resolve.
+        for raw in (
+            m.get("name"),
+            (m.get("profile") or {}).get("display_name"),
+            (m.get("profile") or {}).get("real_name"),
+        ):
+            if isinstance(raw, str) and raw:
+                index[raw.lower()] = user_id
+
+    _HANDLE_CACHE[cache_key] = index
+    logger.info(
+        "Indexed %d Slack handles for team=%s (cached for process lifetime)",
+        len(index),
+        cache_key,
+    )
+    return index

--- a/packages/python/tests/slack/test_notifier_target_resolution.py
+++ b/packages/python/tests/slack/test_notifier_target_resolution.py
@@ -1,0 +1,288 @@
+"""Slack notifier target resolution — `slack:@alice` works.
+
+The user-facing contract: `notify=["slack:@alice"]` (the Slack handle)
+is equivalent to `notify=["slack:@U_ALICE_ID"]` (the user_id). The
+resolver translates handles to user_ids via `users.list` because
+Slack's `chat.postMessage` doesn't do that translation itself —
+posting to `@alice` raw silently fails.
+
+Three resolution paths covered:
+
+  - User ID → pass through (`@U123ABC` and `U123ABC`)
+  - Channel sigil → pass through (`#general`, `C123ABC`)
+  - Handle → resolved via `users.list` (`@alice` → `U_ALICE`)
+  - Email → resolved via `users.lookupByEmail` (`alice@acme.com` → `U_ALICE`)
+
+Cache hits don't re-call the API. Cache misses log + return None.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from awaithumans.server.channels.slack.notifier import (
+    _HANDLE_CACHE,
+    _resolve_target,
+)
+
+
+# ─── Fakes ───────────────────────────────────────────────────────────
+
+
+class _FakeResp:
+    def __init__(self, data: dict) -> None:
+        self._data = data
+
+    def get(self, key: str, default=None):
+        return self._data.get(key, default)
+
+
+class _FakeClient:
+    """Stand-in for `slack_sdk.web.async_client.AsyncWebClient`.
+
+    Records every method call so tests assert on (method, args). The
+    `users.list` payload is fully scriptable so each test can pin a
+    different roster."""
+
+    def __init__(self, members: list[dict] | None = None) -> None:
+        self._members = members or []
+        self.calls: list[str] = []
+        self._lookup_by_email_response: dict | None = None
+        self._users_list_error: Exception | None = None
+
+    def with_email_lookup(self, email: str, user_id: str) -> _FakeClient:
+        self._lookup_by_email_response = {
+            "expected_email": email,
+            "user_id": user_id,
+        }
+        return self
+
+    def with_users_list_error(self, exc: Exception) -> _FakeClient:
+        self._users_list_error = exc
+        return self
+
+    async def users_list(self) -> _FakeResp:
+        self.calls.append("users_list")
+        if self._users_list_error is not None:
+            raise self._users_list_error
+        return _FakeResp({"members": self._members})
+
+    async def users_lookupByEmail(self, *, email: str) -> _FakeResp:
+        self.calls.append(f"users_lookupByEmail:{email}")
+        if self._lookup_by_email_response is None:
+            return _FakeResp({"user": {}})
+        if email != self._lookup_by_email_response["expected_email"]:
+            return _FakeResp({"user": {}})
+        return _FakeResp(
+            {"user": {"id": self._lookup_by_email_response["user_id"]}}
+        )
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Each test starts with an empty handle cache so prior tests
+    can't poison the lookup."""
+    _HANDLE_CACHE.clear()
+    yield
+    _HANDLE_CACHE.clear()
+
+
+# ─── Pass-through paths ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_channel_sigil_passes_through() -> None:
+    client = _FakeClient()
+    out = await _resolve_target(client=client, target="#general", team_id=None)
+    assert out == "#general"
+    # No API call needed.
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_user_id_with_at_sign_strips_and_returns() -> None:
+    """`@U_ALICE` → `U_ALICE` — Slack's chat.postMessage doesn't
+    want the leading `@`."""
+    client = _FakeClient()
+    out = await _resolve_target(client=client, target="@U01ABC234", team_id=None)
+    assert out == "U01ABC234"
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_user_id_without_at_sign_passes_through() -> None:
+    client = _FakeClient()
+    out = await _resolve_target(client=client, target="U01ABC234", team_id=None)
+    assert out == "U01ABC234"
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_channel_id_passes_through() -> None:
+    client = _FakeClient()
+    out = await _resolve_target(client=client, target="C01ABC234", team_id=None)
+    assert out == "C01ABC234"
+    assert client.calls == []
+
+
+# ─── Handle resolution via users.list ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_handle_resolves_via_users_list() -> None:
+    client = _FakeClient(
+        members=[
+            {
+                "id": "U_ALICE",
+                "name": "alice",
+                "real_name": "Alice Singh",
+                "is_bot": False,
+                "deleted": False,
+                "profile": {"display_name": "alice.s", "real_name": "Alice Singh"},
+            },
+            {
+                "id": "U_BOB",
+                "name": "bob",
+                "is_bot": False,
+                "deleted": False,
+                "profile": {"display_name": "", "real_name": "Bob"},
+            },
+        ]
+    )
+
+    assert await _resolve_target(client=client, target="@alice", team_id=None) == "U_ALICE"
+    assert await _resolve_target(client=client, target="@bob", team_id=None) == "U_BOB"
+
+
+@pytest.mark.asyncio
+async def test_handle_resolution_is_case_insensitive() -> None:
+    client = _FakeClient(
+        members=[
+            {"id": "U_ALICE", "name": "alice", "is_bot": False, "deleted": False, "profile": {}}
+        ]
+    )
+    assert await _resolve_target(client=client, target="@Alice", team_id=None) == "U_ALICE"
+    assert await _resolve_target(client=client, target="@ALICE", team_id=None) == "U_ALICE"
+
+
+@pytest.mark.asyncio
+async def test_handle_can_match_display_name_or_real_name() -> None:
+    """If the operator types `@alice.singh` (display_name) or
+    `@Alice Singh` (real_name), still resolves."""
+    client = _FakeClient(
+        members=[
+            {
+                "id": "U_ALICE",
+                "name": "alice",
+                "is_bot": False,
+                "deleted": False,
+                "profile": {
+                    "display_name": "alice.singh",
+                    "real_name": "Alice Singh",
+                },
+            }
+        ]
+    )
+    assert (
+        await _resolve_target(client=client, target="@alice.singh", team_id=None)
+        == "U_ALICE"
+    )
+    # real_name with a space — operators rarely do this but it works.
+    assert (
+        await _resolve_target(client=client, target="@Alice Singh", team_id=None)
+        == "U_ALICE"
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_returns_none_when_not_found() -> None:
+    client = _FakeClient(
+        members=[
+            {"id": "U_ALICE", "name": "alice", "is_bot": False, "deleted": False, "profile": {}}
+        ]
+    )
+    assert (
+        await _resolve_target(client=client, target="@nonexistent", team_id=None)
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_bots_and_deleted_users_excluded() -> None:
+    """Bots / Slackbot / deleted accounts must NOT be resolution
+    targets — sending to them would either fail or annoy the wrong
+    person."""
+    client = _FakeClient(
+        members=[
+            {"id": "USLACKBOT", "name": "slackbot", "is_bot": True, "deleted": False, "profile": {}},
+            {"id": "U_BOT", "name": "mybot", "is_bot": True, "deleted": False, "profile": {}},
+            {"id": "U_GHOST", "name": "ghost", "is_bot": False, "deleted": True, "profile": {}},
+        ]
+    )
+    assert await _resolve_target(client=client, target="@slackbot", team_id=None) is None
+    assert await _resolve_target(client=client, target="@mybot", team_id=None) is None
+    assert await _resolve_target(client=client, target="@ghost", team_id=None) is None
+
+
+# ─── Cache behaviour ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_users_list_called_once_then_cache_serves() -> None:
+    """High-traffic queues shouldn't hammer `users.list` — once per
+    process is the contract."""
+    client = _FakeClient(
+        members=[
+            {"id": "U_ALICE", "name": "alice", "is_bot": False, "deleted": False, "profile": {}}
+        ]
+    )
+
+    await _resolve_target(client=client, target="@alice", team_id=None)
+    await _resolve_target(client=client, target="@alice", team_id=None)
+    await _resolve_target(client=client, target="@alice", team_id=None)
+
+    # Only one users.list call across three resolutions.
+    assert client.calls.count("users_list") == 1
+
+
+@pytest.mark.asyncio
+async def test_cache_keyed_by_team() -> None:
+    """Two distinct teams → two distinct caches."""
+    client_a = _FakeClient(
+        members=[{"id": "U_A", "name": "alice", "is_bot": False, "deleted": False, "profile": {}}]
+    )
+    client_b = _FakeClient(
+        members=[{"id": "U_B", "name": "alice", "is_bot": False, "deleted": False, "profile": {}}]
+    )
+
+    out_a = await _resolve_target(client=client_a, target="@alice", team_id="T_AAA")
+    out_b = await _resolve_target(client=client_b, target="@alice", team_id="T_BBB")
+    assert out_a == "U_A"
+    assert out_b == "U_B"
+
+
+# ─── Email resolution ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_email_resolves_via_lookup_by_email() -> None:
+    """Email-shaped targets use the dedicated lookup endpoint, not
+    users.list — cheaper + has its own rate limit."""
+    client = _FakeClient().with_email_lookup("alice@acme.com", "U_ALICE")
+
+    out = await _resolve_target(
+        client=client, target="alice@acme.com", team_id=None
+    )
+    assert out == "U_ALICE"
+    assert "users_lookupByEmail:alice@acme.com" in client.calls
+    # Did NOT fall through to users.list.
+    assert "users_list" not in client.calls
+
+
+@pytest.mark.asyncio
+async def test_unknown_email_returns_none() -> None:
+    client = _FakeClient()  # no email lookup configured
+    out = await _resolve_target(
+        client=client, target="ghost@acme.com", team_id=None
+    )
+    assert out is None


### PR DESCRIPTION
Two friction points surfaced during the slack-native E2E pass.

## 1. Notify by Slack handle (or email)

Before: `notify=["slack:@U01ABC1234"]` required copy-pasting the raw user ID. Slack's `chat.postMessage` doesn't translate handles — raw `@alice` silently fails.

After: handles and emails resolve automatically.

```python
notify=["slack:@alice"]                     # handle (most natural)
notify=["slack:alice@acme.com"]             # email (users.lookupByEmail)
notify=["slack:@U01ABC1234"]                # raw user ID (still works)
```

The notifier's new `_resolve_target` helper:
- Channel sigils (`#general`, `C…`, `G…`) pass through
- User IDs (`U…` / `W…`) pass through with the leading `@` stripped
- Handles → `users.list` lookup with case-insensitive matching against `name` / `display_name` / `real_name`
- Emails → `users.lookupByEmail`
- Per-team cache so high-traffic queues hit `users.list` exactly once per process

13 new tests cover all paths including bot/Slackbot/deleted exclusion and cache hits not re-calling the API.

## 2. Slack-only directory users showed as the raw row ID

Before: a Slack-only user (no email, no display_name) appeared as `fd9b37df9b484e33879ae40c337a086c` in Settings → Users.

After: two fixes layered.

- **user-form.tsx**: when the operator picks from the Slack member dropdown, `display_name` auto-fills from the Slack profile (`real_name` → `display_name` → `name`) when the field is empty. Future users get a human name on file.
- **users.tsx**: extended the headline fallback chain to `display_name → email → @<slack_user_id> → id`. Existing Slack-only users now display as `@U_ALICE` instead of the hex row ID.

## Docs + example updated

`docs/channels/slack.mdx` and `examples/slack-native/README.md` now show the @handle / email / user_id forms side-by-side.

## Test plan

- [x] 13 new resolution tests pass
- [x] Full Python suite green (419 passed)
- [x] Dashboard typecheck clean
- [ ] Manual: create a Slack-only user via the dropdown, verify display name is auto-filled and the row reads cleanly
- [ ] Manual: `notify=["slack:@your-handle"]` posts the DM correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)