### PR TITLE
docs(channels): refresh email + slack to match shipped behavior

### DIFF
--- a/docs/channels/email.mdx
+++ b/docs/channels/email.mdx
@@ -7,22 +7,30 @@ The email channel sends an HTML email with the task description, payload context
 
 ## Transport options
 
-Two transport implementations:
-
 | Transport | Best for | Setup |
 |---|---|---|
 | **Resend** | Quick start, good deliverability | API key only |
-| **SMTP** | Existing email infrastructure | Host, port, user, pass |
+| **SMTP** | Existing email infrastructure (Gmail, Hostinger, AWS SES, Mailgun) | Host, port, user, pass |
+| **File** | Local dev + automated tests | Directory path |
+| **Logging** | Manual smoke test ("did the renderer fire?") | None |
+| **Noop** | Disabling email entirely | None |
 
-Plus `logging` (echoes emails to logs — good for tests) and `noop`.
+## Two ways to configure
 
-## Quickstart with Resend
+The server accepts email configuration through **either**:
+
+1. **Environment variables** — picks one default identity, applied to every `notify=["email:..."]` entry. Best for single-tenant deployments and quickstart.
+2. **Per-identity sender records** stored in the DB — each identity has its own transport, `from_email`, and credentials. Routed via `notify=["email+<identity>:..."]`. Best for multi-tenant deployments or when you need multiple senders from one server.
+
+You can mix both: env vars provide the default, per-identity overrides for specific routes.
+
+## Quickstart with Resend (env-var path)
 
 ### 1. Get a Resend API key
 
-Sign up at [resend.com](https://resend.com), create an API key, verify a sender domain.
+Sign up at [resend.com](https://resend.com), create an API key. Either verify a sender domain, or use `onboarding@resend.dev` (no DNS setup needed) for testing.
 
-### 2. Configure the awaithumans server
+### 2. Set env vars
 
 ```bash
 export AWAITHUMANS_EMAIL_TRANSPORT=resend
@@ -33,7 +41,7 @@ export AWAITHUMANS_RESEND_KEY=re_...
 
 Restart `awaithumans dev`.
 
-### 3. Test it
+### 3. Send
 
 ```python
 await_human_sync(
@@ -43,9 +51,13 @@ await_human_sync(
 )
 ```
 
-The reviewer gets an email. Click an action button or the "Review in dashboard" link, fill the form, submit. The script's `await_human` returns.
+The recipient gets an email; clicking through completes the task.
 
-## SMTP
+## SMTP — env-var path
+
+Works against any SMTP server. The transport auto-picks SSL vs STARTTLS based on the port (465 → SSL on connect, anything else → STARTTLS upgrade). Override with `AWAITHUMANS_SMTP_USE_TLS=true` for non-standard ports.
+
+### Gmail (port 587, STARTTLS)
 
 ```bash
 export AWAITHUMANS_EMAIL_TRANSPORT=smtp
@@ -57,39 +69,91 @@ export AWAITHUMANS_SMTP_START_TLS=true
 export AWAITHUMANS_EMAIL_FROM="you@gmail.com"
 ```
 
-For Gmail you need an [app password](https://myaccount.google.com/apppasswords) — regular passwords don't work with SMTP.
+Gmail requires an [App Password](https://myaccount.google.com/apppasswords) (regular passwords don't work over SMTP).
 
-## Sender identities (multi-tenant)
+### Hostinger Mail (port 465, SSL)
 
-If you serve multiple teams from one awaithumans server, each can have its own sender:
+```bash
+export AWAITHUMANS_EMAIL_TRANSPORT=smtp
+export AWAITHUMANS_SMTP_HOST=smtp.hostinger.com
+export AWAITHUMANS_SMTP_PORT=465
+export AWAITHUMANS_SMTP_USER=you@yourdomain.com
+export AWAITHUMANS_SMTP_PASSWORD="<mailbox-password>"
+export AWAITHUMANS_SMTP_USE_TLS=true
+export AWAITHUMANS_EMAIL_FROM="you@yourdomain.com"   # must match SMTP_USER
+```
+
+The mailbox password is the one you set when creating the mailbox in hPanel — **not** your Hostinger account password.
+
+Hostinger gotchas:
+
+- `from_email` must match `SMTP_USER` exactly. Hostinger rejects mismatched senders even on the same domain.
+- Outbound mail is rate-limited per mailbox per hour; one test won't trigger it, a verifier-reject loop might.
+- Some plans only enable port 465 OR 587 (not both). Pick whichever the dashboard shows.
+
+### AWS SES, Mailgun, etc.
+
+Same flags, swap the host. SES uses SMTP credentials (not your IAM key); Mailgun's are in their dashboard.
+
+## Per-identity setup (multi-tenant or named senders)
+
+When you need more than one sender — different teams, different transports per route, or just a clean `acme-prod` vs `acme-dev` distinction — use sender identities.
+
+Each identity has its own `from_email`, `from_name`, `reply_to`, transport, and transport credentials. Stored encrypted at rest (AES-GCM keyed off `PAYLOAD_KEY`).
+
+### Configure via the dashboard
+
+**Settings → Email → Identities → Add identity** (operator-only). Pick the transport, fill in the credentials, save.
+
+### Configure via the admin API
+
+```bash
+TOKEN=$(cat ~/.awaithumans-dev.json | jq -r .admin_token)
+
+curl -X POST http://localhost:3001/api/channels/email/identities \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "id": "acme-prod",
+    "display_name": "Acme Production",
+    "from_email": "notifications@acme.com",
+    "from_name": "Acme Reviews",
+    "reply_to": null,
+    "transport": "resend",
+    "transport_config": {"api_key": "re_..."}
+  }'
+```
+
+POST is upsert — same `id` overwrites. Re-run to rotate credentials in place.
+
+### Route to a specific identity
 
 ```python
-notify=["email+acme:reviewer@acme.com"]    # send via the "acme" identity
-notify=["email+initech:bob@initech.com"]   # send via the "initech" identity
+notify=["email+acme-prod:reviewer@acme.com"]    # send via the "acme-prod" identity
+notify=["email+initech:bob@initech.com"]        # send via the "initech" identity
+notify=["email:reviewer@acme.com"]              # send via the env-var default
 ```
 
-Identities are managed in Settings → Email → Identities (admin-only). Each identity has its own `from_email`, `from_name`, `reply_to`, and transport config.
+## Action buttons vs dashboard link-out
 
-Plain `email:...` (no `+id`) uses the server's default identity (the env-configured one).
+The renderer makes a per-task decision based on the response schema's `form_definition`:
 
-## Action buttons
+- **Single `switch` or small `single_select` (≤4 options)** → action buttons render inline:
+  ```
+  [ Approve ]    [ Reject ]
+  ```
+- **Anything else** (multi-field forms, file uploads, long text) → single "Review in dashboard" link
 
-For simple response shapes (`switch`, single-option `single_select`), the email includes per-option action buttons:
+This is intentional: clicking a button in your inbox completes a yes/no in two seconds; anything more substantive belongs in the dashboard where the form has room to breathe.
 
-```
-[ Approve ]    [ Reject ]
-```
-
-Clicking lands on a confirmation page. The two-step flow (GET shows confirm, POST submits) prevents Outlook SafeLinks / Google image proxy from accidentally completing tasks via prefetch.
-
-For complex schemas (multi-field forms, file uploads, etc.), the email includes a single "Review in dashboard" link.
+For the buttons to fire from a TypeScript-created task, the SDK has to send a `form_definition` describing a single Switch — that's what `extractForm()` in the TS SDK produces from `z.object({ approved: z.boolean() })`. The Python SDK does the equivalent via `extract_form()` against a Pydantic model.
 
 ## Magic-link tokens
 
 Action button URLs encode the task ID, field, value, expiry, and a unique `jti` (replay protection):
 
 ```
-https://YOUR-URL/api/channels/email/action/<token>
+https://YOUR-PUBLIC-URL/api/channels/email/action/<token>
 ```
 
 Each token:
@@ -98,16 +162,44 @@ Each token:
 - Expires in 24h by default
 - Is single-use — `consumed_email_tokens` table records each `jti` on first use; replays return 410 Gone
 
-Forwarded emails, leaked URLs, and SafeLinks fetches all become safe-to-have-in-logs after first use.
+Forwarded emails, leaked URLs, and Outlook SafeLinks fetches all become safe-to-have-in-logs after first use. The two-step flow (GET shows confirm, POST submits) prevents Outlook SafeLinks / Google image proxy from accidentally completing tasks via prefetch.
 
 ## Authorization
 
-Anyone with the magic link can complete the task — the link IS the auth token. So:
+Anyone with the magic-link URL can complete the task — the link IS the auth token. So:
 
 - Don't forward task emails. The recipient list is the authorization list.
 - For tasks with no specific assignee (`assign_to=None`), the email recipient is implicitly the assignee. Audit log records `completed_via_channel=email` so you can see this happened.
 
 For higher-stakes tasks, prefer Slack (which validates the submitter against the directory) or the dashboard (which requires a session).
+
+## File transport (dev / testing)
+
+The `file` transport writes one JSON file per email to a configured directory instead of sending. Used by the smoke tests but also useful for manual dev when you want a deterministic record of every email the server would have shipped.
+
+Per-identity:
+
+```json
+{
+  "transport": "file",
+  "transport_config": {"dir": "/tmp/awaithumans-emails"}
+}
+```
+
+Each captured email is a JSON file with `to`, `subject`, `html`, `text`, `from_email`, `from_name`, `reply_to`, `tags`, plus bookkeeping (`_received_at`, `_message_id`). Filename leads with unix-ms so newest sorts last.
+
+Never use this in production.
+
+## Runnable examples
+
+| Example | Language | Transport | What it tests |
+|---|---|---|---|
+| [`examples/email-smoke/`](https://github.com/awaithumans/awaithumans/tree/main/examples/email-smoke) | TypeScript | `file` | Automated end-to-end: SDK creates task → email captured → magic-link clicked programmatically → SDK resolves |
+| [`examples/email-smoke-py/`](https://github.com/awaithumans/awaithumans/tree/main/examples/email-smoke-py) | Python | `file` | Same loop, Python SDK |
+| [`examples/email-end-to-end/`](https://github.com/awaithumans/awaithumans/tree/main/examples/email-end-to-end) | TypeScript | Resend / SMTP | Real-delivery: email lands in your inbox, you click Approve, SDK resolves |
+| [`examples/email-end-to-end-py/`](https://github.com/awaithumans/awaithumans/tree/main/examples/email-end-to-end-py) | Python | Resend / SMTP | Same, Python SDK. Includes Hostinger walkthrough |
+
+The smoke tests run automatically and prove the SDK ↔ server contract. The end-to-end examples prove the integration with a real email provider — you only run those manually before a release.
 
 ## Resending
 
@@ -116,5 +208,8 @@ If the email is lost (spam folder, address typo, …), the dashboard's task-deta
 ## Common gotchas
 
 - **No domain verification.** Resend / Gmail will silently drop emails from unverified senders. Check your transport's dashboard for delivery logs.
-- **Action button URLs not reachable.** The awaithumans server must be reachable from the recipient's mail client. Localhost-only servers can't be tested by sending real emails — use the `logging` transport.
+- **Action button URLs not reachable.** The awaithumans server must be reachable from the recipient's mail client. Localhost-only servers can't be tested with real emails — use the `file` transport, or expose your dev server via ngrok.
 - **Token expired.** Default TTL is 24 hours. For long-running review windows, raise via `MAGIC_LINK_MAX_AGE_SECONDS` in `utils/constants.py` (operator override planned post-launch).
+- **`from_email` mismatch.** Most providers reject mail when `from_email` doesn't match the authenticated mailbox. For SMTP especially, set `from_email` and `SMTP_USER` to the same value.
+- **TLS mode wrong for the port.** Port 465 is implicit SSL (`use_tls=true`); 587 is STARTTLS (`start_tls=true`). The transport auto-flips based on port; override with `AWAITHUMANS_SMTP_USE_TLS` if your server uses a non-standard port.
+- **No buttons in the email, just a "Review in dashboard" link.** The response schema has more than one input field — that's the link-out fallback. Either reduce to a single boolean for the button shortcut, or accept that complex forms belong in the dashboard.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Slack"
-description: "Deliver tasks via Slack. Block Kit modal review, NL thread replies, broadcast claim."
+description: "Deliver tasks via Slack. Block Kit modal review, NL thread replies, broadcast claim, signed dashboard handoff for Slack-only users."
 ---
 
-The Slack channel posts tasks to a channel or DM, opens a Block Kit modal for the form, and accepts both structured submissions and natural-language thread replies (parsed by the [verifier](/adapters/verifier)).
+The Slack channel posts tasks to a channel or DM, opens a Block Kit modal for the form, and accepts both structured submissions and natural-language thread replies (parsed by the [verifier](/adapters/verifier)). Reviewers without an email/password get a signed handoff URL that drops them into the dashboard authenticated.
 
 ## Two install modes
 
@@ -34,6 +34,7 @@ oauth_config:
       - channels:read
       - groups:read
       - users:read
+      - users:read.email
       - files:write
       - files:read
 settings:
@@ -45,7 +46,7 @@ settings:
   token_rotation_enabled: false
 ```
 
-Replace `YOUR-PUBLIC-URL` with your awaithumans server's public address. For local dev: `https://<your-ngrok-id>.ngrok.io`.
+Replace `YOUR-PUBLIC-URL` with your awaithumans server's public address. For local dev: `https://<your-ngrok-id>.ngrok.io`. The `users:read.email` scope is needed for the `slack:alice@acme.com` route format (resolves emails to Slack user IDs).
 
 Install to your workspace. Copy the **Bot User OAuth Token** (`xoxb-...`) and the **Signing Secret** from Basic Information.
 
@@ -78,6 +79,12 @@ Open `https://YOUR-PUBLIC-URL/api/channels/slack/oauth/start?install_token=YOUR_
 
 OAuth installs are stored encrypted at rest (AES-GCM keyed off `PAYLOAD_KEY`).
 
+## Adding users to the directory
+
+Tasks DM'd to a Slack user only open the modal if that user exists in the awaithumans directory. Add them via:
+
+**Dashboard → Users → Add user**. The form has a "Slack member" picker that pulls the workspace's `users.list` so operators select from a dropdown rather than copy-pasting `U…` IDs. The display name auto-fills. Email is optional — a Slack-only user (no email, no password) can still complete tasks; they reach the dashboard via the signed handoff URL the bot puts on every DM.
+
 ## Notify formats
 
 ```python
@@ -90,25 +97,41 @@ notify=["slack:#approvals", "email:..."]   # multi-channel
 
 The middle three forms can target the same person — pick whichever's easiest. Handles (`@alice`) are resolved via `users.list` once per workspace per process, then cached. Emails use Slack's dedicated `users.lookupByEmail`. Raw user IDs pass through unchanged.
 
+For a multi-workspace OAuth install, suffix the channel/handle with the team:
+
+```python
+notify=["slack+T123456:@alice"]            # DM Alice in workspace T123456
+notify=["slack+T_OTHER:#approvals"]        # broadcast in a different workspace's channel
+```
+
 ### Broadcast (channel)
 
 Posts a message with a "Claim this task" button. First clicker wins atomically. After claim:
 
 - The original message updates to "Claimed by @user" so the button vanishes for everyone else
 - The modal pops for the claimer immediately (using Slack's interactivity trigger)
+- The "View in dashboard" button on the updated message is now signed for the claimer (handoff URL — see below)
 - Audit log records the claim with channel=`slack`
 
 ### Direct (user)
 
-DMs the Slack user. They see "Open in Slack" and click straight into the modal. The user must be in your awaithumans directory (Settings → Users) for the modal to open.
+DMs the Slack user with two buttons: **Approve in Slack** (opens the modal in place) and **Open in Dashboard** (signed handoff URL — works even if the user has no email/password).
 
-For the `notify=` string you can use any of:
+The implicit-assignee derivation pins the recipient as `assigned_to_user_id` at task-create time, so the Slack `view_submission` auth check accepts their submission. Without this, a DM to `@alice` would surface "This task isn't assigned to you" when she clicks through.
 
-- `slack:@alice` — Slack handle (most natural)
-- `slack:alice@acme.com` — email (when you only know that)
-- `slack:@U01ABC1234` — raw user ID (always works, no API call)
+## Signed dashboard handoff (Slack-only users)
 
-For the directory entry (Settings → Users), the dashboard's "Slack member" picker pulls the workspace member list — operators pick from a dropdown rather than copy-pasting `U…` strings.
+A Slack-only user (no email, no password in the directory) has no way to clear the dashboard's login wall — clicking "Open in Dashboard" without help would bounce them to `/login`. The notifier signs the URL with `(user_id, task_id, expiry, hmac)` at post time:
+
+```
+https://YOUR-PUBLIC-URL/api/auth/slack-handoff?u=USER&t=TASK&e=EXP&s=SIG
+```
+
+The endpoint verifies the signature, mints a session cookie scoped to that user, and redirects to `/task?id=TASK`. Stateless HMAC, HKDF-derived key from `PAYLOAD_KEY`, no DB roundtrip on the verify path.
+
+TTL is bound to `task.timeout_at` — a 7-day approval has a working link on day 6. Expired links return 400.
+
+The post-claim "View in dashboard" button on broadcast messages is also signed, so claimers without password credentials get the same handoff.
 
 ## Modal form
 
@@ -124,6 +147,8 @@ The modal is auto-generated from the response schema's `form_definition`. Fields
 
 Complex types (file uploads, images, signatures) fall back to a "Review in dashboard" link.
 
+Both SDKs synthesize `form_definition` from their native schema language — Python via `extract_form()` against a Pydantic model, TypeScript via `extractForm()` against a Zod object schema. A single boolean response in either tongue produces a Switch primitive, which is what the email/Slack renderers use to decide whether to emit inline action shortcuts.
+
 ## NL thread replies
 
 A reviewer can reply in the message's thread instead of clicking through the modal. The verifier parses the natural language into the response schema:
@@ -136,23 +161,52 @@ A reviewer can reply in the message's thread instead of clicking through the mod
 
 If `verifier=` is set on the task and the verifier supports NL parsing (all four built-ins do), the thread text becomes the response. See [Verifier](/adapters/verifier).
 
+## Post-completion message updates
+
+When a task transitions to a terminal state — completed (Slack modal OR dashboard), cancelled by an operator, or timed out by the scheduler — the original Slack message is rewritten via `chat.update`:
+
+```
+✅ Completed: Approve $250 refund? — by <@U_ALICE>
+[ View in dashboard ]    ← signed handoff URL
+```
+
+No buttons. The recipient can't accidentally re-trigger the form on a stale DM days later. The "View in dashboard" link stays so audit / replay is one click away.
+
+The update fires as a FastAPI background task after the response so a slow Slack API call never blocks the human's submit. Slack errors are logged, not raised — a Slack outage affects the cosmetic message, not the task lifecycle.
+
+For this to work, the notifier records `(channel, ts, team_id)` in the `slack_task_messages` table on every post. Tasks created before this feature shipped won't have refs — their DMs stay interactive forever.
+
 ## Authorization
 
 awaithumans validates the Slack user submitting against the task's assignee:
 
 - Submitter must be in the directory and active
 - Submitter must be either the task's assignee OR an operator
+- Operators stepping in on someone else's task see an inline banner in the dashboard ("⚠ Assigned to @alice — you're submitting as operator (ops@acme.com)")
 - Anyone else gets a clear ephemeral reply: "This task isn't assigned to you."
 
 The broadcast-claim path doesn't enforce this (it's first-claim-wins by design); the direct-DM and modal-submit paths do.
 
 ## Audit identity
 
-`completed_by_email` is the directory user's email, NOT the Slack `user.username`. Operators see consistent attribution across Slack and dashboard completions.
+`completed_by_email` is the directory user's email when set. For Slack-only users (no email) the audit log surfaces `completed_by_user_id` plus a `completed_by_display_name` derived from `display_name → email → @<slack_user_id> → row id`. Operators see consistent attribution across Slack and dashboard completions, even when one of the parties has no email.
+
+## Runnable examples
+
+| Example | Language | What it tests |
+|---|---|---|
+| [`examples/slack-native/`](https://github.com/awaithumans/awaithumans/tree/main/examples/slack-native) | Python | Refund-approval task DM'd to a Slack user; manual review |
+| [`examples/slack-native-ts/`](https://github.com/awaithumans/awaithumans/tree/main/examples/slack-native-ts) | TypeScript | Same flow, TS SDK |
+
+Both block until the human reviews. After their click, the SDK resolves with the typed response.
+
+There's no automated Slack smoke equivalent to the email one — Slack's interactivity callback is signed against a per-workspace secret and routes through Slack's own servers, not feasible to drive from a local script. The smoke story for Slack is the integration tests in `tests/slack/`.
 
 ## Common gotchas
 
-- **`request_url` mismatch.** Slack tries to verify your interactivity URL. If your awaithumans server moves, update the manifest.
+- **`request_url` mismatch.** Slack tries to verify your interactivity URL. If your awaithumans server moves (ngrok ID rotates, etc.), update the manifest.
 - **`SLACK_SIGNING_SECRET` mismatch.** Every interaction gets HMAC-checked. Wrong secret → 401s in your logs.
 - **Bot not in channel.** The bot needs to be in the channel you're posting to. Add it manually or via `channels:join` scope.
 - **Workspace member cache.** The dashboard's "Pick Slack member" dropdown caches `users.list` results — restart the server to refresh.
+- **Slack-only user but no `users:read.email` scope.** The `slack:alice@acme.com` route format needs that scope. Add it to the app manifest and reinstall.
+- **DM modal doesn't open.** The recipient isn't in the directory. Add them via Dashboard → Users → Add user.

--- a/examples/email-end-to-end-py/README.md
+++ b/examples/email-end-to-end-py/README.md
@@ -1,0 +1,129 @@
+# email-end-to-end-py
+
+Python counterpart of [`../email-end-to-end/`](../email-end-to-end/)
+(TypeScript). Same flow, same shape — different SDK.
+
+A small script that creates a real-delivery email task, waits for
+you to click the Approve button in your actual inbox, and prints
+the response when the click lands.
+
+## Prerequisites
+
+- **`awaithumans dev` running** in another terminal. The Python
+  SDK reads its discovery file for URL + admin token, so no
+  env-var dance is needed.
+- **A real email transport** — pick one:
+  - **Resend** (recommended) — a free account + API key
+  - **SMTP** — Gmail App Password / Hostinger mailbox / AWS SES
+    SMTP credentials / Mailgun SMTP / etc.
+
+## Option A — Resend (5 minutes)
+
+1. Sign up at resend.com (free tier is plenty).
+2. **API Keys → Create API Key** — copy the `re_…` value.
+3. Run:
+   ```sh
+   cd examples/email-end-to-end-py
+   pip install -r requirements.txt
+   AWAITHUMANS_TEST_TRANSPORT=resend \
+     RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxxxxxxxx \
+     RECIPIENT_EMAIL=you@example.com \
+     python send.py
+   ```
+4. Check your inbox — should land within ~2 seconds. Click
+   **Approve**.
+5. Script prints `✓ Approved — task completed end-to-end via real
+   email` and exits.
+
+`onboarding@resend.dev` is the default sender (no domain
+verification needed). Override with `FROM_EMAIL=alerts@yourdomain.com`
+once you've verified a domain in Resend.
+
+## Option B — SMTP (Gmail App Password)
+
+1. Enable 2FA on the Google account
+   (https://myaccount.google.com/security).
+2. Generate an App Password
+   (https://myaccount.google.com/apppasswords) — pick "Mail" →
+   "Other (custom name)" → name it `awaithumans-dev`.
+3. Run:
+   ```sh
+   AWAITHUMANS_TEST_TRANSPORT=smtp \
+     SMTP_HOST=smtp.gmail.com SMTP_PORT=587 \
+     SMTP_USER=you@gmail.com SMTP_PASSWORD="<the 16-char app password>" \
+     FROM_EMAIL=you@gmail.com \
+     RECIPIENT_EMAIL=you@gmail.com \
+     python send.py
+   ```
+
+## Option C — Hostinger Mail
+
+Hostinger uses port 465 with implicit TLS (SSL on connect). The
+script auto-flips between SSL and STARTTLS based on the port — no
+extra flag.
+
+1. **Find your mailbox credentials** in Hostinger hPanel:
+   - **Emails → pick the mailbox → Connect Apps & Devices**
+   - **SMTP host**: `smtp.hostinger.com`
+   - **SMTP port**: `465` (SSL — preferred) or `587` (STARTTLS)
+   - **Username**: full email address (`you@yourdomain.com`)
+   - **Password**: the mailbox password (NOT your Hostinger
+     account password; reset via hPanel if you forget)
+2. Run:
+   ```sh
+   AWAITHUMANS_TEST_TRANSPORT=smtp \
+     SMTP_HOST=smtp.hostinger.com \
+     SMTP_PORT=465 \
+     SMTP_USER=you@yourdomain.com \
+     SMTP_PASSWORD="<your-mailbox-password>" \
+     FROM_EMAIL=you@yourdomain.com \
+     RECIPIENT_EMAIL=you@yourdomain.com \
+     python send.py
+   ```
+3. Click Approve in your inbox; script returns.
+
+Hostinger-specific gotchas:
+
+- **`from_email` must equal `SMTP_USER`** — Hostinger rejects
+  sending from a different address even on the same domain
+- **Use port 465 if 587 fails** (or vice versa) — some plans only
+  enable one; the script auto-switches between SSL and STARTTLS
+- **Outbound rate limits per mailbox per hour** — one test won't
+  trigger them; a verifier-reject loop could
+
+## What this catches that the file-transport smoke doesn't
+
+- Real DNS resolution + TLS / STARTTLS to the provider
+- Actual rendering in real mail clients (Gmail, Outlook, Apple
+  Mail) — buttons survive the client's email-CSS sandbox
+- The `from_email` clears SPF / DKIM / DMARC at the recipient
+- The magic-link URL is reachable from a different browser (your
+  phone, your laptop) than the one that ran the test
+- The Python SDK's poll loop resolves on real out-of-band human
+  action, not a scripted POST
+
+## Re-runs
+
+The identity ID is hardcoded as `email-e2e-real-py` and uses
+upsert semantics — running again with different transport
+credentials overwrites the config in the DB. No need to delete
+anything between runs.
+
+If you want to clean up after testing:
+
+```sh
+TOKEN=$(cat ~/.awaithumans-dev.json | jq -r .admin_token)
+curl -X DELETE \
+  -H "Authorization: Bearer $TOKEN" \
+  http://localhost:3001/api/channels/email/identities/email-e2e-real-py
+```
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `Couldn't find an admin token` | Start `awaithumans dev` first — the Python SDK reads its discovery file |
+| `RESEND_API_KEY required` | Pass it to the command (see Option A) |
+| Email never arrives | Check `awaithumans dev` logs for the email-channel error. Common causes: invalid API key, sender not verified in Resend, SMTP creds wrong, TLS mode mismatch (try `SMTP_TLS_MODE=ssl` or `starttls` to override) |
+| `5xx` clicking the magic link | Token expired (24h TTL) or already consumed — magic links are single-use. Re-run the script for a fresh token |
+| Email arrives but no buttons | Response schema isn't a single boolean. Multi-field forms render as a "Review in dashboard" link-out (intentional) |

--- a/examples/email-end-to-end-py/requirements.txt
+++ b/examples/email-end-to-end-py/requirements.txt
@@ -1,0 +1,3 @@
+awaithumans
+httpx>=0.27
+pydantic>=2.0

--- a/examples/email-end-to-end-py/send.py
+++ b/examples/email-end-to-end-py/send.py
@@ -1,0 +1,238 @@
+"""End-to-end real-delivery email test (Python).
+
+Mirror of `examples/email-end-to-end/send.ts` — exercises the same
+real-mail loop (configure identity → fire task → wait for the human
+to click the magic-link button in their inbox → resolve) but driven
+from the Python SDK.
+
+Pick a transport via env:
+
+    AWAITHUMANS_TEST_TRANSPORT=resend RESEND_API_KEY=re_... \
+      RECIPIENT_EMAIL=you@example.com \
+      [FROM_EMAIL=onboarding@resend.dev] \
+      python send.py
+
+    AWAITHUMANS_TEST_TRANSPORT=smtp \
+      SMTP_HOST=smtp.gmail.com SMTP_PORT=587 \
+      SMTP_USER=you@gmail.com SMTP_PASSWORD=<app password> \
+      RECIPIENT_EMAIL=you@example.com \
+      FROM_EMAIL=you@gmail.com \
+      python send.py
+
+    # Hostinger Mail (port 465 / SSL):
+    AWAITHUMANS_TEST_TRANSPORT=smtp \
+      SMTP_HOST=smtp.hostinger.com SMTP_PORT=465 \
+      SMTP_USER=you@yourdomain.com SMTP_PASSWORD=... \
+      FROM_EMAIL=you@yourdomain.com \
+      RECIPIENT_EMAIL=you@yourdomain.com \
+      python send.py
+
+The identity is upserted as `email-e2e-real-py` so re-runs with
+new transport_config overwrite in place — no duplicate-id error.
+
+Prerequisites:
+  - `awaithumans dev` running in another terminal (the SDK reads
+    URL + admin token from the discovery file, no env-var dance)
+  - For Resend: a Resend account + API key. The
+    `onboarding@resend.dev` sender works without domain verification.
+  - For SMTP: a working SMTP host. Gmail needs an App Password
+    (https://myaccount.google.com/apppasswords). Hostinger uses
+    port 465 with the mailbox password (NOT the Hostinger account
+    password).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from typing import Any
+
+import httpx
+from pydantic import BaseModel, Field
+
+from awaithumans import await_human
+from awaithumans.utils.discovery import resolve_admin_token, resolve_server_url
+
+# ─── Resolve config ────────────────────────────────────────────────────
+
+SERVER_URL = resolve_server_url().rstrip("/")
+ADMIN_TOKEN = resolve_admin_token()
+
+if not ADMIN_TOKEN:
+    print(
+        "Couldn't find an admin token. Run `awaithumans dev` first "
+        "(writes ~/.awaithumans-dev.json), or export "
+        "AWAITHUMANS_ADMIN_API_TOKEN.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+RECIPIENT = os.environ.get("RECIPIENT_EMAIL")
+if not RECIPIENT:
+    print("RECIPIENT_EMAIL is required — your real inbox.", file=sys.stderr)
+    sys.exit(1)
+
+TRANSPORT = os.environ.get("AWAITHUMANS_TEST_TRANSPORT", "resend")
+IDENTITY_ID = "email-e2e-real-py"
+
+
+# ─── Build transport_config from env ───────────────────────────────────
+
+
+def build_transport_setup() -> dict[str, Any]:
+    if TRANSPORT == "resend":
+        api_key = os.environ.get("RESEND_API_KEY")
+        if not api_key:
+            print(
+                "RESEND_API_KEY required when transport=resend.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        return {
+            "from_email": os.environ.get("FROM_EMAIL", "onboarding@resend.dev"),
+            "transport": "resend",
+            "transport_config": {"api_key": api_key},
+        }
+
+    if TRANSPORT == "smtp":
+        host = os.environ.get("SMTP_HOST")
+        from_email = os.environ.get("FROM_EMAIL")
+        if not host or not from_email:
+            print(
+                "SMTP_HOST and FROM_EMAIL required when transport=smtp.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        port = int(os.environ.get("SMTP_PORT", "587"))
+        # Port 465 is implicit TLS (SSL on connect — what Hostinger,
+        # Gmail SSL, and most "secure" SMTP setups use). Port 587 is
+        # STARTTLS (plain connect, upgrade with STARTTLS — what
+        # Gmail modern, O365, AWS SES, Mailgun use). aiosmtplib
+        # rejects setting both modes — pick one based on port.
+        # Override with SMTP_TLS_MODE=ssl|starttls if your server
+        # uses a non-standard port.
+        tls_mode = os.environ.get(
+            "SMTP_TLS_MODE", "ssl" if port == 465 else "starttls"
+        )
+        use_tls = tls_mode == "ssl"
+        return {
+            "from_email": from_email,
+            "transport": "smtp",
+            "transport_config": {
+                "host": host,
+                "port": port,
+                "username": os.environ.get("SMTP_USER"),
+                "password": os.environ.get("SMTP_PASSWORD"),
+                "use_tls": use_tls,
+                "start_tls": not use_tls,
+            },
+        }
+
+    print(
+        f"Unknown transport '{TRANSPORT}'. Valid: resend, smtp. "
+        "(The `file` and `logging` transports are dev-only — see "
+        "examples/email-smoke-py for that.)",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+# ─── Identity setup (idempotent upsert) ────────────────────────────────
+
+
+_admin = httpx.Client(
+    base_url=SERVER_URL,
+    headers={
+        "Authorization": f"Bearer {ADMIN_TOKEN}",
+        "Content-Type": "application/json",
+    },
+    timeout=10,
+)
+
+
+def configure_identity(setup: dict[str, Any]) -> None:
+    resp = _admin.post(
+        "/api/channels/email/identities",
+        json={
+            "id": IDENTITY_ID,
+            "display_name": "awaithumans e2e real (py)",
+            "from_email": setup["from_email"],
+            "from_name": "awaithumans test",
+            "reply_to": None,
+            "transport": setup["transport"],
+            "transport_config": setup["transport_config"],
+        },
+    )
+    if resp.status_code >= 400:
+        print(
+            f"identity setup failed ({resp.status_code}): {resp.text}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    print(
+        f"→ identity '{IDENTITY_ID}' configured "
+        f"(transport={setup['transport']}, from={setup['from_email']})"
+    )
+
+
+# ─── Schemas ───────────────────────────────────────────────────────────
+
+
+class TestNote(BaseModel):
+    note: str
+    sent_at: str
+
+
+class ApprovalResponse(BaseModel):
+    """Single boolean → server-side `extract_form` produces a Switch
+    primitive, which is what the email renderer uses to decide whether
+    to emit Approve/Reject magic-link buttons."""
+
+    approved: bool = Field(..., description="Approve this test?")
+
+
+# ─── Run ───────────────────────────────────────────────────────────────
+
+
+async def main() -> None:
+    print(f"→ server: {SERVER_URL}")
+    print(f"→ recipient: {RECIPIENT}")
+    print(f"→ transport: {TRANSPORT}")
+
+    configure_identity(build_transport_setup())
+
+    print("")
+    print(
+        "→ creating task — check your inbox in a few seconds and click "
+        "the Approve button to complete it"
+    )
+
+    decision: ApprovalResponse = await await_human(
+        task="Approve this real-delivery test (Python)",
+        payload_schema=TestNote,
+        payload=TestNote(
+            note="If you received this email, awaithumans (Python) → real-mail integration works.",
+            sent_at=__import__("datetime").datetime.now().isoformat(),
+        ),
+        response_schema=ApprovalResponse,
+        # 30-minute window — generous so you have time to find the
+        # email, click through, and walk back. The post-completion
+        # updater will mark the message done either way.
+        timeout_seconds=30 * 60,
+        notify=[f"email+{IDENTITY_ID}:{RECIPIENT}"],
+        idempotency_key=f"email-e2e-real-py:{int(__import__('time').time())}",
+    )
+
+    print("")
+    if decision.approved:
+        print("✓ Approved — task completed end-to-end via real email")
+    else:
+        print("✗ Rejected — task completed end-to-end via real email")
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    finally:
+        _admin.close()


### PR DESCRIPTION
## Why

The `/channels/email` and `/channels/slack` docs hadn't kept pace with what shipped in PRs #34 through #50. Operators reading them today miss the signed Slack handoff, post-completion message updates, file transport, per-identity SMTP setup, and the runnable examples in both languages.

## Email page — what got added

- **File transport row** in the transports table + dedicated section for dev / testing
- **Two-paths-to-configure framing**: env var (default identity) vs per-identity DB records (multi-tenant). Quickstart stays env-var; multi-tenant section walks the dashboard / admin-API paths
- **SMTP examples** for Gmail (587/STARTTLS) AND Hostinger (465/SSL) — the transport auto-flips between modes based on the port
- **Hostinger-specific gotchas**: `from_email` must equal `SMTP_USER`, per-mailbox-per-hour rate limits, port 465-or-587 plan differences
- **Per-identity setup walkthrough** — dashboard route AND admin-API curl with all four transports
- **Action-button decision tree** clarified — single Switch / small SingleSelect → buttons; multi-field → dashboard link-out — plus the cross-language note that TS `extractForm()` and Python `extract_form()` produce the `form_definition`
- **Runnable-examples table** linking the four examples (smoke + end-to-end, TS + Python)

## Slack page — what got added

- `users:read.email` added to manifest scopes (was silently missing, broke the `slack:alice@acme.com` route format)
- **Adding users to the directory** section — Slack member picker + the fact that Slack-only users are valid
- **Multi-workspace `slack+T_ID:` route** examples
- **Signed dashboard handoff** section — URL shape, TTL bound to `task.timeout_at`, why Slack-only users can't reach the dashboard without it
- **Post-completion message updates** section — `chat.update` with no-buttons surface across completion paths (Slack modal / dashboard / cancel / timeout); note that pre-feature tasks don't have message refs
- Authorization section now mentions the operator-stepping-in banner
- Audit identity section explains the display-name fallback for Slack-only users
- **Runnable-examples table** linking `slack-native` (Python) and `slack-native-ts` (TS)
- New gotchas: missing `users:read.email`, "DM modal doesn't open" → user not in directory

## What didn't change

- No structural changes to the docs site — same pages, same nav position
- No new pages added, no `mint.json` changes
- All other docs pages untouched

## Test plan

- [ ] Build the docs locally (`cd docs && mintlify dev`) — both pages render without MDX errors
- [ ] Walk a fresh operator through email setup using the new email page → they end up with a working integration
- [ ] Walk a fresh operator through Slack setup using the new slack page → they end up with a working integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)