### PR TITLE
feat(typescript-sdk): auto-read admin token + URL from discovery file

### DIFF
--- a/packages/typescript-sdk/src/await-human.ts
+++ b/packages/typescript-sdk/src/await-human.ts
@@ -23,6 +23,7 @@ import {
 	POLL_FETCH_SLACK_SECONDS,
 	POLL_INTERVAL_SECONDS,
 } from "./internal/constants.js";
+import { resolveDiscoveryConfig } from "./internal/discovery.js";
 import { envVar } from "./internal/env.js";
 import { fetchWithTimeout } from "./internal/fetch.js";
 import { generateIdempotencyKey } from "./internal/idempotency.js";
@@ -72,17 +73,30 @@ export async function awaitHuman<TPayload, TResponse>(
 		throw new MarketplaceNotAvailableError();
 	}
 
-	// ── Resolve server URL ──────────────────────────────────────────────
+	// ── Resolve server URL + admin token ────────────────────────────────
+	// Resolution priority (matches the Python SDK's `resolve_*` helpers):
+	//   explicit option → env var → discovery file → default / undefined
+	//
+	// The discovery file lives at `~/.awaithumans-dev.json` and is
+	// written by `awaithumans dev`. Reading it lets a developer run
+	// `awaithumans dev` in one terminal and `npm start` in another
+	// with zero env-var dance — same DX the Python SDK has.
+	const discovery = await resolveDiscoveryConfig();
 	const serverUrl = (
-		options.serverUrl ?? envVar("AWAITHUMANS_URL") ?? DEFAULT_SERVER_URL
+		options.serverUrl ??
+		envVar("AWAITHUMANS_URL") ??
+		discovery.url ??
+		DEFAULT_SERVER_URL
 	).replace(/\/$/, "");
 
-	// ── Resolve admin token ─────────────────────────────────────────────
 	// `awaitHuman` is the agent path — task creation and polling are
 	// admin-only on the server. The Temporal adapter already had this
-	// pattern; direct mode missed it, so any non-localhost-disabled
-	// server 403'd unless callers hand-rolled a fetch wrapper.
-	const apiKey = options.apiKey ?? envVar("AWAITHUMANS_ADMIN_API_TOKEN");
+	// pattern; direct mode missed it, so any admin-gated server
+	// (including dev) 403'd unless callers hand-rolled a fetch wrapper.
+	const apiKey =
+		options.apiKey ??
+		envVar("AWAITHUMANS_ADMIN_API_TOKEN") ??
+		discovery.adminToken;
 
 	// ── Generate idempotency key ────────────────────────────────────────
 	const idempotencyKey =

--- a/packages/typescript-sdk/src/internal/discovery.ts
+++ b/packages/typescript-sdk/src/internal/discovery.ts
@@ -1,0 +1,165 @@
+/**
+ * Read the dev-server discovery file written by `awaithumans dev`.
+ *
+ * Mirrors `awaithumans/utils/discovery.py`. The dev CLI drops a JSON
+ * file at `~/.awaithumans-dev.json` containing the bound URL plus the
+ * auto-generated admin token; the SDK reads it so users don't have to
+ * `export AWAITHUMANS_ADMIN_API_TOKEN=$(cat ...)` before every run.
+ *
+ * Resolution order (matches `client.py`'s `resolve_admin_token` /
+ * `resolve_server_url`):
+ *
+ *     explicit option → env var → discovery file → default / undefined
+ *
+ * Cross-runtime safety: the SDK has to work in Bun, Deno, edge
+ * runtimes, and browsers. Of those only Node + Bun + Deno expose
+ * `node:fs`/`os`, and only via dynamic import. We swallow every
+ * failure and return an empty config — the SDK falls back to defaults
+ * and the server's auth response tells the user what's missing.
+ */
+
+interface DiscoveryFile {
+	url?: string;
+	host?: string;
+	port?: number;
+	pid?: number;
+	started_at?: string;
+	admin_token?: string;
+}
+
+export interface DiscoveryConfig {
+	/** Server URL the dev CLI bound to, e.g. `http://localhost:3001`. */
+	url?: string;
+	/** Auto-generated admin bearer token. */
+	adminToken?: string;
+}
+
+const DISCOVERY_FILE_NAME = ".awaithumans-dev.json";
+
+let _cached: DiscoveryConfig | null = null;
+
+/**
+ * Best-effort: read the dev-server config dropped by `awaithumans dev`.
+ * Returns `{}` when the file doesn't exist / can't be read / we're
+ * in a non-Node runtime.
+ *
+ * Memoized for the process lifetime — agents call awaitHuman in a
+ * hot loop and we don't want a stat per task. Restarting the dev
+ * server invalidates the cached config; restart the agent too in
+ * that case.
+ */
+export async function resolveDiscoveryConfig(): Promise<DiscoveryConfig> {
+	if (_cached !== null) return _cached;
+	_cached = await readDiscovery();
+	return _cached;
+}
+
+// ─── Internals ─────────────────────────────────────────────────────────
+
+interface FsModule {
+	readFile(p: string, enc: string): Promise<string>;
+}
+interface OsModule {
+	homedir(): string;
+}
+interface PathModule {
+	join(...parts: string[]): string;
+}
+
+// Indirected import specs so TypeScript can't statically resolve them
+// against `@types/node` — keeps the SDK's type surface free of Node-
+// specific globals (the SDK has to compile cleanly for Bun/Deno/edge
+// targets too). Resolution happens at runtime; failures fall through
+// to `{}`.
+const NODE_FS_PROMISES = "node:fs/promises";
+const NODE_OS = "node:os";
+const NODE_PATH = "node:path";
+
+async function readDiscovery(): Promise<DiscoveryConfig> {
+	// Dynamic imports so module load doesn't blow up in browser /
+	// edge-runtime contexts that lack node:* — we just return {}.
+	let fsMod: FsModule | undefined;
+	let osMod: OsModule | undefined;
+	let pathMod: PathModule | undefined;
+	try {
+		fsMod = (await import(NODE_FS_PROMISES)) as unknown as FsModule;
+		osMod = (await import(NODE_OS)) as unknown as OsModule;
+		pathMod = (await import(NODE_PATH)) as unknown as PathModule;
+	} catch {
+		return {};
+	}
+	if (!fsMod || !osMod || !pathMod) return {};
+
+	const filePath = pathMod.join(osMod.homedir(), DISCOVERY_FILE_NAME);
+
+	let raw: string;
+	try {
+		raw = await fsMod.readFile(filePath, "utf8");
+	} catch {
+		// Missing file is the common case — first-run before
+		// `awaithumans dev` has been launched, or running in an
+		// environment without a HOME directory.
+		return {};
+	}
+
+	let parsed: DiscoveryFile;
+	try {
+		parsed = JSON.parse(raw) as DiscoveryFile;
+	} catch {
+		// Hand-edited or partially-written file — pretend it's not
+		// there rather than crash the SDK on startup.
+		return {};
+	}
+
+	// Stale-PID detection. The Python SDK does this via os.kill(pid, 0).
+	// On Node we use process.kill(pid, 0) — same idiom, also non-
+	// destructive (signal 0 is "permission probe, no actual signal").
+	// When the dev server crashed without cleanup the file is left
+	// behind; trusting its config would mean sending a stale bearer
+	// to whatever else is bound on that port.
+	if (typeof parsed.pid === "number" && !isProcessAlive(parsed.pid)) {
+		return {};
+	}
+
+	const config: DiscoveryConfig = {};
+	if (typeof parsed.url === "string" && parsed.url) {
+		config.url = parsed.url;
+	}
+	if (typeof parsed.admin_token === "string" && parsed.admin_token) {
+		config.adminToken = parsed.admin_token;
+	}
+	return config;
+}
+
+interface KillableProcess {
+	kill?(pid: number, signal: 0): void;
+}
+
+function isProcessAlive(pid: number): boolean {
+	const proc = (globalThis as { process?: KillableProcess }).process;
+	if (!proc?.kill) return true; // can't tell — best-effort: trust it
+	try {
+		proc.kill(pid, 0);
+		return true;
+	} catch (err) {
+		const code = (err as { code?: string }).code;
+		if (code === "ESRCH") return false; // No such process
+		// EPERM: process exists, we just can't signal — treat as alive.
+		return true;
+	}
+}
+
+/** Test-only: drop the cache so a follow-up read picks up a new file. */
+export function _resetDiscoveryCache(): void {
+	_cached = null;
+}
+
+/**
+ * Test-only: pin the discovery result to a fixed config without
+ * touching the filesystem. Lets unit tests assert against the
+ * "no discovery file" or "specific discovery file" cases without
+ * depending on what the developer has running locally.
+ */
+export function _setDiscoveryCacheForTesting(config: DiscoveryConfig): void {
+	_cached = config;
+}

--- a/packages/typescript-sdk/tests/await-human.test.ts
+++ b/packages/typescript-sdk/tests/await-human.test.ts
@@ -26,6 +26,7 @@ import {
 	TimeoutRangeError,
 	VerificationExhaustedError,
 } from "../src/errors";
+import { _setDiscoveryCacheForTesting } from "../src/internal/discovery";
 
 // ─── Fixtures ────────────────────────────────────────────────────────
 
@@ -74,6 +75,10 @@ function installFetchReject(err: Error): FetchMock {
 
 beforeEach(() => {
 	vi.useRealTimers();
+	// Stub out the discovery file so tests don't depend on whether the
+	// developer has `awaithumans dev` running locally. Each test that
+	// wants to exercise discovery sets its own override.
+	_setDiscoveryCacheForTesting({});
 });
 
 afterEach(() => {
@@ -282,6 +287,58 @@ describe("happy path", () => {
 
 		const createInit = fetchMock.mock.calls[0][1];
 		expect(createInit.headers.Authorization).toBeUndefined();
+	});
+
+	it("falls back to discovery-file admin token when env var omitted", async () => {
+		// When `awaithumans dev` is running, the dev CLI drops a
+		// `~/.awaithumans-dev.json` file with the auto-generated admin
+		// token. The SDK reads it as a third-tier fallback so users
+		// don't have to `export AWAITHUMANS_ADMIN_API_TOKEN=...` before
+		// every run — same DX as the Python SDK.
+		_setDiscoveryCacheForTesting({
+			url: "http://test.local",
+			adminToken: "discovery-file-token-123",
+		});
+
+		const fetchMock = installFetchSequence([
+			makeResponse(200, { id: "t", status: "created" }),
+			makeResponse(200, { status: "completed", response: { approved: true } }),
+		]);
+
+		const original = process.env.AWAITHUMANS_ADMIN_API_TOKEN;
+		delete process.env.AWAITHUMANS_ADMIN_API_TOKEN;
+		try {
+			await awaitHuman(BASE_OPTIONS);
+		} finally {
+			if (original !== undefined) {
+				process.env.AWAITHUMANS_ADMIN_API_TOKEN = original;
+			}
+		}
+
+		const createInit = fetchMock.mock.calls[0][1];
+		expect(createInit.headers.Authorization).toBe(
+			"Bearer discovery-file-token-123",
+		);
+	});
+
+	it("explicit apiKey overrides discovery-file token", async () => {
+		// Resolution priority: option → env → discovery → undefined.
+		// Operators sometimes run their dev server with one token and
+		// want a script to use a different one (e.g. testing a
+		// rotated token). The explicit option must win.
+		_setDiscoveryCacheForTesting({
+			adminToken: "discovery-file-token",
+		});
+
+		const fetchMock = installFetchSequence([
+			makeResponse(200, { id: "t", status: "created" }),
+			makeResponse(200, { status: "completed", response: { approved: true } }),
+		]);
+
+		await awaitHuman({ ...BASE_OPTIONS, apiKey: "explicit-wins" });
+
+		const createInit = fetchMock.mock.calls[0][1];
+		expect(createInit.headers.Authorization).toBe("Bearer explicit-wins");
 	});
 });
 


### PR DESCRIPTION
## Why

After the email-smoke PR landed I tried `cd examples/quickstart-ts && npm start` and got:

```
TaskCreateError [AwaitHumansError]: Failed to create task on the server (HTTP 401).
Server response: {"detail":"Authentication required."}
```

The dev server is admin-gated; the SDK had no token. The Python SDK doesn't have this problem — it reads `~/.awaithumans-dev.json` (the discovery file `awaithumans dev` writes) and pulls the auto-generated admin token + bound URL from there. The TS SDK didn't.

## Fix

Port `resolve_admin_token` / `resolve_server_url` to TypeScript. New `internal/discovery.ts` reads the same `~/.awaithumans-dev.json` file and returns `{url, adminToken}`. `awaitHuman` now uses it as the third tier of resolution:

```
explicit option → env var → discovery file → default / undefined
```

Same priority as the Python SDK's `resolve_*` helpers.

### Cross-runtime safety

The SDK has to compile and run on Bun, Deno, edge runtimes, and browsers — none of which expose `node:fs`. Implementation:

- **Dynamic imports** of `node:fs/promises`, `node:os`, `node:path` so module load doesn't blow up in non-Node runtimes
- **Indirected import specs** (string variables) so TypeScript doesn't try to statically resolve them against `@types/node` (deliberately not a dep — the SDK's type surface stays runtime-agnostic)
- **Failures return `{}`** — falls back to the existing default behavior

### Stale-PID guard

Mirrors the Python SDK's `os.kill(pid, 0)` check via Node's `process.kill(pid, 0)` — non-destructive permission probe that returns `ESRCH` when the process is dead. A discovery file left by a crashed dev server returns `{}` instead of pointing the SDK at a stale token.

## Tests

- 2 new cases on `await-human.test.ts`:
  - discovery-file token used when env var is absent
  - explicit `apiKey` overrides discovery file
- All existing tests now stub the discovery cache via `_setDiscoveryCacheForTesting({})` in `beforeEach` so they don't depend on whether the developer has a dev server running locally

`53 → 55 passing` (+2). Typecheck clean.

## Verified end-to-end

After this change, with **no env vars** set:

```sh
awaithumans dev                   # in another terminal
cd examples/quickstart-ts && npm start
→ creating task on the awaithumans server...
# → task appears in admin task list with status=created
```

Same DX as `python refund.py` against a running dev server.

## Test plan

- [ ] `cd packages/typescript-sdk && npm test` — 55 passing
- [ ] `cd examples/quickstart-ts && npm install && npm start` against a fresh dev server with NO env vars — task gets created
- [ ] Stop the dev server, leave the stale discovery file, run `npm start` — falls back to default URL + no token (server is gone, request errors with ServerUnreachableError, not a stale-token 401)
- [ ] `cd examples/email-smoke && AWAITHUMANS_ADMIN_API_TOKEN=$(cat ~/.awaithumans-dev.json | jq -r .admin_token) npm start` — explicit token still works (existing path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)