### PR TITLE
Email channel: file transport + TypeScript end-to-end smoke test

### DIFF
--- a/examples/email-smoke/README.md
+++ b/examples/email-smoke/README.md
@@ -9,26 +9,19 @@ email path. No mocks; runs against a real `awaithumans dev` server.
 1. Creates an email sender identity using the `file` transport — emails
    are written to a tmp directory instead of being shipped through Resend
    or SMTP. Lets the test capture them deterministically.
-2. Calls `awaitHuman` from the TS SDK with `notify=["email+<id>:..."]`,
-   then immediately starts polling the tmp dir for the rendered email.
-3. Asserts on the captured email's content (task title, payload fields,
-   dashboard link). Confirms the renderer didn't regress on a known good
-   shape.
-4. Completes the task via the admin API; `awaitHuman`'s long-poll
-   resolves with the typed response. Asserts `approved === true`.
+2. Calls `awaitHuman` from the TS SDK with a single-Switch response
+   schema and `notify=["email+<id>:..."]`. The TS SDK now synthesizes a
+   `form_definition` from the Zod schema, so the email renderer emits
+   Approve / Reject magic-link buttons (not the link-out fallback).
+3. Polls the tmp dir for the captured email; asserts on its content
+   (task title, payload), then parses out the Approve magic-link URL.
+4. POSTs the magic-link URL — the public action endpoint completes the
+   task with `approved=true` baked into the signed token.
+5. `awaitHuman`'s long-poll resolves with the typed response. Asserts
+   `approved === true`.
 
 If any step fails, the test exits non-zero with the detail. The email
 identity is cleaned up on both success and failure.
-
-### Why admin-API completion instead of clicking the magic-link button?
-
-The TS SDK doesn't yet synthesize a `form_definition` from a Zod schema
-— Python has `extract_form` (Pydantic-driven), the TS port is
-post-launch work. Without that, the email renderer falls back to a
-"Review in dashboard" link-out and never emits Approve/Reject magic-link
-buttons. Once form synthesis lands in the TS SDK, this script will
-switch to clicking the button instead. The magic-link click path itself
-has full Python coverage in `tests/email/`.
 
 ## Run it
 
@@ -57,9 +50,9 @@ Expected output:
 → created email identity 'smoke-...' (file transport)
 → captured email: subject="Review: Approve wire transfer (smoke test)" to=smoke-recipient@example.test
 → email body content checks: OK
-→ resolved task_id=...
-→ completed task ... via admin API
-✓ smoke pass: TS SDK created task → email captured → SDK polled → resolved
+→ magic-link URL: http://localhost:3001/api/channels/email/action/...
+→ POSTed magic-link → 200
+✓ smoke pass: TS SDK + email channel + magic-link round-trip
 ```
 
 ## Knobs
@@ -85,11 +78,16 @@ Expected output:
 ## What this catches that unit tests don't
 
 - Wire-format drift between the TS SDK and Python server schemas
+- The TS SDK's `extractForm` synthesizing a Switch shape the email
+  renderer actually accepts (the magic-link decision tree only fires
+  on a single Switch / small SingleSelect)
 - The notify route parser accepting the `email+<identity>:<target>`
   syntax against a real DB row
-- The email renderer actually rendering against a real task — task
-  title, payload table, dashboard link
+- The email renderer actually emitting magic-link buttons for a
+  synthesized FormDefinition
+- The action endpoint completing the task without auth (signed token,
+  no session)
 - The TS SDK's `Authorization: Bearer` header reaching the server
 - The TS SDK's poll loop resolving when the task completes via a
-  non-SDK path (the admin completion happens out-of-band, just like
-  a real human review would)
+  non-SDK path (the magic-link POST happens out-of-band, just like a
+  real human review would)

--- a/examples/email-smoke/README.md
+++ b/examples/email-smoke/README.md
@@ -1,0 +1,95 @@
+# email-smoke
+
+End-to-end smoke test for the email channel — driven from TypeScript so
+the test exercises both the public TS SDK contract AND the Python server's
+email path. No mocks; runs against a real `awaithumans dev` server.
+
+## What it does
+
+1. Creates an email sender identity using the `file` transport — emails
+   are written to a tmp directory instead of being shipped through Resend
+   or SMTP. Lets the test capture them deterministically.
+2. Calls `awaitHuman` from the TS SDK with `notify=["email+<id>:..."]`,
+   then immediately starts polling the tmp dir for the rendered email.
+3. Asserts on the captured email's content (task title, payload fields,
+   dashboard link). Confirms the renderer didn't regress on a known good
+   shape.
+4. Completes the task via the admin API; `awaitHuman`'s long-poll
+   resolves with the typed response. Asserts `approved === true`.
+
+If any step fails, the test exits non-zero with the detail. The email
+identity is cleaned up on both success and failure.
+
+### Why admin-API completion instead of clicking the magic-link button?
+
+The TS SDK doesn't yet synthesize a `form_definition` from a Zod schema
+— Python has `extract_form` (Pydantic-driven), the TS port is
+post-launch work. Without that, the email renderer falls back to a
+"Review in dashboard" link-out and never emits Approve/Reject magic-link
+buttons. Once form synthesis lands in the TS SDK, this script will
+switch to clicking the button instead. The magic-link click path itself
+has full Python coverage in `tests/email/`.
+
+## Run it
+
+In one terminal, start the dev server:
+
+```sh
+awaithumans dev
+```
+
+The first run generates a dev admin token at `~/.awaithumans/admin.token`.
+
+In another terminal:
+
+```sh
+cd examples/email-smoke
+npm install
+export AWAITHUMANS_ADMIN_API_TOKEN="$(cat ~/.awaithumans/admin.token)"
+npm start
+```
+
+Expected output:
+
+```
+→ email capture dir: /var/folders/.../awaithumans-smoke-XXXXXX
+→ smoke against http://localhost:3001
+→ created email identity 'smoke-...' (file transport)
+→ captured email: subject="Review: Approve wire transfer (smoke test)" to=smoke-recipient@example.test
+→ email body content checks: OK
+→ resolved task_id=...
+→ completed task ... via admin API
+✓ smoke pass: TS SDK created task → email captured → SDK polled → resolved
+```
+
+## Knobs
+
+| Env var | Default | Notes |
+|---|---|---|
+| `AWAITHUMANS_URL` | `http://localhost:3001` | Override if your dev server is elsewhere (ngrok, separate host) |
+| `AWAITHUMANS_ADMIN_API_TOKEN` | required | Bearer token for `/api/tasks` and `/api/channels/email/identities`. The dev server prints its path on first start |
+
+## Troubleshooting
+
+- **"AWAITHUMANS_ADMIN_API_TOKEN is required"** — start `awaithumans dev`
+  first, then export the token from the path the CLI printed.
+- **"Timed out waiting for email"** — the dev server's email transport may
+  have rejected the route (unknown identity, wrong format). Check the dev
+  server logs.
+- **`awaitHuman` rejects with `TaskCreateError 403`** — your token doesn't
+  match the server's `ADMIN_API_TOKEN`. Re-export it from the CLI's path.
+- **`awaitHuman` rejects with `TaskTimeoutError`** — the magic-link click
+  succeeded but the task didn't transition to completed. Inspect the task
+  in the dashboard at `http://localhost:3001/`.
+
+## What this catches that unit tests don't
+
+- Wire-format drift between the TS SDK and Python server schemas
+- The notify route parser accepting the `email+<identity>:<target>`
+  syntax against a real DB row
+- The email renderer actually rendering against a real task — task
+  title, payload table, dashboard link
+- The TS SDK's `Authorization: Bearer` header reaching the server
+- The TS SDK's poll loop resolving when the task completes via a
+  non-SDK path (the admin completion happens out-of-band, just like
+  a real human review would)

--- a/examples/email-smoke/package.json
+++ b/examples/email-smoke/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "awaithumans-email-smoke",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "tsx smoke.ts"
+  },
+  "dependencies": {
+    "awaithumans": "file:../../packages/typescript-sdk",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/email-smoke/smoke.ts
+++ b/examples/email-smoke/smoke.ts
@@ -188,41 +188,41 @@ function assertEmailLooksRight(email: CapturedEmail): void {
 	if (!email.html.includes("WT-SMOKE-1")) {
 		throw new Error("Email body missing the payload (transferId)");
 	}
-	if (!email.html.includes(`/tasks/`) && !email.html.includes(`/task?id=`)) {
-		throw new Error("Email body missing the dashboard link-out");
-	}
 }
 
-async function completeTaskViaAdmin(taskId: string): Promise<void> {
-	// `awaitHuman` doesn't currently synthesize a `form_definition` from
-	// a Zod schema (Python has `extract_form`; the TS port is a
-	// post-launch task). Without that, the email renderer falls back
-	// to a "Review in dashboard" link-out — no magic-link buttons. So
-	// the smoke test completes the task via the admin completion API
-	// instead of clicking a magic link.
-	//
-	// What this still proves end-to-end:
-	//   - TS SDK's `awaitHuman` creates the task with the right wire shape
-	//   - The notify list resolves to the email channel
-	//   - The email transport actually fires + writes the message
-	//   - Polling resolves when the task transitions to completed
-	//
-	// The magic-link click path has its own Python coverage; once form
-	// synthesis lands in the TS SDK we'll switch this script to click
-	// the link instead.
-	const resp = await adminFetch(`/api/tasks/${taskId}/complete`, {
-		method: "POST",
-		body: JSON.stringify({
-			response: { approved: true },
-			completed_via_channel: "smoke",
-		}),
-	});
-	if (!resp.ok) {
+const ACTION_PATH_RE = /\/api\/channels\/email\/action\/[A-Za-z0-9_\-.]+/;
+
+function findApproveLink(email: CapturedEmail): string {
+	// The renderer emits BOTH Approve and Reject buttons for a single
+	// Switch field. They appear in declaration order — Approve first
+	// (style="primary"), Reject second (style="danger") — per
+	// `_buttons_for_form` in the Python renderer. We grab the first
+	// match and click it; the smoke test always wants the approve
+	// path (so the asserted `approved === true` lines up).
+	const match =
+		email.text.match(ACTION_PATH_RE) ?? email.html.match(ACTION_PATH_RE);
+	if (!match) {
 		throw new Error(
-			`task complete failed: ${resp.status} ${await resp.text()}`,
+			"No magic-link URL found in captured email. Was form_definition " +
+				"synthesized? See packages/typescript-sdk/src/forms.ts.\n" +
+				`text body:\n${email.text}\n\nhtml body:\n${email.html}`,
 		);
 	}
-	console.log(`→ completed task ${taskId} via admin API`);
+	return `${SERVER_URL}${match[0]}`;
+}
+
+async function clickMagicLink(url: string): Promise<void> {
+	// The action endpoint accepts POST with no body — the value is
+	// baked into the signed token. GET renders the "are you sure"
+	// confirmation page; POST is what actually completes the task.
+	// Public endpoint, no auth needed.
+	const resp = await fetch(url, { method: "POST" });
+	if (!resp.ok) {
+		throw new Error(
+			`Magic-link POST returned ${resp.status}: ${await resp.text()}`,
+		);
+	}
+	console.log(`→ POSTed magic-link → ${resp.status}`);
 }
 
 // ─── Orchestration ─────────────────────────────────────────────────────
@@ -268,13 +268,10 @@ async function main(): Promise<void> {
 	assertEmailLooksRight(email);
 	console.log("→ email body content checks: OK");
 
-	// Find the task we just created so we can complete it via admin API.
-	// The list endpoint returns most-recent-first; we filter by our
-	// idempotency_key for an exact match.
-	const taskId = await findTaskByIdempotencyKey(idem);
-	console.log(`→ resolved task_id=${taskId}`);
+	const approveUrl = findApproveLink(email);
+	console.log(`→ magic-link URL: ${approveUrl}`);
 
-	await completeTaskViaAdmin(taskId);
+	await clickMagicLink(approveUrl);
 
 	const decision = await awaitPromise;
 	if (decision.approved !== true) {
@@ -283,29 +280,7 @@ async function main(): Promise<void> {
 		);
 	}
 
-	console.log("✓ smoke pass: TS SDK created task → email captured → SDK polled → resolved");
-}
-
-async function findTaskByIdempotencyKey(idem: string): Promise<string> {
-	// The TS SDK doesn't yet expose the task_id from awaitHuman directly
-	// (it returns the typed response, not the wire record). So the
-	// smoke test recovers the id via the admin list — fine for a
-	// dev-mode test, not a pattern we'd recommend for production code.
-	const resp = await adminFetch("/api/tasks?limit=50");
-	if (!resp.ok) {
-		throw new Error(`task list failed: ${resp.status}`);
-	}
-	const tasks = (await resp.json()) as Array<{
-		id: string;
-		idempotency_key: string;
-	}>;
-	const match = tasks.find((t) => t.idempotency_key === idem);
-	if (!match) {
-		throw new Error(
-			`Couldn't find task with idempotency_key=${idem} in the listing`,
-		);
-	}
-	return match.id;
+	console.log("✓ smoke pass: TS SDK + email channel + magic-link round-trip");
 }
 
 main()

--- a/examples/email-smoke/smoke.ts
+++ b/examples/email-smoke/smoke.ts
@@ -1,0 +1,320 @@
+/**
+ * End-to-end email-channel smoke test (TypeScript).
+ *
+ * Exercises the full create → notify → click-magic-link → resolve loop
+ * against a real awaithumans server, using ONLY the public TypeScript
+ * SDK + a tiny admin helper for the email-identity setup. No mocks,
+ * no internal imports.
+ *
+ * What runs:
+ *   1. Configure an email sender identity that uses the `file` transport
+ *      (drops one JSON per email into a tmp dir — captures what would
+ *      otherwise have left for Resend).
+ *   2. Call `awaitHuman` with `notify=["email:..."]` and a single-Switch
+ *      response schema (the renderer emits magic-link buttons for that).
+ *   3. Concurrently poll the tmp dir for the email file, parse the
+ *      "Approve" magic-link URL out of the rendered text body, then
+ *      POST to it (the action endpoint is public — no auth needed).
+ *   4. Wait for `awaitHuman` to resolve. Assert the response matches.
+ *
+ * Why a runnable script and not a vitest unit test:
+ *   - The whole point is "does the TS SDK actually talk to the server."
+ *   - Mocked unit coverage already exists (tests/await-human.test.ts).
+ *   - This catches contract drift between the wire formats.
+ *
+ * Prerequisites (in another terminal):
+ *
+ *     awaithumans dev
+ *
+ * Then in this terminal:
+ *
+ *     cd examples/email-smoke
+ *     npm install
+ *     export AWAITHUMANS_ADMIN_API_TOKEN="$(cat ~/.awaithumans/admin.token)"
+ *     npm start
+ *
+ * The default server URL is http://localhost:3001. Override with
+ * AWAITHUMANS_URL if your dev server is elsewhere (e.g., behind ngrok).
+ */
+
+import { mkdtempSync, readFileSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+
+import { awaitHuman } from "awaithumans";
+import { z } from "zod";
+
+// ─── Config ────────────────────────────────────────────────────────────
+
+const SERVER_URL =
+	process.env.AWAITHUMANS_URL ?? "http://localhost:3001";
+const ADMIN_TOKEN = process.env.AWAITHUMANS_ADMIN_API_TOKEN;
+
+if (!ADMIN_TOKEN) {
+	console.error(
+		"AWAITHUMANS_ADMIN_API_TOKEN is required. " +
+			"Run `awaithumans dev` first, then set the env var to the contents " +
+			"of ~/.awaithumans/admin.token (or wherever your dev DB sits).",
+	);
+	process.exit(1);
+}
+
+const RECIPIENT_EMAIL = "smoke-recipient@example.test";
+const IDENTITY_ID = `smoke-${Date.now().toString(36)}`;
+
+// Use a unique tmp dir per run so old emails from prior smoke runs
+// don't pollute the magic-link search.
+const EMAIL_DIR = mkdtempSync(join(tmpdir(), "awaithumans-smoke-"));
+console.log(`→ email capture dir: ${EMAIL_DIR}`);
+
+// ─── Schemas ───────────────────────────────────────────────────────────
+
+const TransferRequest = z.object({
+	transferId: z.string(),
+	amountUsd: z.number(),
+	to: z.string(),
+});
+
+// IMPORTANT: a single boolean field triggers the renderer's magic-
+// link path (Approve/Reject buttons in the email). Multi-field
+// responses fall back to a "review in dashboard" link-out, which
+// is harder to script.
+const ApprovalResponse = z.object({
+	approved: z.boolean().describe("Approve this transfer?"),
+});
+
+// ─── Admin helpers ─────────────────────────────────────────────────────
+
+async function adminFetch(
+	path: string,
+	init: RequestInit = {},
+): Promise<Response> {
+	return fetch(`${SERVER_URL}${path}`, {
+		...init,
+		headers: {
+			...(init.headers ?? {}),
+			Authorization: `Bearer ${ADMIN_TOKEN}`,
+			"Content-Type": "application/json",
+		},
+	});
+}
+
+async function configureFileTransportIdentity(): Promise<void> {
+	const resp = await adminFetch("/api/channels/email/identities", {
+		method: "POST",
+		body: JSON.stringify({
+			id: IDENTITY_ID,
+			display_name: "Smoke test sender",
+			from_email: "smoke@app.example",
+			from_name: "awaithumans smoke",
+			reply_to: null,
+			transport: "file",
+			transport_config: { dir: EMAIL_DIR },
+		}),
+	});
+	if (!resp.ok) {
+		throw new Error(
+			`identity create failed: ${resp.status} ${await resp.text()}`,
+		);
+	}
+	console.log(`→ created email identity '${IDENTITY_ID}' (file transport)`);
+}
+
+async function deleteIdentity(): Promise<void> {
+	// Best-effort cleanup so a half-run smoke test doesn't leave junk
+	// rows in the operator's email-identity list.
+	try {
+		await adminFetch(`/api/channels/email/identities/${IDENTITY_ID}`, {
+			method: "DELETE",
+		});
+	} catch {
+		// non-fatal — the row is harmless and the operator can clear
+		// it manually if they care.
+	}
+}
+
+// ─── Email capture ────────────────────────────────────────────────────
+
+interface CapturedEmail {
+	to: string;
+	subject: string;
+	html: string;
+	text: string;
+}
+
+async function pollForEmail(
+	deadlineMs: number,
+): Promise<CapturedEmail> {
+	while (Date.now() < deadlineMs) {
+		const files = readdirSync(EMAIL_DIR)
+			.filter((f) => f.endsWith(".json"))
+			.sort(); // unix-ms-prefixed names sort chronologically
+
+		const recent = files.find((f: string) => {
+			const payload = JSON.parse(
+				readFileSync(join(EMAIL_DIR, f), "utf8"),
+			);
+			return payload.to === RECIPIENT_EMAIL;
+		});
+
+		if (recent) {
+			const payload = JSON.parse(
+				readFileSync(join(EMAIL_DIR, recent), "utf8"),
+			);
+			return {
+				to: payload.to,
+				subject: payload.subject,
+				html: payload.html,
+				text: payload.text,
+			};
+		}
+		await sleep(250);
+	}
+	throw new Error(
+		`Timed out waiting for email to ${RECIPIENT_EMAIL} in ${EMAIL_DIR}`,
+	);
+}
+
+function assertEmailLooksRight(email: CapturedEmail): void {
+	// Pin the things the email channel SHOULD always include — anything
+	// missing here would mean the renderer regressed.
+	if (!email.subject) {
+		throw new Error("Email has empty subject");
+	}
+	if (!email.html.includes("Approve wire transfer (smoke test)")) {
+		throw new Error("Email body missing the task title");
+	}
+	if (!email.html.includes("WT-SMOKE-1")) {
+		throw new Error("Email body missing the payload (transferId)");
+	}
+	if (!email.html.includes(`/tasks/`) && !email.html.includes(`/task?id=`)) {
+		throw new Error("Email body missing the dashboard link-out");
+	}
+}
+
+async function completeTaskViaAdmin(taskId: string): Promise<void> {
+	// `awaitHuman` doesn't currently synthesize a `form_definition` from
+	// a Zod schema (Python has `extract_form`; the TS port is a
+	// post-launch task). Without that, the email renderer falls back
+	// to a "Review in dashboard" link-out — no magic-link buttons. So
+	// the smoke test completes the task via the admin completion API
+	// instead of clicking a magic link.
+	//
+	// What this still proves end-to-end:
+	//   - TS SDK's `awaitHuman` creates the task with the right wire shape
+	//   - The notify list resolves to the email channel
+	//   - The email transport actually fires + writes the message
+	//   - Polling resolves when the task transitions to completed
+	//
+	// The magic-link click path has its own Python coverage; once form
+	// synthesis lands in the TS SDK we'll switch this script to click
+	// the link instead.
+	const resp = await adminFetch(`/api/tasks/${taskId}/complete`, {
+		method: "POST",
+		body: JSON.stringify({
+			response: { approved: true },
+			completed_via_channel: "smoke",
+		}),
+	});
+	if (!resp.ok) {
+		throw new Error(
+			`task complete failed: ${resp.status} ${await resp.text()}`,
+		);
+	}
+	console.log(`→ completed task ${taskId} via admin API`);
+}
+
+// ─── Orchestration ─────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+	console.log(`→ smoke against ${SERVER_URL}`);
+
+	await configureFileTransportIdentity();
+
+	// `awaitHuman` is an awaitable that resolves on completion. Run it
+	// concurrently with the email-capture poll so we can click the
+	// magic link while the SDK is still polling.
+	const idem = `email-smoke-${Date.now()}`;
+
+	const awaitPromise = awaitHuman({
+		task: "Approve wire transfer (smoke test)",
+		payloadSchema: TransferRequest,
+		payload: {
+			transferId: "WT-SMOKE-1",
+			amountUsd: 10_000,
+			to: "Acme Inc.",
+		},
+		responseSchema: ApprovalResponse,
+		timeoutMs: 5 * 60_000, // 5 minutes — plenty of slack for CI
+		idempotencyKey: idem,
+		// notify format: `<channel>[+<identity>]:<target>`. The `+identity`
+		// suffix on the channel side picks our smoke-test sender; without
+		// it the notifier would fall back to env-configured defaults.
+		notify: [`email+${IDENTITY_ID}:${RECIPIENT_EMAIL}`],
+		serverUrl: SERVER_URL,
+		apiKey: ADMIN_TOKEN,
+	});
+
+	// 30s deadline for the background email — the notifier runs as a
+	// FastAPI BackgroundTask AFTER the create-task response, so it
+	// always lands within ~1s on a healthy box. 30s is paranoid.
+	// 30s deadline for the background email — the notifier runs as a
+	// FastAPI BackgroundTask AFTER the create-task response, so it
+	// always lands within ~1s on a healthy box. 30s is paranoid.
+	const captureDeadline = Date.now() + 30_000;
+	const email = await pollForEmail(captureDeadline);
+	console.log(`→ captured email: subject="${email.subject}" to=${email.to}`);
+	assertEmailLooksRight(email);
+	console.log("→ email body content checks: OK");
+
+	// Find the task we just created so we can complete it via admin API.
+	// The list endpoint returns most-recent-first; we filter by our
+	// idempotency_key for an exact match.
+	const taskId = await findTaskByIdempotencyKey(idem);
+	console.log(`→ resolved task_id=${taskId}`);
+
+	await completeTaskViaAdmin(taskId);
+
+	const decision = await awaitPromise;
+	if (decision.approved !== true) {
+		throw new Error(
+			`Expected approved=true, got: ${JSON.stringify(decision)}`,
+		);
+	}
+
+	console.log("✓ smoke pass: TS SDK created task → email captured → SDK polled → resolved");
+}
+
+async function findTaskByIdempotencyKey(idem: string): Promise<string> {
+	// The TS SDK doesn't yet expose the task_id from awaitHuman directly
+	// (it returns the typed response, not the wire record). So the
+	// smoke test recovers the id via the admin list — fine for a
+	// dev-mode test, not a pattern we'd recommend for production code.
+	const resp = await adminFetch("/api/tasks?limit=50");
+	if (!resp.ok) {
+		throw new Error(`task list failed: ${resp.status}`);
+	}
+	const tasks = (await resp.json()) as Array<{
+		id: string;
+		idempotency_key: string;
+	}>;
+	const match = tasks.find((t) => t.idempotency_key === idem);
+	if (!match) {
+		throw new Error(
+			`Couldn't find task with idempotency_key=${idem} in the listing`,
+		);
+	}
+	return match.id;
+}
+
+main()
+	.catch(async (err) => {
+		console.error("✗ smoke FAILED");
+		console.error(err);
+		await deleteIdentity();
+		process.exit(1);
+	})
+	.then(async () => {
+		await deleteIdentity();
+	});

--- a/examples/email-smoke/tsconfig.json
+++ b/examples/email-smoke/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["*.ts"]
+}

--- a/packages/python/awaithumans/server/channels/email/transport/factory.py
+++ b/packages/python/awaithumans/server/channels/email/transport/factory.py
@@ -20,6 +20,7 @@ from awaithumans.server.channels.email.transport.base import (
     EmailTransport,
     EmailTransportError,
 )
+from awaithumans.server.channels.email.transport.file import FileTransport
 from awaithumans.server.channels.email.transport.logging import LoggingTransport
 from awaithumans.server.channels.email.transport.noop import NoopTransport
 from awaithumans.server.channels.email.transport.resend import ResendTransport
@@ -65,9 +66,15 @@ def resolve_transport(name: str, config: dict[str, Any]) -> EmailTransport:
     if name == "noop":
         return NoopTransport()
 
+    if name == "file":
+        directory = config.get("dir")
+        if not directory:
+            raise EmailTransportError("file transport: config.dir is required.")
+        return FileTransport(dir=directory)
+
     raise EmailTransportError(
         f"Unknown email transport: '{name}'. "
-        "Valid: resend, smtp, logging, noop."
+        "Valid: resend, smtp, logging, noop, file."
     )
 
 

--- a/packages/python/awaithumans/server/channels/email/transport/file.py
+++ b/packages/python/awaithumans/server/channels/email/transport/file.py
@@ -1,0 +1,98 @@
+"""File transport — drops one JSON per email into a directory.
+
+For local development and end-to-end smoke tests. Each `send()` writes
+`{timestamp}-{message_id}.json` containing the rendered email so a
+test runner can poll the directory, parse the file, extract the magic
+link, and POST to the action endpoint without ever touching a real
+SMTP server.
+
+Configuration:
+  - `dir` (required): absolute path to a writable directory. Created
+    on first send if missing.
+
+Use it via the `/api/channels/email/identities` API:
+
+    {
+      "transport": "file",
+      "transport_config": {"dir": "/tmp/awaithumans-emails"}
+    }
+
+Never use this in production: emails are written to disk in plaintext
+and never reach a recipient.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from dataclasses import asdict
+from pathlib import Path
+
+from awaithumans.server.channels.email.transport.base import (
+    EmailMessage,
+    EmailSendResult,
+    EmailTransportError,
+)
+
+logger = logging.getLogger("awaithumans.server.channels.email.transport.file")
+
+
+class FileTransport:
+    """Write each email as a JSON file under `dir`.
+
+    Filenames are `{unix_ms}-{shortid}.json` so they sort
+    chronologically and don't collide across rapid sends. The body
+    is the EmailMessage serialized with all fields — `to`, `subject`,
+    `html`, `text`, `from_email`, `from_name`, `reply_to`, `tags`.
+    Plus a `_received_at` ISO timestamp for tooling that doesn't want
+    to parse filenames.
+    """
+
+    def __init__(self, *, dir: str) -> None:
+        if not dir:
+            raise EmailTransportError(
+                "file transport: config.dir is required."
+            )
+        self._dir = Path(dir).expanduser().resolve()
+
+    @property
+    def name(self) -> str:
+        return "file"
+
+    async def send(self, message: EmailMessage) -> EmailSendResult:
+        try:
+            self._dir.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            raise EmailTransportError(
+                f"file transport: cannot create dir {self._dir}: {exc}"
+            ) from exc
+
+        message_id = f"file-{uuid.uuid4().hex[:16]}"
+        unix_ms = int(time.time() * 1000)
+        filename = self._dir / f"{unix_ms}-{message_id}.json"
+
+        payload = asdict(message)
+        payload["_received_at"] = time.strftime(
+            "%Y-%m-%dT%H:%M:%SZ", time.gmtime()
+        )
+        payload["_message_id"] = message_id
+
+        try:
+            filename.write_text(json.dumps(payload, indent=2))
+        except OSError as exc:
+            raise EmailTransportError(
+                f"file transport: failed to write {filename}: {exc}"
+            ) from exc
+
+        logger.info(
+            "[email/file] wrote %s (to=%s subject=%s)",
+            filename.name,
+            message.to,
+            message.subject,
+        )
+        return EmailSendResult(
+            message_id=message_id,
+            transport=self.name,
+        )

--- a/packages/python/awaithumans/server/schemas/email.py
+++ b/packages/python/awaithumans/server/schemas/email.py
@@ -18,8 +18,8 @@ class IdentityCreateRequest(BaseModel):
     from_email: str
     from_name: str | None = None
     reply_to: str | None = None
-    transport: str                    # "resend" | "smtp" | "logging" | "noop"
-    transport_config: dict[str, Any]  # kind-specific (api_key, host, port, ...)
+    transport: str                    # "resend" | "smtp" | "logging" | "noop" | "file"
+    transport_config: dict[str, Any]  # kind-specific (api_key, host, port, dir, ...)
 
 
 class IdentityResponse(BaseModel):

--- a/packages/python/tests/email/test_file_transport.py
+++ b/packages/python/tests/email/test_file_transport.py
@@ -1,0 +1,113 @@
+"""File email transport — write JSON per email for E2E smoke tests.
+
+The file transport drops one JSON-serialized email into a directory
+on each send. The TS smoke test in `examples/email-smoke/` polls
+that directory to capture the magic-link URL — without this transport
+the test would have to scrape stdout from the dev server.
+
+Tests pin:
+  - File appears with the rendered email's fields
+  - Directory is created on first send when missing
+  - Header-injection guard from EmailMessage still applies
+  - Missing `dir` config raises at construction
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from awaithumans.server.channels.email.transport.base import (
+    EmailMessage,
+    EmailTransportError,
+)
+from awaithumans.server.channels.email.transport.factory import resolve_transport
+from awaithumans.server.channels.email.transport.file import FileTransport
+
+
+def _msg() -> EmailMessage:
+    return EmailMessage(
+        to="recipient@example.com",
+        subject="A new task to review",
+        html="<p>Click <a href='https://app/x'>here</a></p>",
+        text="Click here: https://app/x",
+        from_email="bot@app.example",
+        from_name="awaithumans",
+        reply_to="ops@app.example",
+        tags={"task_id": "t-001"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_writes_file_with_message_fields(tmp_path: Path) -> None:
+    transport = FileTransport(dir=str(tmp_path))
+    result = await transport.send(_msg())
+
+    files = list(tmp_path.glob("*.json"))
+    assert len(files) == 1, f"expected one file, got {files}"
+
+    payload = json.loads(files[0].read_text())
+    assert payload["to"] == "recipient@example.com"
+    assert payload["subject"] == "A new task to review"
+    assert "https://app/x" in payload["text"]
+    assert payload["from_email"] == "bot@app.example"
+    assert payload["from_name"] == "awaithumans"
+    assert payload["tags"] == {"task_id": "t-001"}
+    # Bookkeeping fields the test runner can rely on.
+    assert payload["_message_id"] == result.message_id
+    assert payload["_received_at"].endswith("Z")
+
+
+@pytest.mark.asyncio
+async def test_directory_created_on_first_send(tmp_path: Path) -> None:
+    """Missing parent dir is OK — transport mkdirs on first send so a
+    fresh repo doesn't need an extra setup step."""
+    target = tmp_path / "deeply" / "nested" / "dir"
+    assert not target.exists()
+
+    transport = FileTransport(dir=str(target))
+    await transport.send(_msg())
+
+    assert target.is_dir()
+    assert len(list(target.glob("*.json"))) == 1
+
+
+@pytest.mark.asyncio
+async def test_files_sort_chronologically(tmp_path: Path) -> None:
+    """Filenames lead with unix-ms so a runner that sorts and takes
+    `[-1]` always gets the most recent email."""
+    transport = FileTransport(dir=str(tmp_path))
+    await transport.send(_msg())
+    await transport.send(_msg())
+    files = sorted(tmp_path.glob("*.json"))
+    # Two distinct filenames, sortable.
+    assert len(files) == 2
+    assert files[0].name < files[1].name
+
+
+def test_construct_without_dir_raises() -> None:
+    """An empty/missing `dir` is a config error at startup, not a
+    silent default — refusing to start is the safer behavior since
+    the alternative is silently writing to an unintended location."""
+    with pytest.raises(EmailTransportError, match="dir is required"):
+        FileTransport(dir="")
+
+
+def test_factory_routes_file_name() -> None:
+    transport = resolve_transport("file", {"dir": "/tmp/awaithumans-pyx"})
+    assert transport.name == "file"
+
+
+def test_factory_rejects_file_without_dir() -> None:
+    with pytest.raises(EmailTransportError, match="dir is required"):
+        resolve_transport("file", {})
+
+
+def test_factory_unknown_name_lists_file() -> None:
+    """Make sure the operator-facing error message advertises `file`
+    so they don't have to read source to discover the transport
+    exists."""
+    with pytest.raises(EmailTransportError, match="file"):
+        resolve_transport("not-a-real-transport", {})

--- a/packages/typescript-sdk/src/await-human.ts
+++ b/packages/typescript-sdk/src/await-human.ts
@@ -76,6 +76,13 @@ export async function awaitHuman<TPayload, TResponse>(
 		options.serverUrl ?? envVar("AWAITHUMANS_URL") ?? DEFAULT_SERVER_URL
 	).replace(/\/$/, "");
 
+	// ── Resolve admin token ─────────────────────────────────────────────
+	// `awaitHuman` is the agent path — task creation and polling are
+	// admin-only on the server. The Temporal adapter already had this
+	// pattern; direct mode missed it, so any non-localhost-disabled
+	// server 403'd unless callers hand-rolled a fetch wrapper.
+	const apiKey = options.apiKey ?? envVar("AWAITHUMANS_ADMIN_API_TOKEN");
+
 	// ── Generate idempotency key ────────────────────────────────────────
 	const idempotencyKey =
 		options.idempotencyKey ??
@@ -107,7 +114,7 @@ export async function awaitHuman<TPayload, TResponse>(
 	};
 
 	// ── POST /api/tasks ─────────────────────────────────────────────────
-	const task = await createTask(serverUrl, body);
+	const task = await createTask(serverUrl, body, apiKey);
 
 	// ── Long-poll until terminal ────────────────────────────────────────
 	return pollUntilTerminal(
@@ -116,20 +123,29 @@ export async function awaitHuman<TPayload, TResponse>(
 		options.task,
 		timeoutSeconds,
 		options.responseSchema,
+		apiKey,
 	);
 }
 
 // ─── Internals ──────────────────────────────────────────────────────────
 
+function authHeaders(apiKey: string | undefined): Record<string, string> {
+	return apiKey ? { Authorization: `Bearer ${apiKey}` } : {};
+}
+
 async function createTask(
 	serverUrl: string,
 	body: CreateTaskRequestWire,
+	apiKey: string | undefined,
 ): Promise<CreateTaskResponseWire> {
 	const resp = await fetchWithTimeout(
 		`${serverUrl}/api/tasks`,
 		{
 			method: "POST",
-			headers: { "Content-Type": "application/json" },
+			headers: {
+				"Content-Type": "application/json",
+				...authHeaders(apiKey),
+			},
 			body: JSON.stringify(body),
 		},
 		CREATE_TASK_TIMEOUT_MS,
@@ -151,6 +167,7 @@ async function pollUntilTerminal<TResponse>(
 	// The response schema validates the server's returned response.
 	// Typed as the user-supplied Zod schema to preserve inference.
 	responseSchema: AwaitHumanOptions<unknown, TResponse>["responseSchema"],
+	apiKey: string | undefined,
 ): Promise<TResponse> {
 	const url = `${serverUrl}/api/tasks/${encodeURIComponent(
 		taskId,
@@ -163,7 +180,12 @@ async function pollUntilTerminal<TResponse>(
 	// for ~POLL_INTERVAL_SECONDS and then returns the current status.
 	// When the status is non-terminal we reconnect.
 	while (true) {
-		const resp = await fetchWithTimeout(url, {}, fetchTimeoutMs, serverUrl);
+		const resp = await fetchWithTimeout(
+			url,
+			{ headers: authHeaders(apiKey) },
+			fetchTimeoutMs,
+			serverUrl,
+		);
 
 		if (resp.status === 404) {
 			throw new TaskNotFoundError(taskId);

--- a/packages/typescript-sdk/src/await-human.ts
+++ b/packages/typescript-sdk/src/await-human.ts
@@ -36,6 +36,7 @@ import {
 	VerificationExhaustedError,
 } from "./errors";
 import { fetchWithTimeout } from "./fetch";
+import { extractForm } from "./forms";
 import { generateIdempotencyKey } from "./idempotency";
 import type { AwaitHumanOptions } from "./types";
 import {
@@ -93,17 +94,21 @@ export async function awaitHuman<TPayload, TResponse>(
 	const responseJsonSchema = zodToJsonSchema(options.responseSchema);
 	const timeoutSeconds = Math.round(options.timeoutMs / 1000);
 
+	// Synthesize a FormDefinition from the response schema where we can.
+	// The server uses this to decide channel-specific rendering — most
+	// notably whether the email channel emits Approve/Reject magic-link
+	// buttons (single Switch primitive) or just a "Review in dashboard"
+	// link-out (anything else). Returns null for shapes we can't yet
+	// synthesize; the server falls back to JSON-schema rendering in
+	// that case. See `forms.ts` for coverage.
+	const formDefinition = extractForm(options.responseSchema);
+
 	const body: CreateTaskRequestWire = {
 		task: options.task,
 		payload: options.payload,
 		payload_schema: payloadJsonSchema,
 		response_schema: responseJsonSchema,
-		// form_definition is optional on the server. The TS SDK can't yet
-		// extract per-primitive form metadata from a Zod schema the way
-		// the Python SDK does from Pydantic — the dashboard falls back to
-		// generic JSON-schema rendering, which is fine. Future work:
-		// adopt the FormDefinition wire format from the forms framework.
-		form_definition: null,
+		form_definition: formDefinition,
 		timeout_seconds: timeoutSeconds,
 		idempotency_key: idempotencyKey,
 		assign_to: serializeAssignTo(options.assignTo),

--- a/packages/typescript-sdk/src/forms.ts
+++ b/packages/typescript-sdk/src/forms.ts
@@ -1,0 +1,177 @@
+/**
+ * Build a `FormDefinition` from a Zod schema.
+ *
+ * The Python SDK has `extract_form()` driven by Pydantic; the server
+ * uses `form_definition` to decide things like whether the email
+ * channel emits Approve/Reject magic-link buttons or just a "Review
+ * in dashboard" link-out (single Switch primitive → buttons; anything
+ * else → link-out).
+ *
+ * Without this synthesis, every TS-created task got the link-out
+ * fallback, even for the simple `z.object({ approved: z.boolean() })`
+ * case where the magic-link path is the obvious DX win.
+ *
+ * Coverage today: boolean (Switch), string (ShortText / LongText), number
+ * (ShortText with type=number), enum (SingleSelect). That's enough for
+ * the email magic-link path, which only fires for a single Switch or a
+ * small SingleSelect anyway. The other 23 primitives in the Python
+ * library require explicit `Annotated` decoration on the Pydantic model
+ * — Zod has no equivalent affordance, so the long tail is intentionally
+ * left to a future explicit-DSL escape hatch.
+ *
+ * Returns `null` when the schema isn't a `ZodObject`. Caller should
+ * treat null as "no form_definition" and let the server / dashboard
+ * fall back to JSON-schema rendering.
+ */
+
+import type { ZodType, ZodTypeAny } from "zod";
+
+// ─── Wire types ────────────────────────────────────────────────────────
+
+/**
+ * Subset of the FormField wire shape that this synthesizer can emit.
+ * `kind` is the Pydantic discriminator. The full union lives server-
+ * side; we only produce the leaves we synthesize.
+ */
+export interface FormField {
+	kind: "switch" | "short_text" | "long_text" | "single_select";
+	name: string;
+	label?: string;
+	hint?: string;
+	required: boolean;
+	// kind-specific extras are widened to `unknown` so this file doesn't
+	// have to mirror the full server-side schema.
+	[extra: string]: unknown;
+}
+
+export interface FormDefinition {
+	fields: FormField[];
+}
+
+// ─── Zod introspection helpers ─────────────────────────────────────────
+
+interface ZodDef {
+	typeName?: string;
+	values?: unknown[];
+	innerType?: ZodTypeAny;
+	checks?: Array<{ kind?: string }>;
+	defaultValue?: () => unknown;
+}
+
+function zdef(schema: ZodTypeAny): ZodDef {
+	return (schema as unknown as { _def: ZodDef })._def;
+}
+
+/**
+ * Strip ZodOptional / ZodNullable / ZodDefault layers and report
+ * whether any of them made the field non-required.
+ */
+function unwrap(
+	schema: ZodTypeAny,
+): { inner: ZodTypeAny; required: boolean } {
+	let current = schema;
+	let required = true;
+	// Bound the loop in case of pathological nesting.
+	for (let i = 0; i < 8; i++) {
+		const def = zdef(current);
+		if (
+			def.typeName === "ZodOptional" ||
+			def.typeName === "ZodNullable" ||
+			def.typeName === "ZodDefault"
+		) {
+			required = false;
+			if (!def.innerType) break;
+			current = def.innerType;
+			continue;
+		}
+		break;
+	}
+	return { inner: current, required };
+}
+
+/**
+ * Snake_case attribute → "Title Case" — same fallback as the Python
+ * `_humanize` helper so labels look identical across SDKs.
+ */
+function humanize(name: string): string {
+	return name
+		.replace(/[_-]+/g, " ")
+		.trim()
+		.replace(/\w\S*/g, (w) => w[0].toUpperCase() + w.slice(1).toLowerCase());
+}
+
+function description(schema: ZodTypeAny): string | undefined {
+	return (schema as unknown as { description?: string }).description;
+}
+
+// ─── Per-type field synthesis ──────────────────────────────────────────
+
+function fieldFor(
+	name: string,
+	schema: ZodTypeAny,
+	required: boolean,
+): FormField | null {
+	const def = zdef(schema);
+	const label = description(schema) ?? humanize(name);
+	const base = { name, label, required } as const;
+
+	switch (def.typeName) {
+		case "ZodBoolean":
+			return { ...base, kind: "switch", true_label: "Yes", false_label: "No" };
+
+		case "ZodString": {
+			// Long text heuristic: explicit `.min(N)` >= 100 OR
+			// `.describe("...long...")`. Conservative — defaults to
+			// short_text. Operators who want the long-text textarea can
+			// pass `z.string().min(200)` or use the eventual explicit DSL.
+			const hasLongMin = (def.checks ?? []).some(
+				(c) => c.kind === "min" && (c as { value?: number }).value! >= 100,
+			);
+			return { ...base, kind: hasLongMin ? "long_text" : "short_text" };
+		}
+
+		case "ZodNumber":
+			// The server's ShortText accepts a `number` input mode for
+			// numeric fields; we keep things simple and emit a short_text
+			// — the email-magic-link decision (single-Switch only)
+			// doesn't care about numeric fields anyway.
+			return { ...base, kind: "short_text" };
+
+		case "ZodEnum": {
+			const values = (def.values as string[] | undefined) ?? [];
+			const options = values.map((v) => ({ value: v, label: v }));
+			return { ...base, kind: "single_select", options };
+		}
+
+		default:
+			// Unknown primitive — skip rather than emit a malformed field.
+			// The server falls back to JSON-schema rendering, so the
+			// dashboard still works; the email channel just won't get
+			// magic-link treatment for unsupported types.
+			return null;
+	}
+}
+
+// ─── Public API ────────────────────────────────────────────────────────
+
+export function extractForm(
+	schema: ZodType<unknown>,
+): FormDefinition | null {
+	const def = zdef(schema as ZodTypeAny);
+	if (def.typeName !== "ZodObject") return null;
+
+	const shape = (
+		schema as unknown as { shape: Record<string, ZodTypeAny> }
+	).shape;
+	if (!shape || typeof shape !== "object") return null;
+
+	const fields: FormField[] = [];
+	for (const [name, subSchema] of Object.entries(shape)) {
+		const { inner, required } = unwrap(subSchema);
+		const field = fieldFor(name, inner, required);
+		if (field !== null) fields.push(field);
+	}
+
+	if (fields.length === 0) return null;
+	return { fields };
+}

--- a/packages/typescript-sdk/src/types.ts
+++ b/packages/typescript-sdk/src/types.ts
@@ -39,6 +39,14 @@ export interface AwaitHumanOptions<TPayload, TResponse> {
 
 	/** Server URL override. Defaults to AWAITHUMANS_URL env var or http://localhost:3001. */
 	serverUrl?: string;
+
+	/**
+	 * Bearer token sent as `Authorization: Bearer <token>` on task creation
+	 * and long-poll requests. Defaults to `AWAITHUMANS_ADMIN_API_TOKEN` env
+	 * var. Required against any server with admin auth enabled — including
+	 * the dev server, which auto-generates a token at first start.
+	 */
+	apiKey?: string;
 }
 
 // ─── Routing ────────────────────────────────────────────────────────────

--- a/packages/typescript-sdk/tests/await-human.test.ts
+++ b/packages/typescript-sdk/tests/await-human.test.ts
@@ -135,11 +135,26 @@ describe("happy path", () => {
 			timeout_seconds: 60,
 			redact_payload: false,
 			callback_url: null,
-			form_definition: null,
 		});
 		expect(typeof body.idempotency_key).toBe("string");
 		expect(body.payload_schema).toBeDefined();
 		expect(body.response_schema).toBeDefined();
+		// `responseSchema` here is `{ approved: boolean }` — extractForm
+		// synthesizes a single Switch. The server uses this to decide
+		// whether the email channel emits magic-link buttons. Pin the
+		// shape so a regression in `forms.ts` is caught here too.
+		expect(body.form_definition).toEqual({
+			fields: [
+				{
+					kind: "switch",
+					name: "approved",
+					label: "Approved",
+					required: true,
+					true_label: "Yes",
+					false_label: "No",
+				},
+			],
+		});
 
 		// Second call: poll.
 		const [pollUrl] = fetchMock.mock.calls[1];

--- a/packages/typescript-sdk/tests/await-human.test.ts
+++ b/packages/typescript-sdk/tests/await-human.test.ts
@@ -203,6 +203,71 @@ describe("happy path", () => {
 		const body = JSON.parse(fetchMock.mock.calls[0][1].body);
 		expect(body.idempotency_key).toBe("explicit-key-xyz");
 	});
+
+	it("sends Authorization: Bearer header when apiKey is supplied", async () => {
+		// `awaitHuman` is the agent path — task creation and polling are
+		// admin-only on the server. Without this header the dev server
+		// 403s every direct-mode call.
+		const fetchMock = installFetchSequence([
+			makeResponse(200, { id: "t", status: "created" }),
+			makeResponse(200, { status: "completed", response: { approved: true } }),
+		]);
+
+		await awaitHuman({ ...BASE_OPTIONS, apiKey: "test-token-abc" });
+
+		const createInit = fetchMock.mock.calls[0][1];
+		expect(createInit.headers.Authorization).toBe("Bearer test-token-abc");
+
+		// Poll request must also carry the header — the poll endpoint is
+		// gated the same way as create.
+		const pollInit = fetchMock.mock.calls[1][1];
+		expect(pollInit.headers.Authorization).toBe("Bearer test-token-abc");
+	});
+
+	it("falls back to AWAITHUMANS_ADMIN_API_TOKEN env var when apiKey omitted", async () => {
+		const fetchMock = installFetchSequence([
+			makeResponse(200, { id: "t", status: "created" }),
+			makeResponse(200, { status: "completed", response: { approved: true } }),
+		]);
+
+		const original = process.env.AWAITHUMANS_ADMIN_API_TOKEN;
+		process.env.AWAITHUMANS_ADMIN_API_TOKEN = "env-token-xyz";
+		try {
+			await awaitHuman(BASE_OPTIONS);
+		} finally {
+			if (original === undefined) {
+				delete process.env.AWAITHUMANS_ADMIN_API_TOKEN;
+			} else {
+				process.env.AWAITHUMANS_ADMIN_API_TOKEN = original;
+			}
+		}
+
+		const createInit = fetchMock.mock.calls[0][1];
+		expect(createInit.headers.Authorization).toBe("Bearer env-token-xyz");
+	});
+
+	it("omits Authorization header entirely when no apiKey configured", async () => {
+		// Localhost-with-no-admin-token setups should still work — sending
+		// `Authorization: Bearer undefined` would 401 against any sane
+		// validator.
+		const fetchMock = installFetchSequence([
+			makeResponse(200, { id: "t", status: "created" }),
+			makeResponse(200, { status: "completed", response: { approved: true } }),
+		]);
+
+		const original = process.env.AWAITHUMANS_ADMIN_API_TOKEN;
+		delete process.env.AWAITHUMANS_ADMIN_API_TOKEN;
+		try {
+			await awaitHuman(BASE_OPTIONS);
+		} finally {
+			if (original !== undefined) {
+				process.env.AWAITHUMANS_ADMIN_API_TOKEN = original;
+			}
+		}
+
+		const createInit = fetchMock.mock.calls[0][1];
+		expect(createInit.headers.Authorization).toBeUndefined();
+	});
 });
 
 // ─── Terminal status branches ────────────────────────────────────────

--- a/packages/typescript-sdk/tests/forms.test.ts
+++ b/packages/typescript-sdk/tests/forms.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for `extractForm` — the Zod → FormDefinition synthesizer.
+ *
+ * The server uses `form_definition` to decide channel-specific rendering.
+ * The most important contract is the magic-link path in the email
+ * channel: a SINGLE Switch primitive triggers Approve/Reject buttons;
+ * anything else falls back to a link-out. These tests pin the shapes
+ * that need to round-trip through to the server's renderer.
+ */
+
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { extractForm } from "../src/forms";
+
+describe("extractForm", () => {
+	it("emits a Switch for a single boolean field", () => {
+		// This is the exact shape the email magic-link path needs.
+		const schema = z.object({
+			approved: z.boolean().describe("Approve this transfer?"),
+		});
+
+		const def = extractForm(schema);
+		expect(def).not.toBeNull();
+		expect(def!.fields).toHaveLength(1);
+		expect(def!.fields[0]).toMatchObject({
+			kind: "switch",
+			name: "approved",
+			label: "Approve this transfer?",
+			required: true,
+			true_label: "Yes",
+			false_label: "No",
+		});
+	});
+
+	it("falls back to humanized name when no description set", () => {
+		const schema = z.object({ has_paid: z.boolean() });
+		const def = extractForm(schema)!;
+		expect(def.fields[0].label).toBe("Has Paid");
+	});
+
+	it("marks optional fields as not required", () => {
+		const schema = z.object({
+			approved: z.boolean(),
+			reason: z.string().optional(),
+		});
+		const def = extractForm(schema)!;
+		const reason = def.fields.find((f) => f.name === "reason")!;
+		expect(reason.required).toBe(false);
+	});
+
+	it("nullable + default also flip required to false", () => {
+		const schema = z.object({
+			a: z.boolean().nullable(),
+			b: z.boolean().default(true),
+		});
+		const def = extractForm(schema)!;
+		expect(def.fields.find((f) => f.name === "a")!.required).toBe(false);
+		expect(def.fields.find((f) => f.name === "b")!.required).toBe(false);
+	});
+
+	it("emits short_text for plain strings", () => {
+		const schema = z.object({ note: z.string() });
+		expect(extractForm(schema)!.fields[0].kind).toBe("short_text");
+	});
+
+	it("emits long_text when min length suggests a paragraph", () => {
+		// `.min(N)` with N >= 100 is the heuristic for "the operator
+		// expects a long answer." Anything shorter stays short_text.
+		const schema = z.object({ essay: z.string().min(120) });
+		expect(extractForm(schema)!.fields[0].kind).toBe("long_text");
+	});
+
+	it("emits single_select for ZodEnum", () => {
+		const schema = z.object({
+			priority: z.enum(["low", "medium", "high"]),
+		});
+		const field = extractForm(schema)!.fields[0];
+		expect(field.kind).toBe("single_select");
+		expect(field.options).toEqual([
+			{ value: "low", label: "low" },
+			{ value: "medium", label: "medium" },
+			{ value: "high", label: "high" },
+		]);
+	});
+
+	it("emits short_text for numbers", () => {
+		// Numbers don't drive the magic-link decision, so a string-shape
+		// short_text with the value parsed by the server is fine.
+		const schema = z.object({ amount: z.number() });
+		expect(extractForm(schema)!.fields[0].kind).toBe("short_text");
+	});
+
+	it("returns null for non-object schemas", () => {
+		// FormDefinition only models record-shaped responses. A bare
+		// boolean / string at the top level has no field name — there's
+		// nothing to synthesize.
+		expect(extractForm(z.boolean())).toBeNull();
+		expect(extractForm(z.string())).toBeNull();
+		expect(extractForm(z.array(z.string()))).toBeNull();
+	});
+
+	it("returns null when the object is empty", () => {
+		expect(extractForm(z.object({}))).toBeNull();
+	});
+
+	it("skips fields whose primitive isn't supported yet", () => {
+		// `z.date()` isn't in the synthesizer's coverage — it should be
+		// dropped silently rather than emit a malformed field. The
+		// server falls back to JSON-schema rendering for the omitted
+		// field; the supported one still gets a synthesized Switch.
+		const schema = z.object({
+			when: z.date(),
+			approved: z.boolean(),
+		});
+		const def = extractForm(schema)!;
+		expect(def.fields).toHaveLength(1);
+		expect(def.fields[0].name).toBe("approved");
+	});
+
+	it("preserves field order from the Zod object", () => {
+		// The email magic-link decision is order-sensitive — Approve
+		// first, Reject second. Pin order so future refactors don't
+		// silently swap them.
+		const schema = z.object({
+			a: z.boolean(),
+			b: z.string(),
+			c: z.enum(["x", "y"]),
+		});
+		const names = extractForm(schema)!.fields.map((f) => f.name);
+		expect(names).toEqual(["a", "b", "c"]);
+	});
+});


### PR DESCRIPTION
## Why

The email channel had no automated end-to-end coverage, and most of our existing tests are Python — meaning the TypeScript SDK's wire contract has been mostly trust-by-mock-fetch.

This PR closes both gaps and fixes a real SDK bug found along the way.

## What's in here

### Backend
- New `file` email transport: writes one JSON per email into a configured directory. Captured by the smoke test; useful for dev too. Wired into `resolve_transport` and the identity-create surface.

### TS SDK
- **`apiKey` support on `awaitHuman`** — the SDK was silently 403'ing against any admin-gated server (including `awaithumans dev`'s auto-generated token). Now accepts `apiKey` option, falls back to `AWAITHUMANS_ADMIN_API_TOKEN` env var.
- **`extractForm(schema)` → FormDefinition** — Zod-driven port of the Python `extract_form`. Emits Switch / ShortText / LongText / SingleSelect for the corresponding Zod primitives. `awaitHuman` now ships the synthesized FormDefinition on the create wire instead of `null`.
- This is what makes the email renderer's magic-link decision tree fire for TS-created tasks. Without it, every TS task got the link-out fallback no matter the response schema shape.

### examples/email-smoke
A runnable TS script that exercises the full loop:

1. Creates a sender identity with the file transport
2. Calls `awaitHuman` with a single-Switch response schema and `notify=["email+<id>:..."]`
3. Polls the tmp dir for the rendered email, asserts on content
4. **Parses out the Approve magic-link URL and POSTs it** ← the click-the-button path
5. `awaitHuman` resolves; asserts `approved === true`

Verified end-to-end:

```
→ captured email: subject="Review: Approve wire transfer (smoke test)" to=...
→ email body content checks: OK
→ magic-link URL: http://localhost:3091/api/channels/email/action/aPtzazXM...
→ POSTed magic-link → 200
✓ smoke pass: TS SDK + email channel + magic-link round-trip
```

## Tests

| Suite | Before | After | Delta |
|---|---|---|---|
| Python | 467 | 474 | +7 (file transport) |
| TS SDK | 38 | 53 | +15 (apiKey + forms.ts coverage + happy-path now asserts the synthesized Switch) |

## What's intentionally NOT in here

- Full 27-primitive port of Python's form library. Zod has no `Annotated` equivalent for the explicit-DSL escape hatch, so DatePicker / Slider / Subform / Table etc. need their own design (probably a `formField()` decorator helper). Coverage today is "the shapes the magic-link path needs" + "the common Zod primitives that compose into a useful response form."
- A Slack-driven TS smoke. Slack has its own E2E test (`tests/slack/test_claim_broadcast_e2e.py`); a TS-driven version is the natural follow-up shape.

## Test plan

- [ ] `cd examples/email-smoke && npm install`
- [ ] `awaithumans dev` in another terminal
- [ ] `export AWAITHUMANS_ADMIN_API_TOKEN=$(cat .awaithumans/admin.token)`
- [ ] `npm start` — expect the magic-link round-trip output above
- [ ] `pytest tests/email/` — file transport tests pass
- [ ] `cd packages/typescript-sdk && npm test` — 53 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)