### PR TITLE
feat(examples): email-end-to-end — real-delivery TS test (Resend / SMTP)

### DIFF
--- a/MANUAL_TESTING.md
+++ b/MANUAL_TESTING.md
@@ -179,15 +179,24 @@ Once the Slack app is configured and the workspace is connected:
    click "Add user", paste your Slack handle (`@youhandle`), pick
    your workspace from the dropdown. Display name auto-fills.
 
-2. **Run the slack-native example:**
+2. **Run a slack-native example.** Pick the language you want to
+   exercise — the flow is identical, only the SDK differs.
 
+   Python:
    ```sh
    cd examples/slack-native
    python refund.py
    ```
 
-   The script creates a task with `notify=["slack:@youhandle"]` and
-   blocks.
+   TypeScript:
+   ```sh
+   cd examples/slack-native-ts
+   npm install
+   npm start
+   ```
+
+   Either script creates a task with `notify=["slack:@youhandle"]`
+   and blocks.
 
 3. **Open the Slack DM the bot just sent you.** The message has an
    "Open in Dashboard" button (signed handoff URL — works even if

--- a/examples/email-end-to-end/README.md
+++ b/examples/email-end-to-end/README.md
@@ -1,0 +1,118 @@
+# email-end-to-end
+
+Real-delivery email test. Same shape as
+[`../email-smoke/`](../email-smoke/) but configured for an actual
+provider — you receive the email in your real inbox and click the
+Approve button by hand. The TypeScript SDK long-polls until your
+click lands.
+
+This is the test that exercises the FULL pipeline:
+
+- TS SDK creates the task
+- Server resolves the email channel + identity
+- Real provider (Resend / SMTP) ships the email through real DNS
+- Email lands in your inbox, with HTML + text bodies, magic-link
+  buttons, the works
+- You click "Approve" — the action endpoint completes the task
+  with the value baked into the signed token
+- TS SDK's `awaitHuman` resolves with the typed response
+
+Pick whichever transport you have credentials for.
+
+## Option A — Resend (recommended; 5 minutes)
+
+Fastest path. Resend's free tier is enough for this and they have a
+no-setup sender (`onboarding@resend.dev`) so you can skip domain
+verification.
+
+1. Sign up at https://resend.com — free tier is generous.
+2. Go to **API Keys** → **Create API Key** → name it whatever, full
+   access. Copy the `re_…` value.
+3. Run:
+   ```sh
+   cd examples/email-end-to-end
+   npm install
+   AWAITHUMANS_TEST_TRANSPORT=resend \
+     RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxxxxxxxx \
+     RECIPIENT_EMAIL=you@example.com \
+     npm start
+   ```
+4. Check your inbox — you should see a "Review: Approve this
+   real-delivery test" email within 1–2 seconds. Click **Approve**.
+5. The script prints `✓ Approved — task completed end-to-end via
+   real email` and exits.
+
+If you want to send from your own domain instead of
+`onboarding@resend.dev`:
+
+- In Resend, **Domains → Add Domain** → follow the DNS verification
+- Then pass `FROM_EMAIL=alerts@yourdomain.com` to the npm command
+
+## Option B — SMTP (Gmail App Password)
+
+Use this if you're testing against your own SMTP server, AWS SES,
+Mailgun, or want the Gmail-via-SMTP path.
+
+For Gmail specifically (a common dev setup):
+
+1. Enable 2FA on the Google account (required for App Passwords):
+   https://myaccount.google.com/security
+2. Generate an App Password:
+   https://myaccount.google.com/apppasswords
+   Pick "Mail" → "Other (custom name)" → name it `awaithumans-dev`.
+   Google shows you a 16-character password. Copy it (no spaces).
+3. Run:
+   ```sh
+   cd examples/email-end-to-end
+   npm install
+   AWAITHUMANS_TEST_TRANSPORT=smtp \
+     SMTP_HOST=smtp.gmail.com \
+     SMTP_PORT=587 \
+     SMTP_USER=you@gmail.com \
+     SMTP_PASSWORD="<the 16-char app password>" \
+     FROM_EMAIL=you@gmail.com \
+     RECIPIENT_EMAIL=you@gmail.com \
+     npm start
+   ```
+4. Check your inbox; click Approve; script returns.
+
+For other SMTP providers, swap `SMTP_HOST`/`SMTP_PORT`/`SMTP_USER`/
+`SMTP_PASSWORD`/`FROM_EMAIL` accordingly. AWS SES needs SMTP
+credentials (not your IAM key); Mailgun's SMTP creds are in their
+dashboard. The same flags work everywhere.
+
+## What this catches that the smoke test doesn't
+
+- Real DNS resolution + TLS / STARTTLS to the provider
+- Actual rendering in real mail clients (Gmail, Outlook, Apple
+  Mail) — buttons survive the client's email-CSS sandbox
+- The `from_email` is well-formed enough for SPF / DKIM / DMARC
+  not to bounce it
+- The magic-link URL is reachable from a browser that didn't run
+  the test (your phone, your laptop, etc.)
+
+## Re-runs
+
+The identity ID is hardcoded as `email-e2e-real` and uses upsert
+semantics — running again with a different `RESEND_API_KEY` or
+SMTP host just overwrites the config in the DB. No need to delete
+anything between runs.
+
+If you want to clean up after the test:
+
+```sh
+TOKEN=$(cat ~/.awaithumans-dev.json | jq -r .admin_token)
+curl -X DELETE \
+  -H "Authorization: Bearer $TOKEN" \
+  http://localhost:3001/api/channels/email/identities/email-e2e-real
+```
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `Couldn't find an admin token` | Start `awaithumans dev` first — the SDK reads its discovery file |
+| `RESEND_API_KEY required` | Pass it as a flag (see Option A) |
+| Email never arrives | Check `awaithumans dev` logs for the email-channel error. Common causes: invalid API key, sender not verified in Resend, SMTP creds wrong |
+| `5xx` from clicking the magic link | Token expired (default TTL is 24h) or already consumed — magic links are single-use |
+| Email arrives but no buttons, just a "Review in dashboard" link | The response schema isn't a single boolean. The renderer falls back to the dashboard link-out for multi-field forms — this is expected behavior. Click the dashboard link instead |

--- a/examples/email-end-to-end/README.md
+++ b/examples/email-end-to-end/README.md
@@ -81,6 +81,51 @@ For other SMTP providers, swap `SMTP_HOST`/`SMTP_PORT`/`SMTP_USER`/
 credentials (not your IAM key); Mailgun's SMTP creds are in their
 dashboard. The same flags work everywhere.
 
+### Option B-bis — Hostinger Mail (custom domain on Hostinger hPanel)
+
+Hostinger uses port 465 with SSL (implicit TLS). The script
+auto-detects port 465 and switches off STARTTLS — no extra flag
+needed.
+
+1. **Get your mailbox credentials.** In Hostinger hPanel → Emails
+   → pick the mailbox → "Connect Apps & Devices" (or "Configure
+   Desktop App"). Hostinger shows the SMTP host, port, and the
+   password is whatever you set when you created the mailbox.
+   Common values:
+   - **SMTP host**: `smtp.hostinger.com`
+   - **SMTP port**: `465` (SSL — preferred) or `587` (STARTTLS)
+   - **Username**: your full email address (`you@yourdomain.com`)
+   - **Password**: the mailbox password you set in hPanel
+     (NOT your Hostinger account password)
+2. **Run:**
+   ```sh
+   cd examples/email-end-to-end
+   npm install
+   AWAITHUMANS_TEST_TRANSPORT=smtp \
+     SMTP_HOST=smtp.hostinger.com \
+     SMTP_PORT=465 \
+     SMTP_USER=you@yourdomain.com \
+     SMTP_PASSWORD="<your-mailbox-password>" \
+     FROM_EMAIL=you@yourdomain.com \
+     RECIPIENT_EMAIL=you@yourdomain.com \
+     npm start
+   ```
+3. Click Approve in your inbox; script returns.
+
+Hostinger-specific gotchas:
+
+- **`from_email` must be the same mailbox you authenticated as.**
+  Hostinger's SMTP rejects sending from a different address even if
+  the domain matches. Set `FROM_EMAIL` and `SMTP_USER` to the same
+  value.
+- **Use port 465 if 587 fails.** Some Hostinger plans only enable
+  one — the dashboard shows you which. The script auto-flips
+  between SSL and STARTTLS based on the port.
+- **Check the "Sending limits" page** in hPanel before running this
+  in a loop. Hostinger throttles outbound mail per mailbox per
+  hour; one test send won't hit it but a verifier-rejection cycle
+  could.
+
 ## What this catches that the smoke test doesn't
 
 - Real DNS resolution + TLS / STARTTLS to the provider

--- a/examples/email-end-to-end/package.json
+++ b/examples/email-end-to-end/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "awaithumans-email-end-to-end",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "tsx send.ts"
+  },
+  "dependencies": {
+    "awaithumans": "file:../../packages/typescript-sdk",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/email-end-to-end/send.ts
+++ b/examples/email-end-to-end/send.ts
@@ -1,0 +1,204 @@
+/**
+ * End-to-end real-delivery email test (TypeScript).
+ *
+ * Same shape as `examples/email-smoke/` but configured for an actual
+ * email provider — you receive the email in your real inbox and
+ * click the magic-link button by hand. The SDK long-polls until the
+ * action endpoint records your decision.
+ *
+ * Pick a transport via env:
+ *
+ *   AWAITHUMANS_TEST_TRANSPORT=resend RESEND_API_KEY=re_... \
+ *     RECIPIENT_EMAIL=you@example.com \
+ *     [FROM_EMAIL=onboarding@resend.dev] \
+ *     npm start
+ *
+ *   AWAITHUMANS_TEST_TRANSPORT=smtp \
+ *     SMTP_HOST=smtp.gmail.com SMTP_PORT=587 \
+ *     SMTP_USER=you@gmail.com SMTP_PASSWORD=<app password> \
+ *     RECIPIENT_EMAIL=you@example.com \
+ *     FROM_EMAIL=you@gmail.com \
+ *     npm start
+ *
+ * The script reuses an identity named `email-e2e-real` across runs
+ * so you don't have to re-verify a sender. Re-running with new
+ * transport_config upserts in place — no duplicate-id error.
+ *
+ * Prerequisites:
+ *   - `awaithumans dev` running in another terminal (the SDK reads
+ *     URL + admin token from the discovery file, no env-var dance)
+ *   - For Resend: a Resend account + API key. The `onboarding@resend.dev`
+ *     sender works without domain verification.
+ *   - For SMTP: a working SMTP host (Gmail / SES / Mailgun / your
+ *     preferred provider). Gmail requires an App Password
+ *     (https://myaccount.google.com/apppasswords).
+ */
+
+import {
+	awaitHuman,
+	resolveAdminToken,
+	resolveServerUrl,
+} from "awaithumans";
+import { z } from "zod";
+
+// ─── Resolve config ────────────────────────────────────────────────────
+
+const SERVER_URL = (await resolveServerUrl()).replace(/\/$/, "");
+const ADMIN_TOKEN = await resolveAdminToken();
+
+if (!ADMIN_TOKEN) {
+	console.error(
+		"Couldn't find an admin token. Run `awaithumans dev` first " +
+			"(writes ~/.awaithumans-dev.json), or export " +
+			"AWAITHUMANS_ADMIN_API_TOKEN.",
+	);
+	process.exit(1);
+}
+
+const RECIPIENT = process.env.RECIPIENT_EMAIL;
+if (!RECIPIENT) {
+	console.error("RECIPIENT_EMAIL is required — your real inbox.");
+	process.exit(1);
+}
+
+const TRANSPORT = process.env.AWAITHUMANS_TEST_TRANSPORT ?? "resend";
+const IDENTITY_ID = "email-e2e-real";
+
+// ─── Build transport_config from env ───────────────────────────────────
+
+interface TransportSetup {
+	from_email: string;
+	transport: string;
+	transport_config: Record<string, unknown>;
+}
+
+function buildTransportSetup(): TransportSetup {
+	if (TRANSPORT === "resend") {
+		const apiKey = process.env.RESEND_API_KEY;
+		if (!apiKey) {
+			console.error("RESEND_API_KEY required when transport=resend.");
+			process.exit(1);
+		}
+		return {
+			from_email: process.env.FROM_EMAIL ?? "onboarding@resend.dev",
+			transport: "resend",
+			transport_config: { api_key: apiKey },
+		};
+	}
+
+	if (TRANSPORT === "smtp") {
+		const host = process.env.SMTP_HOST;
+		const fromEmail = process.env.FROM_EMAIL;
+		if (!host || !fromEmail) {
+			console.error(
+				"SMTP_HOST and FROM_EMAIL required when transport=smtp.",
+			);
+			process.exit(1);
+		}
+		return {
+			from_email: fromEmail,
+			transport: "smtp",
+			transport_config: {
+				host,
+				port: Number(process.env.SMTP_PORT ?? 587),
+				username: process.env.SMTP_USER,
+				password: process.env.SMTP_PASSWORD,
+				start_tls: true,
+			},
+		};
+	}
+
+	console.error(
+		`Unknown transport '${TRANSPORT}'. Valid: resend, smtp. ` +
+			"(The `file` and `logging` transports are dev-only — see " +
+			"examples/email-smoke for that.)",
+	);
+	process.exit(1);
+}
+
+// ─── Identity setup (idempotent upsert) ────────────────────────────────
+
+async function configureIdentity(setup: TransportSetup): Promise<void> {
+	const resp = await fetch(
+		`${SERVER_URL}/api/channels/email/identities`,
+		{
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${ADMIN_TOKEN}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				id: IDENTITY_ID,
+				display_name: "awaithumans e2e real",
+				from_email: setup.from_email,
+				from_name: "awaithumans test",
+				reply_to: null,
+				transport: setup.transport,
+				transport_config: setup.transport_config,
+			}),
+		},
+	);
+	if (!resp.ok) {
+		console.error(
+			`identity setup failed (${resp.status}): ${await resp.text()}`,
+		);
+		process.exit(1);
+	}
+	console.log(
+		`→ identity '${IDENTITY_ID}' configured (transport=${setup.transport}, from=${setup.from_email})`,
+	);
+}
+
+// ─── Run ───────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+	console.log(`→ server: ${SERVER_URL}`);
+	console.log(`→ recipient: ${RECIPIENT}`);
+	console.log(`→ transport: ${TRANSPORT}`);
+
+	await configureIdentity(buildTransportSetup());
+
+	console.log("");
+	console.log(
+		"→ creating task — check your inbox in a few seconds and click " +
+			"the Approve button to complete it",
+	);
+
+	// Single-boolean response → email renderer emits Approve / Reject
+	// magic-link buttons inline. Multi-field responses fall back to a
+	// "Review in dashboard" link-out, also valid but less snappy for
+	// a manual demo.
+	const decision = await awaitHuman({
+		task: "Approve this real-delivery test",
+		payloadSchema: z.object({
+			note: z.string(),
+			sentAt: z.string(),
+		}),
+		payload: {
+			note: "If you received this email, awaithumans → real-mail integration works.",
+			sentAt: new Date().toISOString(),
+		},
+		responseSchema: z.object({
+			approved: z.boolean().describe("Approve this test?"),
+		}),
+		// 30-minute window — generous so you have time to find the
+		// email, click through, and walk back. The Slack/email
+		// post-completion updater will mark the message done either
+		// way.
+		timeoutMs: 30 * 60_000,
+		notify: [`email+${IDENTITY_ID}:${RECIPIENT}`],
+		idempotencyKey: `email-e2e-real:${Date.now()}`,
+	});
+
+	console.log("");
+	if (decision.approved) {
+		console.log("✓ Approved — task completed end-to-end via real email");
+	} else {
+		console.log("✗ Rejected — task completed end-to-end via real email");
+	}
+}
+
+main().catch((err) => {
+	console.error("✗ failed:", err);
+	process.exit(1);
+});

--- a/examples/email-end-to-end/send.ts
+++ b/examples/email-end-to-end/send.ts
@@ -95,15 +95,27 @@ function buildTransportSetup(): TransportSetup {
 			);
 			process.exit(1);
 		}
+		const port = Number(process.env.SMTP_PORT ?? 587);
+		// Port 465 is implicit TLS (SSL on connect — what Hostinger,
+		// Gmail SSL, and most "secure" SMTP setups use). Port 587 is
+		// STARTTLS (plain connect, upgrade with STARTTLS — what Gmail
+		// modern, O365, AWS SES, Mailgun use). The server's aiosmtplib
+		// rejects setting both modes — pick one based on port.
+		// Override with `SMTP_TLS_MODE=ssl|starttls` if your server
+		// uses a non-standard port.
+		const tlsMode =
+			process.env.SMTP_TLS_MODE ?? (port === 465 ? "ssl" : "starttls");
+		const useTls = tlsMode === "ssl";
 		return {
 			from_email: fromEmail,
 			transport: "smtp",
 			transport_config: {
 				host,
-				port: Number(process.env.SMTP_PORT ?? 587),
+				port,
 				username: process.env.SMTP_USER,
 				password: process.env.SMTP_PASSWORD,
-				start_tls: true,
+				use_tls: useTls,
+				start_tls: !useTls,
 			},
 		};
 	}

--- a/examples/email-end-to-end/tsconfig.json
+++ b/examples/email-end-to-end/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["*.ts"]
+}

--- a/examples/slack-native-ts/README.md
+++ b/examples/slack-native-ts/README.md
@@ -1,0 +1,88 @@
+# slack-native-ts
+
+TypeScript counterpart of [`../slack-native/`](../slack-native/) (Python).
+Same flow, same shape — different SDK.
+
+A small script that creates a wire-transfer approval task, sends it
+as a Slack DM to a tagged user (`@TA` by default), and prints the
+response when they decide.
+
+## What runs
+
+1. The TS SDK creates a task with `notify=["slack:@TA"]`.
+2. The server resolves `@TA` against the directory (implicit-
+   assignee derivation pins TA as `assigned_to_user_id`), then DMs
+   them via the Slack channel.
+3. TA sees the DM with two buttons:
+   - **Approve in Slack** — opens the Block-Kit modal in place
+   - **Open in Dashboard** — signed handoff URL (works even if TA
+     has no email/password)
+4. TA submits via either path. The Slack message updates to
+   "Completed by @TA" with no buttons.
+5. This script's `awaitHuman` resolves with the typed response.
+
+## Prerequisites
+
+- **`awaithumans dev` running** in another terminal. The TS SDK
+  reads its discovery file for URL + admin token, so no env-var
+  dance is needed.
+- **Slack app linked + workspace OAuth completed** — one-time setup,
+  see [`examples/slack-native/README.md`](../slack-native/README.md)
+  for the full Slack-side configuration. ngrok required for OAuth /
+  interactivity callbacks.
+- **User in the directory.** In the dashboard's Users page, click
+  "Add user", paste the Slack handle (`@TA`), pick the workspace
+  from the dropdown. Display name auto-fills.
+
+## Run
+
+```sh
+cd examples/slack-native-ts
+npm install
+npm start
+```
+
+Expected output:
+
+```
+→ creating task — notify=slack:@TA
+  transfer_id=WT-MOUI...
+[blocks until TA decides in Slack]
+
+✓ Approved by @TA
+  full response: {"approved":true}
+```
+
+## Change the Slack handle
+
+By default the script tags `@TA`. Edit `wire-transfer.ts`:
+
+```ts
+const SLACK_HANDLE = "TA";  // ← change to whatever handle you added
+```
+
+## What this exercises
+
+- TS SDK creates a task with Slack notify entry
+- Server-side implicit-assignee derivation (`@TA` → directory user
+  with that Slack handle → set as `assigned_to_user_id`)
+- Slack notification: DM sent with Approve/Open buttons
+- Slack interactivity: modal opens, view_submission completes the
+  task, message updates to "Completed by @TA"
+- TS SDK long-poll resolves on out-of-band completion
+
+If any of the above breaks, the Slack-channel coverage hasn't
+regressed but the contract between TS SDK and server has — start
+with `pytest tests/slack/` then check the dashboard's audit log.
+
+## Why no automated smoke for Slack (vs email)?
+
+The email path has a public, signed-token endpoint
+(`/api/channels/email/action/<token>`) that any HTTP client can
+POST to. Slack's interactivity endpoints sign requests against a
+shared secret per workspace and route through Slack's own
+servers — not feasible to drive from a local script without
+spinning up a real Slack app.
+
+This example is a manual checklist for "does the Slack flow work
+end-to-end from TypeScript." Run it, click around, watch the dash.

--- a/examples/slack-native-ts/package.json
+++ b/examples/slack-native-ts/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "awaithumans-slack-native-ts",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "tsx wire-transfer.ts"
+  },
+  "dependencies": {
+    "awaithumans": "file:../../packages/typescript-sdk",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/slack-native-ts/tsconfig.json
+++ b/examples/slack-native-ts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["*.ts"]
+}

--- a/examples/slack-native-ts/wire-transfer.ts
+++ b/examples/slack-native-ts/wire-transfer.ts
@@ -1,0 +1,109 @@
+/**
+ * TS counterpart of `examples/slack-native/refund.py` — delegate a
+ * task to a Slack user via DM, await their decision in TypeScript.
+ *
+ * What happens:
+ *
+ *   1. The TS SDK creates a task with `notify=["slack:@TA"]`.
+ *   2. The server resolves `@TA` against the directory (the implicit-
+ *      assignee derivation pins TA as `assigned_to_user_id`), then
+ *      DMs them via the Slack channel.
+ *   3. TA sees the DM with two buttons:
+ *        - "Approve in Slack" — opens the Block-Kit modal in place
+ *        - "Open in Dashboard" — signed handoff URL (works even if
+ *          TA has no email/password)
+ *   4. TA submits via either path. The Slack message updates to
+ *      "Completed by @TA" with no buttons (so they can't re-trigger).
+ *   5. This script's `awaitHuman` resolves with the typed response.
+ *
+ * Prerequisites:
+ *
+ *   - `awaithumans dev` running (the SDK reads its discovery file
+ *     for URL + admin token; no env-var dance needed)
+ *   - Slack app linked + workspace OAuth completed (one-time setup;
+ *     see examples/slack-native/README.md)
+ *   - User `TA` added to the directory with a Slack handle, via the
+ *     dashboard's Users → Add user form
+ *
+ * Run:
+ *
+ *     cd examples/slack-native-ts
+ *     npm install
+ *     npm start
+ */
+
+import { awaitHuman } from "awaithumans";
+import { z } from "zod";
+
+// ─── Schemas ───────────────────────────────────────────────────────────
+
+// What TA sees while reviewing.
+const WireTransfer = z.object({
+	transferId: z.string(),
+	amountUsd: z.number(),
+	to: z.string(),
+});
+
+// IMPORTANT: a single boolean response triggers the email/Slack
+// renderer's compact magic-link / button path. Multi-field responses
+// fall back to "open the form" — still works, but the demo's less
+// snappy. Keep this single-field so the Slack DM has Approve/Reject
+// buttons inline.
+const Approval = z.object({
+	approved: z
+		.boolean()
+		.describe("Approve this wire transfer?"),
+});
+
+// ─── Config ────────────────────────────────────────────────────────────
+
+// The Slack handle we're tagging. Change this to whatever you set
+// when you added the user in the dashboard.
+const SLACK_HANDLE = "TA";
+
+// ─── Run ───────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+	const transferId = `WT-${Date.now().toString(36).toUpperCase()}`;
+	console.log(`→ creating task — notify=slack:@${SLACK_HANDLE}`);
+	console.log(`  transfer_id=${transferId}`);
+
+	const decision = await awaitHuman({
+		task: "Approve this wire transfer",
+		payloadSchema: WireTransfer,
+		payload: {
+			transferId,
+			amountUsd: 12_500,
+			to: "Acme Inc.",
+		},
+		responseSchema: Approval,
+		// 15-minute window — generous for a manual demo. The Slack
+		// message stays interactive that whole time; after expiry it
+		// auto-updates to "Timed out" via the post-completion updater.
+		timeoutMs: 15 * 60_000,
+		// Single notify entry → implicit-assignee derivation fires
+		// server-side, marking TA as `assigned_to_user_id`. Without
+		// this binding, the Slack `view_submission` auth check would
+		// reject TA's submission as "not assigned to you."
+		notify: [`slack:@${SLACK_HANDLE}`],
+		// Stable idempotency so a re-run during the same wall-clock
+		// second returns the existing task instead of stacking
+		// duplicates. In production, tie this to a real business
+		// identifier (transferId here is fine because we generated
+		// it just above).
+		idempotencyKey: `slack-ts-demo:${transferId}`,
+	});
+
+	console.log("");
+	if (decision.approved) {
+		console.log(`✓ Approved by @${SLACK_HANDLE}`);
+	} else {
+		console.log(`✗ Rejected by @${SLACK_HANDLE}`);
+	}
+	console.log(`  full response: ${JSON.stringify(decision)}`);
+}
+
+main().catch((err) => {
+	console.error("✗ failed:", err);
+	process.exit(1);
+});


### PR DESCRIPTION
The existing `email-smoke` uses the `file` transport (writes JSON to disk for automated assertions). That covers the SDK↔server contract but never actually ships an email through real DNS. This example does.

## What it does

Small TS script that picks a transport from env (`resend` or `smtp`), upserts an email identity, fires a real-delivery task to a recipient inbox, and blocks until the human clicks the magic-link button in their inbox.

## Run — Resend (5 min, recommended)

1. Sign up at resend.com → API Keys → Create. Copy the `re_…` value.
2. ```sh
   cd examples/email-end-to-end
   npm install
   AWAITHUMANS_TEST_TRANSPORT=resend \
     RESEND_API_KEY=re_xxxxxxxxxxxx \
     RECIPIENT_EMAIL=you@example.com \
     npm start
   ```
3. Click "Approve" in your inbox. Script returns.

`onboarding@resend.dev` is the default sender so no domain verification needed. Override with `FROM_EMAIL=alerts@yourdomain.com` if you've verified one.

## Run — SMTP (Gmail / SES / Mailgun)

For Gmail: enable 2FA, generate an App Password at https://myaccount.google.com/apppasswords.

```sh
AWAITHUMANS_TEST_TRANSPORT=smtp \
  SMTP_HOST=smtp.gmail.com SMTP_PORT=587 \
  SMTP_USER=you@gmail.com SMTP_PASSWORD="<app-password>" \
  FROM_EMAIL=you@gmail.com \
  RECIPIENT_EMAIL=you@example.com \
  npm start
```

## What this catches that the smoke doesn't

- Real DNS + TLS / STARTTLS handshake with the provider
- Actual rendering in real mail clients (Gmail, Outlook, Apple Mail) — the button survives the client's email-CSS sandbox
- `from_email` clearing SPF / DKIM / DMARC
- The magic-link URL reachable from a browser that didn't run the test (phone, laptop, etc.)
- TS SDK's poll loop resolving on real out-of-band human action, not a scripted POST

## Identity reuse

Identity ID is hardcoded as `email-e2e-real` and uses upsert — re-running with different `RESEND_API_KEY` or SMTP host overwrites the config in place. No delete-and-recreate dance.

Cleanup snippet in the README for when you're done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)