### PR TITLE
feat(examples): slack-native-ts — TS counterpart of slack-native (Python)

### DIFF
--- a/MANUAL_TESTING.md
+++ b/MANUAL_TESTING.md
@@ -179,15 +179,24 @@ Once the Slack app is configured and the workspace is connected:
    click "Add user", paste your Slack handle (`@youhandle`), pick
    your workspace from the dropdown. Display name auto-fills.
 
-2. **Run the slack-native example:**
+2. **Run a slack-native example.** Pick the language you want to
+   exercise — the flow is identical, only the SDK differs.
 
+   Python:
    ```sh
    cd examples/slack-native
    python refund.py
    ```
 
-   The script creates a task with `notify=["slack:@youhandle"]` and
-   blocks.
+   TypeScript:
+   ```sh
+   cd examples/slack-native-ts
+   npm install
+   npm start
+   ```
+
+   Either script creates a task with `notify=["slack:@youhandle"]`
+   and blocks.
 
 3. **Open the Slack DM the bot just sent you.** The message has an
    "Open in Dashboard" button (signed handoff URL — works even if

--- a/examples/slack-native-ts/README.md
+++ b/examples/slack-native-ts/README.md
@@ -1,0 +1,88 @@
+# slack-native-ts
+
+TypeScript counterpart of [`../slack-native/`](../slack-native/) (Python).
+Same flow, same shape — different SDK.
+
+A small script that creates a wire-transfer approval task, sends it
+as a Slack DM to a tagged user (`@TA` by default), and prints the
+response when they decide.
+
+## What runs
+
+1. The TS SDK creates a task with `notify=["slack:@TA"]`.
+2. The server resolves `@TA` against the directory (implicit-
+   assignee derivation pins TA as `assigned_to_user_id`), then DMs
+   them via the Slack channel.
+3. TA sees the DM with two buttons:
+   - **Approve in Slack** — opens the Block-Kit modal in place
+   - **Open in Dashboard** — signed handoff URL (works even if TA
+     has no email/password)
+4. TA submits via either path. The Slack message updates to
+   "Completed by @TA" with no buttons.
+5. This script's `awaitHuman` resolves with the typed response.
+
+## Prerequisites
+
+- **`awaithumans dev` running** in another terminal. The TS SDK
+  reads its discovery file for URL + admin token, so no env-var
+  dance is needed.
+- **Slack app linked + workspace OAuth completed** — one-time setup,
+  see [`examples/slack-native/README.md`](../slack-native/README.md)
+  for the full Slack-side configuration. ngrok required for OAuth /
+  interactivity callbacks.
+- **User in the directory.** In the dashboard's Users page, click
+  "Add user", paste the Slack handle (`@TA`), pick the workspace
+  from the dropdown. Display name auto-fills.
+
+## Run
+
+```sh
+cd examples/slack-native-ts
+npm install
+npm start
+```
+
+Expected output:
+
+```
+→ creating task — notify=slack:@TA
+  transfer_id=WT-MOUI...
+[blocks until TA decides in Slack]
+
+✓ Approved by @TA
+  full response: {"approved":true}
+```
+
+## Change the Slack handle
+
+By default the script tags `@TA`. Edit `wire-transfer.ts`:
+
+```ts
+const SLACK_HANDLE = "TA";  // ← change to whatever handle you added
+```
+
+## What this exercises
+
+- TS SDK creates a task with Slack notify entry
+- Server-side implicit-assignee derivation (`@TA` → directory user
+  with that Slack handle → set as `assigned_to_user_id`)
+- Slack notification: DM sent with Approve/Open buttons
+- Slack interactivity: modal opens, view_submission completes the
+  task, message updates to "Completed by @TA"
+- TS SDK long-poll resolves on out-of-band completion
+
+If any of the above breaks, the Slack-channel coverage hasn't
+regressed but the contract between TS SDK and server has — start
+with `pytest tests/slack/` then check the dashboard's audit log.
+
+## Why no automated smoke for Slack (vs email)?
+
+The email path has a public, signed-token endpoint
+(`/api/channels/email/action/<token>`) that any HTTP client can
+POST to. Slack's interactivity endpoints sign requests against a
+shared secret per workspace and route through Slack's own
+servers — not feasible to drive from a local script without
+spinning up a real Slack app.
+
+This example is a manual checklist for "does the Slack flow work
+end-to-end from TypeScript." Run it, click around, watch the dash.

--- a/examples/slack-native-ts/package.json
+++ b/examples/slack-native-ts/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "awaithumans-slack-native-ts",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "tsx wire-transfer.ts"
+  },
+  "dependencies": {
+    "awaithumans": "file:../../packages/typescript-sdk",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/slack-native-ts/tsconfig.json
+++ b/examples/slack-native-ts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["*.ts"]
+}

--- a/examples/slack-native-ts/wire-transfer.ts
+++ b/examples/slack-native-ts/wire-transfer.ts
@@ -1,0 +1,109 @@
+/**
+ * TS counterpart of `examples/slack-native/refund.py` — delegate a
+ * task to a Slack user via DM, await their decision in TypeScript.
+ *
+ * What happens:
+ *
+ *   1. The TS SDK creates a task with `notify=["slack:@TA"]`.
+ *   2. The server resolves `@TA` against the directory (the implicit-
+ *      assignee derivation pins TA as `assigned_to_user_id`), then
+ *      DMs them via the Slack channel.
+ *   3. TA sees the DM with two buttons:
+ *        - "Approve in Slack" — opens the Block-Kit modal in place
+ *        - "Open in Dashboard" — signed handoff URL (works even if
+ *          TA has no email/password)
+ *   4. TA submits via either path. The Slack message updates to
+ *      "Completed by @TA" with no buttons (so they can't re-trigger).
+ *   5. This script's `awaitHuman` resolves with the typed response.
+ *
+ * Prerequisites:
+ *
+ *   - `awaithumans dev` running (the SDK reads its discovery file
+ *     for URL + admin token; no env-var dance needed)
+ *   - Slack app linked + workspace OAuth completed (one-time setup;
+ *     see examples/slack-native/README.md)
+ *   - User `TA` added to the directory with a Slack handle, via the
+ *     dashboard's Users → Add user form
+ *
+ * Run:
+ *
+ *     cd examples/slack-native-ts
+ *     npm install
+ *     npm start
+ */
+
+import { awaitHuman } from "awaithumans";
+import { z } from "zod";
+
+// ─── Schemas ───────────────────────────────────────────────────────────
+
+// What TA sees while reviewing.
+const WireTransfer = z.object({
+	transferId: z.string(),
+	amountUsd: z.number(),
+	to: z.string(),
+});
+
+// IMPORTANT: a single boolean response triggers the email/Slack
+// renderer's compact magic-link / button path. Multi-field responses
+// fall back to "open the form" — still works, but the demo's less
+// snappy. Keep this single-field so the Slack DM has Approve/Reject
+// buttons inline.
+const Approval = z.object({
+	approved: z
+		.boolean()
+		.describe("Approve this wire transfer?"),
+});
+
+// ─── Config ────────────────────────────────────────────────────────────
+
+// The Slack handle we're tagging. Change this to whatever you set
+// when you added the user in the dashboard.
+const SLACK_HANDLE = "TA";
+
+// ─── Run ───────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+	const transferId = `WT-${Date.now().toString(36).toUpperCase()}`;
+	console.log(`→ creating task — notify=slack:@${SLACK_HANDLE}`);
+	console.log(`  transfer_id=${transferId}`);
+
+	const decision = await awaitHuman({
+		task: "Approve this wire transfer",
+		payloadSchema: WireTransfer,
+		payload: {
+			transferId,
+			amountUsd: 12_500,
+			to: "Acme Inc.",
+		},
+		responseSchema: Approval,
+		// 15-minute window — generous for a manual demo. The Slack
+		// message stays interactive that whole time; after expiry it
+		// auto-updates to "Timed out" via the post-completion updater.
+		timeoutMs: 15 * 60_000,
+		// Single notify entry → implicit-assignee derivation fires
+		// server-side, marking TA as `assigned_to_user_id`. Without
+		// this binding, the Slack `view_submission` auth check would
+		// reject TA's submission as "not assigned to you."
+		notify: [`slack:@${SLACK_HANDLE}`],
+		// Stable idempotency so a re-run during the same wall-clock
+		// second returns the existing task instead of stacking
+		// duplicates. In production, tie this to a real business
+		// identifier (transferId here is fine because we generated
+		// it just above).
+		idempotencyKey: `slack-ts-demo:${transferId}`,
+	});
+
+	console.log("");
+	if (decision.approved) {
+		console.log(`✓ Approved by @${SLACK_HANDLE}`);
+	} else {
+		console.log(`✗ Rejected by @${SLACK_HANDLE}`);
+	}
+	console.log(`  full response: ${JSON.stringify(decision)}`);
+}
+
+main().catch((err) => {
+	console.error("✗ failed:", err);
+	process.exit(1);
+});


### PR DESCRIPTION
## Why

I want to test creating a task and delegating it via Slack from TypeScript, tagging `@TA`. Until now `examples/slack-native/` was Python-only, so there was no hands-on TS demo for the "agent creates task → sent to a Slack user via DM → human approves in Slack" loop. This adds the TS counterpart.

## What's in here

`examples/slack-native-ts/` — small script that:

1. Creates a task with `notify=["slack:@TA"]` (configurable handle in one place)
2. Server's implicit-assignee derivation pins TA as the assignee (so the Slack `view_submission` auth check accepts their click)
3. TA receives a Slack DM with **Approve in Slack** + **Open in Dashboard** buttons
4. They submit via either path; SDK's `awaitHuman` resolves with the typed response

Same shape as `examples/quickstart-ts/refund.ts` and the Python `slack-native/refund.py` — different SDK, identical contract.

## Layout

```
examples/slack-native-ts/
  package.json          # file:../../packages/typescript-sdk
  tsconfig.json
  wire-transfer.ts      # the runnable script (single Switch response → Slack buttons)
  README.md             # run instructions, prereqs, what the test exercises
```

## How to run (after merging)

```sh
cd examples/slack-native-ts
npm install
npm start
```

(Assumes `awaithumans dev` is running with the Slack app linked and `@TA` added to the directory. The TS SDK's discovery resolver finds the URL + admin token without env-var dance, courtesy of #46/#48.)

## Coverage

- TS SDK creates task with Slack notify entry ✓
- Implicit-assignee derivation maps `@TA` → directory user ✓
- Slack DM sent + buttons rendered ✓
- Slack interactivity completes the task (modal or dashboard handoff URL) ✓
- TS SDK long-poll resolves on out-of-band completion ✓

## Why no automated smoke (vs email)

The email path has a public, signed-token endpoint that any HTTP client can POST to. Slack's interactivity callback is signed against a per-workspace secret and routes through Slack's own servers — driving it from a local test script needs a real Slack app + ngrok. This is a manual checklist example, mirrored in `MANUAL_TESTING.md` section 7.

## Other changes

`MANUAL_TESTING.md` section 7 (Slack — DM completion) now points at both the Python and TS scripts so contributors can pick whichever SDK they're testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)