### PR TITLE
fix(examples,cli): Python email-smoke + dev CLI auto-discover admin token

### DIFF
--- a/examples/email-smoke-py/smoke.py
+++ b/examples/email-smoke-py/smoke.py
@@ -48,16 +48,23 @@ import httpx
 from pydantic import BaseModel, Field
 
 from awaithumans import await_human
+from awaithumans.utils.discovery import resolve_admin_token, resolve_server_url
 
 # ─── Config ────────────────────────────────────────────────────────────
 
-SERVER_URL = os.environ.get("AWAITHUMANS_URL", "http://localhost:3001").rstrip("/")
-ADMIN_TOKEN = os.environ.get("AWAITHUMANS_ADMIN_API_TOKEN")
+# Resolve URL + admin token via the same chain `await_human` itself
+# uses internally — explicit env var → discovery file written by
+# `awaithumans dev`. Means the smoke "just works" against a running
+# dev server with no env-var dance, mirroring the Python SDK's
+# default DX.
+SERVER_URL = resolve_server_url().rstrip("/")
+ADMIN_TOKEN = resolve_admin_token()
 
 if not ADMIN_TOKEN:
     print(
-        "AWAITHUMANS_ADMIN_API_TOKEN is required. Run `awaithumans dev` first, "
-        "then export the token from the path it printed.",
+        "Couldn't find an admin token. Either:\n"
+        "  - Run `awaithumans dev` (writes ~/.awaithumans-dev.json) and try again, OR\n"
+        "  - Export AWAITHUMANS_ADMIN_API_TOKEN with the token your server uses.",
         file=sys.stderr,
     )
     sys.exit(1)

--- a/packages/python/awaithumans/cli/commands/dev.py
+++ b/packages/python/awaithumans/cli/commands/dev.py
@@ -188,6 +188,17 @@ def dev(
     logger.info("Starting awaithumans server on http://%s:%d", host, actual_port)
     logger.info("Dashboard at http://%s:%d", host, actual_port)
     logger.info("SQLite database at %s", db_path)
+    # Tell the user where the admin token is + that they don't have to
+    # do anything with it. The Python and TypeScript SDKs both read
+    # it from the discovery file automatically, so a fresh shell
+    # running `python refund.py` or `npm start` "just works." The
+    # only time an operator needs to copy this is when they're
+    # talking to the API from curl.
+    logger.info(
+        "Admin token written to %s (SDKs auto-detect via "
+        "~/.awaithumans-dev.json — copy only for curl)",
+        Path(db_path).parent / "admin.token",
+    )
     logger.info("Ready — waiting for tasks...")
 
     from awaithumans.server.app import create_app


### PR DESCRIPTION
## Symptom

```
$ python smoke.py
AWAITHUMANS_ADMIN_API_TOKEN is required. Run \`awaithumans dev\` first, then export the token from the path it printed.
```

…even though `awaithumans dev` was running. And the dev CLI startup log never tells the user where the token lives, so they don't know what to copy.

## Two layered fixes

### 1. Python email-smoke uses the discovery file

`examples/email-smoke-py/smoke.py` was hardcoded to require `AWAITHUMANS_ADMIN_API_TOKEN` for its admin-API calls (email-identity setup). The Python SDK *itself* already reads the discovery file via `resolve_admin_token()` — the smoke just never plugged into that.

Now uses `resolve_admin_token()` / `resolve_server_url()` from `awaithumans.utils.discovery`. Same precedence the rest of the SDK uses (explicit → env → discovery → None).

### 2. Dev CLI tells users about the token

Adds one log line at startup:

```
[INFO] awaithumans.cli — Admin token written to .awaithumans/admin.token
    (SDKs auto-detect via ~/.awaithumans-dev.json — copy only for curl)
```

So new users see (a) where it is, and (b) that they don't have to copy it for the SDKs — only for raw `curl` calls.

## Verified end-to-end

With **no env vars**:

```
$ awaithumans dev    # in another terminal
$ cd examples/email-smoke-py && python smoke.py
→ captured email: subject="Review: Approve wire transfer (smoke test)" to=...
→ POSTed magic-link → 200
✓ smoke pass: Python SDK + email channel + magic-link round-trip
```

## Tests

  - 474 Python tests still pass (no regressions in the dev-CLI changes)
  - No new tests added — the existing discovery tests cover `resolve_admin_token`; the smoke script's behavior is exercised by the runnable script itself

## Test plan

- [ ] `awaithumans dev` shows the new "Admin token written to..." log line on startup
- [ ] `cd examples/email-smoke-py && python smoke.py` works with no env vars
- [ ] Setting `AWAITHUMANS_ADMIN_API_TOKEN=` to a wrong value still wins (env > discovery)
- [ ] Existing smoke flow (with env var explicitly set) still works

## Related

This is the Python-side parity of [#46](../pull/46) — the TS SDK got the same auto-discovery treatment in that PR. Both SDKs now have the same DX: run the dev server, run your script, no env-var dance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)