### PR TITLE
Derive assignee from notify; validate PUBLIC_URL at boot

### DIFF
--- a/packages/python/awaithumans/server/app.py
+++ b/packages/python/awaithumans/server/app.py
@@ -124,6 +124,17 @@ def create_app(*, serve_dashboard: bool = True) -> FastAPI:
             settings.PUBLIC_URL,
         )
 
+    # PUBLIC_URL must be a base URL (scheme + host[:port]) — no path.
+    # A common misconfiguration: pasting the full Slack OAuth callback
+    # URL (`https://example.com/api/channels/slack/oauth/callback`) into
+    # PUBLIC_URL. That breaks every dashboard click-through (the Slack
+    # message's "Open in dashboard" link becomes
+    # `https://example.com/api/channels/slack/oauth/callback/task?id=…`)
+    # and the OAuth callback redirects to the wrong place. Fail-fast at
+    # boot with a concrete fix instead of letting the operator
+    # debug 404s.
+    _validate_public_url(settings.PUBLIC_URL)
+
     # OAuth stores bot tokens in the DB. Those tokens are encrypted at rest
     # via server/core/encryption.py, which needs PAYLOAD_KEY. Without the
     # key we'd either silently fall back to plaintext (unsafe) or crash on
@@ -264,4 +275,50 @@ def _validate_cors_origins(origins: list[str]) -> None:
             "cookies in cleartext to whichever site the operator listed. "
             "Use https:// only (or http://localhost / http://127.0.0.1 "
             "for local dev)."
+        )
+
+
+def _validate_public_url(url: str) -> None:
+    """Reject `PUBLIC_URL` values that include a path beyond `/`.
+
+    The contract: `PUBLIC_URL` is the base of every URL the server
+    constructs (dashboard click-throughs, OAuth redirects, magic
+    links). Code does `f"{settings.PUBLIC_URL.rstrip('/')}/task?id=…"`
+    and friends. If `PUBLIC_URL` is, say,
+    `https://example.com/api/channels/slack/oauth/callback`, every
+    constructed URL stacks the path and breaks. Operators usually
+    hit this when they paste a full callback URL into the env var
+    instead of just the host.
+
+    Acceptable shapes:
+      https://host
+      https://host:port
+      https://host/         (trailing slash tolerated)
+      http://localhost
+      http://localhost:3001
+
+    Rejected:
+      https://host/api/...
+      https://host/anything-besides-a-trailing-slash
+      missing scheme
+      empty
+    """
+    if not url:
+        raise RuntimeError(
+            "AWAITHUMANS_PUBLIC_URL is unset. Set it to the base URL the "
+            "dashboard is reachable at, e.g. http://localhost:3001 in dev "
+            "or https://reviews.your-company.com in production."
+        )
+
+    valid = re.compile(r"^https?://[A-Za-z0-9.\-]+(:\d+)?/?$")
+    if not valid.match(url):
+        raise RuntimeError(
+            f"AWAITHUMANS_PUBLIC_URL='{url}' is not a base URL — it must "
+            "be scheme + host + optional port, with no path. A common "
+            "mistake is pasting the full Slack OAuth callback URL "
+            "(`/api/channels/slack/oauth/callback`) into this variable; "
+            "use just the host portion. Examples:\n"
+            "  http://localhost:3001\n"
+            "  https://reviews.your-company.com\n"
+            "  https://abcd1234.ngrok-free.app"
         )

--- a/packages/python/awaithumans/server/channels/slack/notifier.py
+++ b/packages/python/awaithumans/server/channels/slack/notifier.py
@@ -5,14 +5,8 @@ Parses the task's `notify` list for Slack routes, resolves the workspace
 `slack+T123456:#channel` to disambiguate multi-workspace setups), and
 posts the initial message.
 
-DM target resolution (`slack:@alice`):
-  Slack's `chat.postMessage` only accepts a real user ID (`U…` / `W…`)
-  in the `channel` argument; it doesn't resolve handles. So when the
-  notify entry is `slack:@alice` we hit `users.list` once, find the
-  member by handle, and post to their user_id. Cached per-team for
-  the process lifetime so a high-traffic queue doesn't burn the
-  `users.list` rate limit. Fallback to `users.lookupByEmail` when
-  the target looks like an email.
+DM target resolution (`slack:@alice`) lives in `resolution.py` so it
+can be reused by the task router for implicit-assignee derivation.
 
 Runs in a FastAPI BackgroundTask after the response is sent, so a slow
 Slack API call never blocks task creation and a Slack outage doesn't
@@ -23,7 +17,6 @@ because the caller's session has already been released by the time we run.
 from __future__ import annotations
 
 import logging
-import re
 from typing import TYPE_CHECKING, Any
 
 from awaithumans.forms import FormDefinition, unsupported_fields
@@ -33,6 +26,7 @@ from awaithumans.server.channels.slack.client import (
     get_client_for_team,
     get_default_client,
 )
+from awaithumans.server.channels.slack.resolution import resolve_slack_target
 from awaithumans.server.core.config import settings
 from awaithumans.server.db.connection import get_async_session_factory
 from awaithumans.utils.constants import (
@@ -45,18 +39,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger("awaithumans.server.channels.slack.notifier")
-
-# Slack user IDs are `U…` (regular user) or `W…` (Enterprise Grid).
-# Anything else after a `@` is treated as a handle and resolved.
-_USER_ID_RE = re.compile(r"^[UW][A-Z0-9]{5,}$")
-_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
-
-# Per-team cache of (handle → user_id) lookups. Populated lazily on
-# first miss; persists for the process lifetime. Slack's user list
-# changes rarely; rotating staff is fine — a stale entry just means
-# the DM goes to the right person who happens to have a new handle.
-# Process restart clears the cache, which is the right invalidation.
-_HANDLE_CACHE: dict[str, dict[str, str]] = {}
 
 
 async def notify_task(
@@ -111,7 +93,7 @@ async def notify_task(
             # Resolve `@handle` / `email` to a real user_id before
             # posting. Slack's chat.postMessage doesn't do handle
             # resolution itself — sending to `@alice` silently fails.
-            target = await _resolve_target(
+            target = await resolve_slack_target(
                 client=client,
                 target=route.target,
                 team_id=route.identity,
@@ -177,146 +159,3 @@ def _parse_form(form_definition: dict[str, Any] | None) -> FormDefinition | None
     except Exception as exc:  # noqa: BLE001
         logger.warning("Invalid form_definition on task: %s", exc)
         return None
-
-
-async def _resolve_target(
-    *,
-    client: AsyncWebClient,
-    target: str,
-    team_id: str | None,
-) -> str | None:
-    """Resolve a notify target to something `chat.postMessage` accepts.
-
-    Channel sigils (`#general`, raw `C…` / `G…` IDs) pass through
-    unchanged. User IDs (`@U…`, `U…`) pass through with the leading
-    `@` stripped — Slack doesn't want it in the channel argument.
-    Anything else after `@` is a handle (`@alice`) and gets resolved
-    via `users.list`. Email-shaped targets use `users.lookupByEmail`.
-
-    Returns None when resolution fails (handle not in workspace,
-    Slack rejected the call, etc.) — the caller logs and skips."""
-    # Channel sigil — broadcast targets pass through unchanged.
-    if target.startswith("#"):
-        return target
-
-    # Strip the leading `@` if present so we can match against IDs /
-    # handles uniformly.
-    body = target.removeprefix("@")
-
-    # Already a real user ID? (`U…` / `W…` followed by alnum)
-    if _USER_ID_RE.match(body):
-        return body
-
-    # Raw channel-ID shape — public, private, or group DM.
-    if body.startswith(("C", "G")) and body[1:].isalnum():
-        return body
-
-    # Email shape — Slack has a dedicated lookup for that.
-    if _EMAIL_RE.match(body):
-        return await _resolve_by_email(client=client, email=body, team_id=team_id)
-
-    # Falls through to handle lookup via users.list.
-    return await _resolve_by_handle(client=client, handle=body, team_id=team_id)
-
-
-async def _resolve_by_email(
-    *, client: AsyncWebClient, email: str, team_id: str | None
-) -> str | None:
-    """Use Slack's `users.lookupByEmail` for email-shaped targets.
-
-    Cheaper than walking `users.list` and uses a dedicated endpoint
-    that doesn't count against the bulk-list rate limit."""
-    try:
-        from slack_sdk.errors import SlackApiError
-
-        try:
-            resp = await client.users_lookupByEmail(email=email)
-        except SlackApiError as exc:
-            logger.warning(
-                "users.lookupByEmail failed for %s (team=%s): %s",
-                email,
-                team_id,
-                exc.response.get("error", exc),
-            )
-            return None
-    except ImportError:
-        logger.error("slack_sdk not installed; can't resolve %s", email)
-        return None
-
-    user = resp.get("user") or {}
-    user_id = user.get("id")
-    return user_id if isinstance(user_id, str) else None
-
-
-async def _resolve_by_handle(
-    *, client: AsyncWebClient, handle: str, team_id: str | None
-) -> str | None:
-    """Resolve a Slack handle (e.g. `alice`, `alice.singh`) to a user_id.
-
-    Compares against `name`, `profile.display_name`, and
-    `profile.real_name` (case-insensitive) so any of the three
-    "names" the operator might know works. Caches the lookup table
-    per-team for the process lifetime — `users.list` is rate-limited
-    and the team rarely changes during a single deploy."""
-    cache_key = team_id or "__default__"
-    cached = _HANDLE_CACHE.get(cache_key)
-
-    if cached is None:
-        cached = await _build_handle_index(client=client, cache_key=cache_key)
-        if cached is None:
-            return None  # API call failed; logged in helper
-
-    # Match case-insensitively, both with and without leading `@`.
-    needle = handle.lstrip("@").lower()
-    return cached.get(needle)
-
-
-async def _build_handle_index(
-    *, client: AsyncWebClient, cache_key: str
-) -> dict[str, str] | None:
-    """Walk `users.list` once, build a {handle_lower: user_id} map.
-
-    Skips bots, deleted users, and the Slackbot pseudo-user. Indexes
-    each member by every name field they have so the operator can
-    use whichever's familiar."""
-    try:
-        from slack_sdk.errors import SlackApiError
-
-        try:
-            resp = await client.users_list()
-        except SlackApiError as exc:
-            logger.warning(
-                "users.list failed for team=%s: %s",
-                cache_key,
-                exc.response.get("error", exc),
-            )
-            return None
-    except ImportError:
-        logger.error("slack_sdk not installed; handle resolution unavailable")
-        return None
-
-    index: dict[str, str] = {}
-    for m in resp.get("members", []) or []:
-        if m.get("deleted") or m.get("is_bot") or m.get("id") == "USLACKBOT":
-            continue
-        user_id = m.get("id")
-        if not isinstance(user_id, str):
-            continue
-        # `name` (the @handle), plus the two display fields a user
-        # might have set. Case-insensitive lookup so `@Alice` and
-        # `@alice` both resolve.
-        for raw in (
-            m.get("name"),
-            (m.get("profile") or {}).get("display_name"),
-            (m.get("profile") or {}).get("real_name"),
-        ):
-            if isinstance(raw, str) and raw:
-                index[raw.lower()] = user_id
-
-    _HANDLE_CACHE[cache_key] = index
-    logger.info(
-        "Indexed %d Slack handles for team=%s (cached for process lifetime)",
-        len(index),
-        cache_key,
-    )
-    return index

--- a/packages/python/awaithumans/server/channels/slack/resolution.py
+++ b/packages/python/awaithumans/server/channels/slack/resolution.py
@@ -1,0 +1,185 @@
+"""Slack target resolution — turn `notify=` strings into IDs Slack accepts.
+
+Public surface: `resolve_slack_target(client, target, team_id)` returns
+the user / channel ID that `chat.postMessage` and friends will accept,
+or None if resolution failed.
+
+Resolution paths:
+
+  - Channel sigil (`#general`, raw `C…` / `G…` IDs) → pass through.
+  - User IDs (`@U…`, `U…`) → strip the `@` and pass through.
+  - Email-shaped target → `users.lookupByEmail`.
+  - Anything else after `@` → handle lookup via `users.list`,
+    matching case-insensitively against `name`,
+    `profile.display_name`, and `profile.real_name`.
+
+The handle index is cached per-team for the process lifetime — Slack
+rosters change rarely and `users.list` is bulk-rate-limited. Process
+restart clears the cache, which is the right invalidation cadence
+(staff changes are infrequent enough that "restart to refresh" is
+acceptable; Slack quotas matter more).
+
+Used by:
+  - `channels/slack/notifier.py` — to translate `notify=` targets
+    before posting.
+  - `services/task_router.py` — to derive an implicit assignee when
+    `notify=` is a single Slack DM target and `assign_to` is None.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from slack_sdk.web.async_client import AsyncWebClient
+
+logger = logging.getLogger("awaithumans.server.channels.slack.resolution")
+
+# Slack user IDs are `U…` (regular) or `W…` (Enterprise Grid).
+_USER_ID_RE = re.compile(r"^[UW][A-Z0-9]{5,}$")
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+# Per-team cache of (handle_lower → user_id). Populated lazily on
+# first miss. Process-lifetime — Slack rosters change rarely.
+_HANDLE_CACHE: dict[str, dict[str, str]] = {}
+
+
+def _cache_key_for(team_id: str | None) -> str:
+    return team_id or "__default__"
+
+
+def clear_handle_cache(team_id: str | None = None) -> None:
+    """Wipe the cache for one team (or all teams if team_id is None).
+
+    Used by tests; in production the cache is process-lifetime."""
+    if team_id is None:
+        _HANDLE_CACHE.clear()
+        return
+    _HANDLE_CACHE.pop(_cache_key_for(team_id), None)
+
+
+async def resolve_slack_target(
+    *,
+    client: AsyncWebClient,
+    target: str,
+    team_id: str | None,
+) -> str | None:
+    """Resolve a notify/route target to something `chat.postMessage` accepts.
+
+    Returns None on miss — the caller logs and skips. Channel sigils
+    pass through unchanged; user IDs are stripped of the leading `@`.
+    """
+    # Channel broadcast — no resolution needed.
+    if target.startswith("#"):
+        return target
+
+    body = target.removeprefix("@")
+
+    # Already a real user ID? (`U…` / `W…` followed by alnum)
+    if _USER_ID_RE.match(body):
+        return body
+
+    # Raw channel-ID shape — public, private, or group DM.
+    if body.startswith(("C", "G")) and body[1:].isalnum():
+        return body
+
+    # Email shape — Slack has a dedicated lookup endpoint.
+    if _EMAIL_RE.match(body):
+        return await _resolve_by_email(client=client, email=body, team_id=team_id)
+
+    # Falls through to handle lookup via users.list.
+    return await _resolve_by_handle(client=client, handle=body, team_id=team_id)
+
+
+async def _resolve_by_email(
+    *, client: AsyncWebClient, email: str, team_id: str | None
+) -> str | None:
+    """Use Slack's `users.lookupByEmail` for email-shaped targets."""
+    try:
+        from slack_sdk.errors import SlackApiError
+    except ImportError:
+        logger.error("slack_sdk not installed; can't resolve %s", email)
+        return None
+
+    try:
+        resp = await client.users_lookupByEmail(email=email)
+    except SlackApiError as exc:
+        logger.warning(
+            "users.lookupByEmail failed for %s (team=%s): %s",
+            email,
+            team_id,
+            exc.response.get("error", exc),
+        )
+        return None
+
+    user = resp.get("user") or {}
+    user_id = user.get("id")
+    return user_id if isinstance(user_id, str) else None
+
+
+async def _resolve_by_handle(
+    *, client: AsyncWebClient, handle: str, team_id: str | None
+) -> str | None:
+    """Resolve a Slack handle (e.g. `alice`, `alice.singh`) to a user_id.
+
+    Compares case-insensitively against `name`, `profile.display_name`,
+    and `profile.real_name` so any of the three name fields works."""
+    cache_key = _cache_key_for(team_id)
+    cached = _HANDLE_CACHE.get(cache_key)
+
+    if cached is None:
+        cached = await _build_handle_index(client=client, cache_key=cache_key)
+        if cached is None:
+            return None  # API call failed; logged in helper
+
+    needle = handle.lstrip("@").lower()
+    return cached.get(needle)
+
+
+async def _build_handle_index(
+    *, client: AsyncWebClient, cache_key: str
+) -> dict[str, str] | None:
+    """Walk `users.list` once, build a {handle_lower: user_id} map.
+
+    Skips bots, deleted users, and the Slackbot pseudo-user. Indexes
+    each member by every name field they have."""
+    try:
+        from slack_sdk.errors import SlackApiError
+    except ImportError:
+        logger.error("slack_sdk not installed; handle resolution unavailable")
+        return None
+
+    try:
+        resp = await client.users_list()
+    except SlackApiError as exc:
+        logger.warning(
+            "users.list failed for team=%s: %s",
+            cache_key,
+            exc.response.get("error", exc),
+        )
+        return None
+
+    index: dict[str, str] = {}
+    for m in resp.get("members", []) or []:
+        if m.get("deleted") or m.get("is_bot") or m.get("id") == "USLACKBOT":
+            continue
+        user_id = m.get("id")
+        if not isinstance(user_id, str):
+            continue
+        for raw in (
+            m.get("name"),
+            (m.get("profile") or {}).get("display_name"),
+            (m.get("profile") or {}).get("real_name"),
+        ):
+            if isinstance(raw, str) and raw:
+                index[raw.lower()] = user_id
+
+    _HANDLE_CACHE[cache_key] = index
+    logger.info(
+        "Indexed %d Slack handles for team=%s (cached for process lifetime)",
+        len(index),
+        cache_key,
+    )
+    return index

--- a/packages/python/awaithumans/server/services/task_router.py
+++ b/packages/python/awaithumans/server/services/task_router.py
@@ -16,10 +16,13 @@ Three input shapes, resolved in priority order:
    race safely (Postgres — last committer wins on the row, second
    pick reads the fresh timestamp).
 
-3. `assign_to = None` OR no matching user — task stays unassigned
-   (`assigned_to_email = None`, `assigned_to_user_id = None`). The
-   operator can assign it manually from the dashboard, or a broadcast
-   channel (PR B) can be claimed by whoever picks it up first.
+3. `assign_to = None` OR no matching user — first try to derive an
+   implicit assignee from `notify` (see `derive_implicit_assignee`).
+   If `notify` is a single Slack DM target that resolves to a
+   directory user, they become the assignee. Otherwise the task
+   stays unassigned (`assigned_to_email = None`, `assigned_to_user_id
+   = None`); the operator can assign it manually from the dashboard,
+   or a broadcast channel can be claimed by whoever picks it up first.
 
 Notification semantics (read by the channels layer):
 
@@ -168,3 +171,127 @@ def _result_from_user(user: User) -> RoutingResult:
         slack_team_id=user.slack_team_id,
         slack_user_id=user.slack_user_id,
     )
+
+
+# ─── Implicit assignee from notify ───────────────────────────────────
+
+
+async def derive_implicit_assignee(
+    session: AsyncSession,
+    notify: list[str] | None,
+) -> RoutingResult:
+    """Infer an assignee when the developer used `notify=` to point at
+    a single specific person but didn't pass `assign_to=`.
+
+    `notify=["slack:@alice"]` means "send a DM to alice." The
+    developer's mental model is *also* "alice is responsible for
+    this task." Without inference, the dashboard's "Assigned to"
+    column is empty and the Slack auth check rejects alice's
+    submission ("not assigned to you"). The fix: derive the
+    assignee at task-creation time when:
+
+      - notify has exactly one entry, AND
+      - that entry is a Slack channel route, AND
+      - the target is a DM (handle, email, or user_id — not a
+        channel sigil), AND
+      - the target resolves to a real Slack user, AND
+      - that user exists in the awaithumans directory and is active.
+
+    Anything else returns an empty `RoutingResult` and the task
+    stays unassigned. Notably:
+
+      - Multiple notify entries → ambiguous; don't guess.
+      - `slack:#channel` → broadcast; the claim flow is the right
+        path.
+      - Resolves to a Slack user not in the directory → can't pin
+        an assignee_user_id; we still post the DM (the notifier
+        has its own resolution layer), but the task stays
+        unassigned. Operator can add the user later if they want
+        the routing tracked.
+    """
+    if not notify or len(notify) != 1:
+        return RoutingResult(user_id=None, email=None)
+
+    # Lazy import to avoid pulling routing into modules that don't
+    # need the channels layer (e.g. CLI).
+    from awaithumans.server.channels.routing import parse_route
+    from awaithumans.server.channels.slack.client import (
+        get_client_for_team,
+        get_default_client,
+    )
+    from awaithumans.server.channels.slack.resolution import resolve_slack_target
+
+    route = parse_route(notify[0])
+    if route is None or route.channel != "slack":
+        return RoutingResult(user_id=None, email=None)
+
+    # Channel sigils (`#general`, raw `C…`/`G…`) are broadcasts; the
+    # claim flow assigns at click time, not creation time.
+    target = route.target
+    body = target.removeprefix("@") if target.startswith("@") else target
+    if target.startswith("#") or (body.startswith(("C", "G")) and body[1:].isalnum()):
+        return RoutingResult(user_id=None, email=None)
+
+    # Resolve target → real Slack user_id. May call users.list /
+    # users.lookupByEmail under the hood; cached per-team.
+    client = (
+        await get_client_for_team(session, route.identity)
+        if route.identity
+        else await get_default_client(session)
+    )
+    if client is None:
+        # No Slack client configured — nothing to derive.
+        return RoutingResult(user_id=None, email=None)
+
+    resolved = await resolve_slack_target(
+        client=client, target=route.target, team_id=route.identity
+    )
+    if resolved is None or not resolved.startswith(("U", "W")):
+        return RoutingResult(user_id=None, email=None)
+
+    # Look up directory user by slack_user_id. team_id constraint is
+    # nice-to-have but not required — a user_id is workspace-unique
+    # in practice for self-hosted single-workspace setups, and the
+    # multi-workspace case still has the unique constraint on
+    # (slack_team_id, slack_user_id) so over-matching is impossible.
+    user = await _get_by_slack_user_id(
+        session,
+        slack_user_id=resolved,
+        slack_team_id=route.identity,
+    )
+    if user is None or not user.active:
+        logger.info(
+            "derive_implicit_assignee: notify=%s resolved to %s but no "
+            "active directory user matches; task stays unassigned.",
+            notify[0],
+            resolved,
+        )
+        return RoutingResult(user_id=None, email=None)
+
+    logger.info(
+        "derive_implicit_assignee: notify=%s → user_id=%s (%s)",
+        notify[0],
+        user.id,
+        user.email or user.display_name or user.id,
+    )
+    return _result_from_user(user)
+
+
+async def _get_by_slack_user_id(
+    session: AsyncSession,
+    *,
+    slack_user_id: str,
+    slack_team_id: str | None,
+) -> User | None:
+    """Look up a directory user by Slack user_id.
+
+    When `slack_team_id` is provided (multi-workspace OAuth case),
+    we filter on both — the unique constraint is on the pair. When
+    it's None (static-token / default workspace), we filter only
+    on user_id. In static-token mode there's only one workspace by
+    construction so the over-match risk is zero."""
+    stmt = select(User).where(User.slack_user_id == slack_user_id)
+    if slack_team_id:
+        stmt = stmt.where(User.slack_team_id == slack_team_id)
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()

--- a/packages/python/awaithumans/server/services/task_service.py
+++ b/packages/python/awaithumans/server/services/task_service.py
@@ -23,7 +23,10 @@ from awaithumans.server.services.exceptions import (
     TaskAlreadyTerminalError,
     TaskNotFoundError,
 )
-from awaithumans.server.services.task_router import resolve_assign_to
+from awaithumans.server.services.task_router import (
+    derive_implicit_assignee,
+    resolve_assign_to,
+)
 from awaithumans.server.services.task_verifier import (
     VerifierOutcome,
     audit_action_for,
@@ -65,6 +68,17 @@ async def create_task(
     # session; committing the task and the bump together keeps Option C
     # fairness in step with task creation.
     route = await resolve_assign_to(session, assign_to)
+
+    # If the developer didn't pin an assignee but DID `notify=` a
+    # specific person via Slack, treat that person as the assignee.
+    # `notify=["slack:@alice"]` is the natural shorthand for "alice
+    # is responsible" — without this, alice gets DMed but the
+    # dashboard's "Assigned to" stays empty AND the Slack auth
+    # check rejects her submission. See `derive_implicit_assignee`.
+    if route.user_id is None and route.email is None:
+        implicit = await derive_implicit_assignee(session, notify)
+        if implicit.user_id is not None or implicit.email is not None:
+            route = implicit
 
     # Create the task
     now = datetime.now(timezone.utc)

--- a/packages/python/tests/core/test_cors_validation.py
+++ b/packages/python/tests/core/test_cors_validation.py
@@ -1,4 +1,4 @@
-"""CORS origin validation refuses unsafe configurations at boot.
+"""CORS origin + PUBLIC_URL validation at boot.
 
 The middleware in `app.py` flips `allow_credentials` ON the moment the
 origin list isn't a bare `*`. Without validation, any operator who
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import pytest
 
-from awaithumans.server.app import _validate_cors_origins
+from awaithumans.server.app import _validate_cors_origins, _validate_public_url
 
 
 # ─── Acceptable configs ──────────────────────────────────────────────
@@ -75,3 +75,54 @@ def test_origin_with_path_refused() -> None:
     """CORS origins must be scheme + host + optional port — no path."""
     with pytest.raises(RuntimeError):
         _validate_cors_origins(["https://app.acme.com/api"])
+
+
+# ─── PUBLIC_URL validation ───────────────────────────────────────────
+
+
+class TestPublicUrlValidation:
+    """`PUBLIC_URL` must be scheme + host + optional port — no path.
+
+    Operators commonly paste the full Slack OAuth callback URL into
+    this env var, which then breaks every constructed URL (dashboard
+    click-throughs become `/api/channels/slack/oauth/callback/task?id=…`).
+    Fail at boot with a clear fix instead of letting them debug 404s."""
+
+    def test_localhost_dev_accepted(self) -> None:
+        _validate_public_url("http://localhost:3001")
+        _validate_public_url("http://localhost")
+
+    def test_loopback_accepted(self) -> None:
+        _validate_public_url("http://127.0.0.1:3001")
+
+    def test_https_host_accepted(self) -> None:
+        _validate_public_url("https://reviews.acme.com")
+        _validate_public_url("https://reviews.acme.com:8443")
+
+    def test_ngrok_subdomain_accepted(self) -> None:
+        _validate_public_url("https://abcd1234.ngrok-free.app")
+
+    def test_trailing_slash_tolerated(self) -> None:
+        _validate_public_url("https://reviews.acme.com/")
+
+    def test_full_oauth_callback_url_refused(self) -> None:
+        """The classic operator footgun: pasting the OAuth redirect URL
+        instead of the base. Server constructs every URL by joining
+        PUBLIC_URL + path, so this would yield `…/api/channels/slack/
+        oauth/callback/task?id=…` for the dashboard link."""
+        with pytest.raises(RuntimeError, match="not a base URL"):
+            _validate_public_url(
+                "https://example.com/api/channels/slack/oauth/callback"
+            )
+
+    def test_path_segment_refused(self) -> None:
+        with pytest.raises(RuntimeError, match="not a base URL"):
+            _validate_public_url("https://example.com/something")
+
+    def test_empty_refused(self) -> None:
+        with pytest.raises(RuntimeError, match="is unset"):
+            _validate_public_url("")
+
+    def test_missing_scheme_refused(self) -> None:
+        with pytest.raises(RuntimeError, match="not a base URL"):
+            _validate_public_url("reviews.acme.com")

--- a/packages/python/tests/slack/test_notifier_target_resolution.py
+++ b/packages/python/tests/slack/test_notifier_target_resolution.py
@@ -20,9 +20,9 @@ from __future__ import annotations
 
 import pytest
 
-from awaithumans.server.channels.slack.notifier import (
+from awaithumans.server.channels.slack.resolution import (
     _HANDLE_CACHE,
-    _resolve_target,
+    resolve_slack_target as _resolve_target,
 )
 
 

--- a/packages/python/tests/users/test_implicit_assignee.py
+++ b/packages/python/tests/users/test_implicit_assignee.py
@@ -1,0 +1,221 @@
+"""Implicit assignee derivation from `notify=` Slack DM target.
+
+The contract: when a developer writes
+`notify=["slack:@alice"]` and doesn't pass `assign_to=`, the task
+should treat alice as the assignee. Without this, the dashboard's
+"Assigned to" stays empty AND the Slack auth check rejects alice's
+submission ("not assigned to you").
+
+Three things the tests pin:
+
+  - Single Slack DM target → assignee derived (handle, email, U_ID).
+  - Channel sigils, multi-target notify lists, and unknown directory
+    users all stay unassigned (correct fallback to claim flow).
+  - When `assign_to=` IS provided, derivation never overrides — the
+    explicit assignment wins.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+from awaithumans.server.channels.slack.resolution import clear_handle_cache
+from awaithumans.server.db.models import (  # noqa: F401 — register models
+    AuditEntry,
+    EmailSenderIdentity,
+    SlackInstallation,
+    Task,
+    User,
+)
+from awaithumans.server.services.task_router import derive_implicit_assignee
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    clear_handle_cache()
+    yield
+    clear_handle_cache()
+
+
+@pytest_asyncio.fixture
+async def session() -> AsyncGenerator[AsyncSession, None]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+async def _seed_user(
+    session: AsyncSession,
+    *,
+    email: str | None = None,
+    slack_user_id: str | None = None,
+    active: bool = True,
+) -> User:
+    user = User(
+        email=email,
+        slack_user_id=slack_user_id,
+        slack_team_id=None,
+        active=active,
+    )
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+    return user
+
+
+def _patch_slack(*, resolved_user_id: str | None):
+    """Patch the channel layer so derive_implicit_assignee can run
+    without a real Slack client. Returns the patches as a context."""
+    fake_client = object()
+    return [
+        patch(
+            "awaithumans.server.channels.slack.client.get_default_client",
+            new=AsyncMock(return_value=fake_client),
+        ),
+        patch(
+            "awaithumans.server.channels.slack.client.get_client_for_team",
+            new=AsyncMock(return_value=fake_client),
+        ),
+        patch(
+            "awaithumans.server.channels.slack.resolution.resolve_slack_target",
+            new=AsyncMock(return_value=resolved_user_id),
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_handle_with_directory_match_becomes_assignee(
+    session: AsyncSession,
+) -> None:
+    alice = await _seed_user(
+        session, email="alice@acme.com", slack_user_id="U_ALICE"
+    )
+    with _patch_slack(resolved_user_id="U_ALICE")[0], _patch_slack(
+        resolved_user_id="U_ALICE"
+    )[1], _patch_slack(resolved_user_id="U_ALICE")[2]:
+        result = await derive_implicit_assignee(session, ["slack:@alice"])
+
+    assert result.user_id == alice.id
+    assert result.email == "alice@acme.com"
+
+
+@pytest.mark.asyncio
+async def test_email_target_resolves_to_directory_user(
+    session: AsyncSession,
+) -> None:
+    bob = await _seed_user(
+        session, email="bob@acme.com", slack_user_id="U_BOB"
+    )
+    with _patch_slack(resolved_user_id="U_BOB")[0], _patch_slack(
+        resolved_user_id="U_BOB"
+    )[1], _patch_slack(resolved_user_id="U_BOB")[2]:
+        result = await derive_implicit_assignee(
+            session, ["slack:bob@acme.com"]
+        )
+
+    assert result.user_id == bob.id
+
+
+@pytest.mark.asyncio
+async def test_user_id_target_resolves_directly(
+    session: AsyncSession,
+) -> None:
+    """`slack:@U_ALICE` → no need to call Slack API; the resolver
+    returns the user_id as-is. The directory lookup still has to find
+    the row."""
+    alice = await _seed_user(session, slack_user_id="U_ALICE")
+    with _patch_slack(resolved_user_id="U_ALICE")[0], _patch_slack(
+        resolved_user_id="U_ALICE"
+    )[1], _patch_slack(resolved_user_id="U_ALICE")[2]:
+        result = await derive_implicit_assignee(session, ["slack:@U_ALICE"])
+
+    assert result.user_id == alice.id
+
+
+@pytest.mark.asyncio
+async def test_channel_sigil_does_not_derive(session: AsyncSession) -> None:
+    """`slack:#approvals` is a broadcast — first-claim-wins flow handles
+    assignment at click time, not at task creation. We must NOT pick
+    a random directory user."""
+    await _seed_user(session, email="alice@acme.com", slack_user_id="U_ALICE")
+    result = await derive_implicit_assignee(session, ["slack:#approvals"])
+    assert result.user_id is None
+    assert result.email is None
+
+
+@pytest.mark.asyncio
+async def test_multiple_notify_entries_does_not_derive(
+    session: AsyncSession,
+) -> None:
+    """Multi-channel notify is ambiguous — operator clearly wanted
+    notification fan-out. Picking one as "the" assignee would be
+    wrong; stay unassigned and let the operator route manually if
+    they care."""
+    await _seed_user(session, email="alice@acme.com", slack_user_id="U_ALICE")
+    result = await derive_implicit_assignee(
+        session, ["slack:@alice", "email:bob@acme.com"]
+    )
+    assert result.user_id is None
+
+
+@pytest.mark.asyncio
+async def test_target_not_in_directory_returns_empty(
+    session: AsyncSession,
+) -> None:
+    """Slack resolves @ghost → U_GHOST, but no directory user has
+    that slack_user_id. The notifier still posts the DM (it does
+    its own resolution); but we can't pin an `assigned_to_user_id`
+    so the task stays unassigned. Operator can add the user later."""
+    with _patch_slack(resolved_user_id="U_GHOST")[0], _patch_slack(
+        resolved_user_id="U_GHOST"
+    )[1], _patch_slack(resolved_user_id="U_GHOST")[2]:
+        result = await derive_implicit_assignee(session, ["slack:@ghost"])
+    assert result.user_id is None
+
+
+@pytest.mark.asyncio
+async def test_inactive_directory_user_skipped(
+    session: AsyncSession,
+) -> None:
+    """An inactive user in the directory must not be assigned a new
+    task — that's the whole point of toggling `active=False`."""
+    await _seed_user(
+        session, email="alice@acme.com", slack_user_id="U_ALICE", active=False
+    )
+    with _patch_slack(resolved_user_id="U_ALICE")[0], _patch_slack(
+        resolved_user_id="U_ALICE"
+    )[1], _patch_slack(resolved_user_id="U_ALICE")[2]:
+        result = await derive_implicit_assignee(session, ["slack:@alice"])
+    assert result.user_id is None
+
+
+@pytest.mark.asyncio
+async def test_email_channel_does_not_derive(session: AsyncSession) -> None:
+    """`notify=["email:alice@..."]` doesn't go through the Slack
+    resolver — different channel, different lookup story. Stay
+    unassigned. (Future: add an email-channel derivation if there's
+    demand.)"""
+    await _seed_user(session, email="alice@acme.com")
+    result = await derive_implicit_assignee(
+        session, ["email:alice@acme.com"]
+    )
+    assert result.user_id is None
+
+
+@pytest.mark.asyncio
+async def test_empty_notify_returns_empty(session: AsyncSession) -> None:
+    result = await derive_implicit_assignee(session, None)
+    assert result.user_id is None
+    result = await derive_implicit_assignee(session, [])
+    assert result.user_id is None


### PR DESCRIPTION
Two fixes from the slack-native E2E pass.

## 1. `notify=["slack:@TA"]` now sets the assignee

Before: the dashboard's "Assigned to" stayed empty even when `notify=` named one specific person via DM, and the Slack auth check then rejected that person's "Open in Slack" click ("not assigned to you").

After: when `assign_to` didn't pin a user AND `notify` has exactly one Slack DM target, the target is resolved (handle / email / user_id) and matched against the directory. If an active user's `slack_user_id` matches, they become the assignee.

Skipped when:
- notify has 0 or 2+ entries (ambiguous)
- target is a channel sigil (`#approvals` — claim flow handles it)
- resolved Slack user not in the directory or inactive
- notify is non-Slack (email channel — different lookup story)

## 2. `PUBLIC_URL` validated at boot

Classic operator footgun: pasting the full Slack OAuth callback URL into the env var instead of just `https://your-host`. Every constructed URL stacks the path and breaks. The dashboard click-through becomes `…/api/channels/slack/oauth/callback/task?id=…` and 404s.

`_validate_public_url` now rejects path segments at boot with an actionable error message and example values.

## Refactor

Moved `_resolve_target` and the handle cache from `channels/slack/notifier.py` to `channels/slack/resolution.py` so both the notifier and the new task-router derivation use the same code path and cache. Same wire format, same fallbacks.

## Tests

- 9 new tests for `derive_implicit_assignee`: handle / email / user_id paths, channel-sigil bypass, multi-entry skip, missing-directory-user fallback, inactive user skipped
- 9 new tests for `_validate_public_url`: localhost/loopback/https/ngrok accepted; OAuth-callback / path / empty / missing-scheme rejected
- Existing slack notifier tests rewired to import from the new resolution module

Full Python suite: 437 passed (was 419).

## Test plan

- [x] Fast suite green
- [x] Existing dev workflows (PUBLIC_URL=`http://localhost:3001`) still pass the new validator
- [ ] Manual: with `notify=["slack:@TA"]`, the dashboard now shows TA as assignee and "Open in Slack" works without the "not assigned to you" rejection
- [ ] Manual: setting `PUBLIC_URL=https://...whatever/api/channels/slack/oauth/callback` causes a clean fail-fast with a concrete fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)