### PR TITLE
feat(typescript-sdk): expose resolveAdminToken / resolveServerUrl + use in TS smoke

### DIFF
--- a/examples/email-smoke/smoke.ts
+++ b/examples/email-smoke/smoke.ts
@@ -42,20 +42,28 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 
-import { awaitHuman } from "awaithumans";
+import {
+	awaitHuman,
+	resolveAdminToken,
+	resolveServerUrl,
+} from "awaithumans";
 import { z } from "zod";
 
 // ─── Config ────────────────────────────────────────────────────────────
 
-const SERVER_URL =
-	process.env.AWAITHUMANS_URL ?? "http://localhost:3001";
-const ADMIN_TOKEN = process.env.AWAITHUMANS_ADMIN_API_TOKEN;
+// Resolve URL + admin token via the same chain `awaitHuman` uses
+// internally (explicit → env var → discovery file written by
+// `awaithumans dev`). Means the smoke "just works" against a
+// running dev server with no env-var dance, mirroring the Python
+// SDK's default DX.
+const SERVER_URL = (await resolveServerUrl()).replace(/\/$/, "");
+const ADMIN_TOKEN = await resolveAdminToken();
 
 if (!ADMIN_TOKEN) {
 	console.error(
-		"AWAITHUMANS_ADMIN_API_TOKEN is required. " +
-			"Run `awaithumans dev` first, then set the env var to the contents " +
-			"of ~/.awaithumans/admin.token (or wherever your dev DB sits).",
+		"Couldn't find an admin token. Either:\n" +
+			"  - Run `awaithumans dev` (writes ~/.awaithumans-dev.json) and try again, OR\n" +
+			"  - Export AWAITHUMANS_ADMIN_API_TOKEN with the token your server uses.",
 	);
 	process.exit(1);
 }

--- a/packages/typescript-sdk/src/discovery.ts
+++ b/packages/typescript-sdk/src/discovery.ts
@@ -1,0 +1,64 @@
+/**
+ * Public dev-server discovery helpers.
+ *
+ * Mirror of `awaithumans.utils.discovery` on the Python side. Lets
+ * tooling (smoke tests, examples, custom scripts) resolve the
+ * dev-server URL + admin token using the same precedence the SDK
+ * uses internally:
+ *
+ *     explicit option → env var → discovery file → default / undefined
+ *
+ * The discovery file at `~/.awaithumans-dev.json` is written by
+ * `awaithumans dev`; reading it is the trick that makes both SDKs
+ * "just work" without an env-var dance.
+ */
+
+import { DEFAULT_SERVER_URL } from "./internal/constants.js";
+import { resolveDiscoveryConfig } from "./internal/discovery.js";
+import { envVar } from "./internal/env.js";
+
+export type { DiscoveryConfig } from "./internal/discovery.js";
+export { resolveDiscoveryConfig } from "./internal/discovery.js";
+
+/**
+ * Resolve the admin bearer token the SDK should send.
+ *
+ * Same precedence as Python's `resolve_admin_token`:
+ *
+ *   1. explicit `explicitToken` argument
+ *   2. `AWAITHUMANS_ADMIN_API_TOKEN` env var
+ *   3. discovery file at `~/.awaithumans-dev.json` (dev-only)
+ *   4. undefined — request goes out without a bearer header
+ *
+ * Returns undefined when none of the layers produce a value; callers
+ * decide whether to error or proceed anonymously.
+ */
+export async function resolveAdminToken(
+	options?: { explicitToken?: string },
+): Promise<string | undefined> {
+	if (options?.explicitToken) return options.explicitToken;
+	const env = envVar("AWAITHUMANS_ADMIN_API_TOKEN");
+	if (env) return env;
+	const config = await resolveDiscoveryConfig();
+	return config.adminToken;
+}
+
+/**
+ * Resolve the awaithumans server URL the SDK should hit.
+ *
+ * Same precedence as Python's `resolve_server_url`:
+ *
+ *   1. explicit `explicitUrl` argument
+ *   2. `AWAITHUMANS_URL` env var
+ *   3. discovery file (dev-server bound URL)
+ *   4. `http://localhost:3001` default
+ */
+export async function resolveServerUrl(
+	options?: { explicitUrl?: string },
+): Promise<string> {
+	if (options?.explicitUrl) return options.explicitUrl;
+	const env = envVar("AWAITHUMANS_URL");
+	if (env) return env;
+	const config = await resolveDiscoveryConfig();
+	return config.url ?? DEFAULT_SERVER_URL;
+}

--- a/packages/typescript-sdk/src/index.ts
+++ b/packages/typescript-sdk/src/index.ts
@@ -48,3 +48,11 @@ export {
 } from "./errors.js";
 
 export { awaitAgent, awaitAny } from "./reserved.js";
+
+// ─── Discovery helpers (read the dev-server config) ────────────────
+export type { DiscoveryConfig } from "./discovery.js";
+export {
+	resolveAdminToken,
+	resolveDiscoveryConfig,
+	resolveServerUrl,
+} from "./discovery.js";

--- a/packages/typescript-sdk/tests/discovery.test.ts
+++ b/packages/typescript-sdk/tests/discovery.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Public discovery helpers — `resolveAdminToken` / `resolveServerUrl`.
+ *
+ * Mirrors the Python `resolve_admin_token` / `resolve_server_url`
+ * tests. The internal `resolveDiscoveryConfig` is already covered by
+ * its own behaviour in `await-human.test.ts`; this file pins the
+ * public surface (precedence between explicit option / env var /
+ * discovery file).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { resolveAdminToken, resolveServerUrl } from "../src/discovery";
+import { _setDiscoveryCacheForTesting } from "../src/internal/discovery";
+
+const ENV_TOKEN_KEY = "AWAITHUMANS_ADMIN_API_TOKEN";
+const ENV_URL_KEY = "AWAITHUMANS_URL";
+
+let savedToken: string | undefined;
+let savedUrl: string | undefined;
+
+beforeEach(() => {
+	savedToken = process.env[ENV_TOKEN_KEY];
+	savedUrl = process.env[ENV_URL_KEY];
+	delete process.env[ENV_TOKEN_KEY];
+	delete process.env[ENV_URL_KEY];
+	// Pin the discovery cache so tests don't depend on the developer's
+	// local `~/.awaithumans-dev.json`.
+	_setDiscoveryCacheForTesting({});
+});
+
+afterEach(() => {
+	if (savedToken === undefined) delete process.env[ENV_TOKEN_KEY];
+	else process.env[ENV_TOKEN_KEY] = savedToken;
+	if (savedUrl === undefined) delete process.env[ENV_URL_KEY];
+	else process.env[ENV_URL_KEY] = savedUrl;
+});
+
+// ─── resolveAdminToken ─────────────────────────────────────────────────
+
+describe("resolveAdminToken", () => {
+	it("returns explicit token when supplied", async () => {
+		process.env[ENV_TOKEN_KEY] = "env-loses";
+		_setDiscoveryCacheForTesting({ adminToken: "discovery-loses" });
+
+		const out = await resolveAdminToken({ explicitToken: "explicit-wins" });
+
+		expect(out).toBe("explicit-wins");
+	});
+
+	it("falls back to env var when no explicit token", async () => {
+		process.env[ENV_TOKEN_KEY] = "env-token";
+		_setDiscoveryCacheForTesting({ adminToken: "discovery-loses" });
+
+		const out = await resolveAdminToken();
+
+		expect(out).toBe("env-token");
+	});
+
+	it("falls back to discovery file when env unset", async () => {
+		_setDiscoveryCacheForTesting({ adminToken: "discovery-token" });
+
+		const out = await resolveAdminToken();
+
+		expect(out).toBe("discovery-token");
+	});
+
+	it("returns undefined when nothing is configured", async () => {
+		const out = await resolveAdminToken();
+		expect(out).toBeUndefined();
+	});
+});
+
+// ─── resolveServerUrl ──────────────────────────────────────────────────
+
+describe("resolveServerUrl", () => {
+	it("returns explicit URL when supplied", async () => {
+		process.env[ENV_URL_KEY] = "http://env-loses.local";
+		_setDiscoveryCacheForTesting({ url: "http://discovery-loses.local" });
+
+		const out = await resolveServerUrl({
+			explicitUrl: "http://explicit-wins.local",
+		});
+
+		expect(out).toBe("http://explicit-wins.local");
+	});
+
+	it("falls back to env var when no explicit URL", async () => {
+		process.env[ENV_URL_KEY] = "http://env.local";
+		_setDiscoveryCacheForTesting({ url: "http://discovery-loses.local" });
+
+		const out = await resolveServerUrl();
+
+		expect(out).toBe("http://env.local");
+	});
+
+	it("falls back to discovery file when env unset", async () => {
+		_setDiscoveryCacheForTesting({ url: "http://discovery.local:3091" });
+
+		const out = await resolveServerUrl();
+
+		expect(out).toBe("http://discovery.local:3091");
+	});
+
+	it("returns the localhost default when nothing is configured", async () => {
+		const out = await resolveServerUrl();
+		// Default lives in `internal/constants.ts`. Pin it so a
+		// regression there doesn't silently change the SDK's
+		// default endpoint.
+		expect(out).toBe("http://localhost:3001");
+	});
+});


### PR DESCRIPTION
Follow-up to #46. That PR's second commit landed on the branch *after* the merge button was pressed, so it never reached main — meaning the public discovery helpers and the smoke-test update aren't on main yet. This PR re-applies them.

## What's in here

The same commit that was sitting orphaned on the post-merge branch:

- **`src/discovery.ts`** — public module wrapping the internal `resolveDiscoveryConfig` with the precedence chain Python's `resolve_admin_token` / `resolve_server_url` use:
  ```
  explicit option → env var → discovery file → default / undefined
  ```

- **Re-exports** from `index.ts`: `resolveAdminToken`, `resolveServerUrl`, `resolveDiscoveryConfig`, `DiscoveryConfig`. Tooling can now read the dev-server config via the public API instead of poking at `internal/`.

- **TS smoke** (`examples/email-smoke/smoke.ts`) now calls `resolveAdminToken()` / `resolveServerUrl()` instead of demanding `AWAITHUMANS_ADMIN_API_TOKEN` up-front. Same DX as the Python smoke after #47.

## Why this fix isn't already on main

PR #46 merged at `2026-05-06T20:19:10Z` with only its first commit. I pushed the second commit (the one in this PR) right after — so it sat on the branch as an orphan once the branch was deleted from the merge UI.

## Tests

55 → 63 passing (+8 covering the full precedence matrix for `resolveAdminToken` and `resolveServerUrl`).

## Verified end-to-end

After merging this and rebuilding (`cd packages/typescript-sdk && npm run build && cd ../../examples/email-smoke && npm install`), with NO env vars:

```
$ awaithumans dev    # in another terminal
$ npm start
→ smoke against http://localhost:3001
→ POSTed magic-link → 200
✓ smoke pass: TS SDK + email channel + magic-link round-trip
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)