### PR TITLE
fix(email): record recipient as completed_by on magic-link click

### DIFF
--- a/packages/python/awaithumans/server/channels/email/magic_links.py
+++ b/packages/python/awaithumans/server/channels/email/magic_links.py
@@ -81,23 +81,35 @@ def sign_action_token(
     task_id: str,
     field_name: str,
     value: Any,
+    recipient: str | None = None,
     ttl_seconds: int | None = None,
     jti: str | None = None,
 ) -> str:
-    """Produce a signed token encoding (task_id, field_name, value, expiry, jti).
+    """Produce a signed token encoding (task_id, field_name, value, expiry, jti, recipient).
+
+    `recipient` is the email address the link is being issued for —
+    needed at click time so the action route can stamp the task's
+    `completed_by_email`. The renderer always knows who it's sending
+    to, so it threads that through here. Pre-feature tokens omit `r`
+    and verify_action_token returns recipient=None for them.
 
     `jti` is a random unique identifier the route uses to enforce
     single-use. Pass an explicit value only in tests where determinism
     helps; production callers leave it None and we generate a fresh
     random one per token."""
     ttl = ttl_seconds if ttl_seconds is not None else MAGIC_LINK_MAX_AGE_SECONDS
-    payload = {
+    payload: dict[str, Any] = {
         "t": task_id,
         "f": field_name,
         "v": value,
         "e": int(time.time()) + ttl,
         "j": jti or secrets.token_urlsafe(_JTI_BYTES),
     }
+    if recipient:
+        # Only include the field when set, so tokens minted without
+        # a recipient stay byte-identical to the old shape (helps
+        # operators eyeballing token payloads across releases).
+        payload["r"] = recipient
     body = _canonical(payload)
     mac = hmac.new(_hmac_key(), body, hashlib.sha256).digest()
     blob = mac + body
@@ -140,10 +152,19 @@ def verify_action_token(token: str) -> ActionClaim:
     if time.time() > expires_at:
         raise InvalidActionTokenError("expired")
 
+    # Recipient is opt-in: pre-feature tokens don't carry it, and
+    # the action route falls back to None for those (audit log will
+    # still show "—" for completed_by, same as before this change).
+    recipient_raw = payload.get("r")
+    recipient = (
+        recipient_raw if isinstance(recipient_raw, str) and recipient_raw else None
+    )
+
     return ActionClaim(
         task_id=task_id,
         field_name=field_name,
         value=value,
         expires_at=expires_at,
         jti=jti,
+        recipient=recipient,
     )

--- a/packages/python/awaithumans/server/channels/email/renderer.py
+++ b/packages/python/awaithumans/server/channels/email/renderer.py
@@ -52,9 +52,15 @@ def _buttons_for_form(
     form: FormDefinition | None,
     *,
     task_id: str,
+    recipient: str,
     public_url: str,
 ) -> list[ButtonSpec]:
-    """Build magic-link buttons, or empty list for link-out-only forms."""
+    """Build magic-link buttons, or empty list for link-out-only forms.
+
+    `recipient` is baked into each token so the action route can
+    stamp `completed_by_email` on the task. Without it, the audit
+    log shows "—" for every email completion.
+    """
     if form is None:
         return []
 
@@ -64,10 +70,16 @@ def _buttons_for_form(
 
     if isinstance(field, Switch):
         approve_token = sign_action_token(
-            task_id=task_id, field_name=field.name, value=True
+            task_id=task_id,
+            field_name=field.name,
+            value=True,
+            recipient=recipient,
         )
         reject_token = sign_action_token(
-            task_id=task_id, field_name=field.name, value=False
+            task_id=task_id,
+            field_name=field.name,
+            value=False,
+            recipient=recipient,
         )
         return [
             ButtonSpec(
@@ -89,7 +101,10 @@ def _buttons_for_form(
                 url=_magic_link_url(
                     public_url,
                     sign_action_token(
-                        task_id=task_id, field_name=field.name, value=opt.value
+                        task_id=task_id,
+                        field_name=field.name,
+                        value=opt.value,
+                        recipient=recipient,
                     ),
                 ),
                 style="primary" if i == 0 else "neutral",
@@ -129,7 +144,9 @@ def build_notification_email(
 ) -> EmailMessage:
     """Assemble the EmailMessage for one recipient."""
     review_url = _review_url(public_url, task_id)
-    buttons = _buttons_for_form(form, task_id=task_id, public_url=public_url)
+    buttons = _buttons_for_form(
+        form, task_id=task_id, recipient=to, public_url=public_url
+    )
     lines = _payload_lines(task_payload, redact_payload)
 
     html = notification_html(

--- a/packages/python/awaithumans/server/channels/email/types.py
+++ b/packages/python/awaithumans/server/channels/email/types.py
@@ -12,8 +12,15 @@ class ActionClaim:
 
     Produced by `magic_links.verify_action_token`. Carries the task
     reference, the single field/value the link commits to, the
-    expiry timestamp, and a unique `jti` (JWT-style ID) used by the
-    consume table to enforce single-use semantics.
+    expiry timestamp, the recipient email the link was issued to,
+    and a unique `jti` (JWT-style ID) used by the consume table
+    to enforce single-use semantics.
+
+    `recipient` is the email address the renderer signed the link
+    for — used by the action route to stamp `completed_by_email`
+    on the task so the audit log isn't a black hole for email
+    completions. None for tokens minted before this field was
+    added (backward-compat with in-flight tokens at deploy time).
     """
 
     task_id: str
@@ -21,3 +28,4 @@ class ActionClaim:
     value: Any
     expires_at: int
     jti: str
+    recipient: str | None = None

--- a/packages/python/awaithumans/server/routes/email.py
+++ b/packages/python/awaithumans/server/routes/email.py
@@ -54,6 +54,7 @@ from awaithumans.server.services.exceptions import (
     TaskNotFoundError,
 )
 from awaithumans.server.services.task_service import complete_task, get_task
+from awaithumans.server.services.user_service import get_user_by_email
 from awaithumans.utils.constants import TERMINAL_STATUSES_SET
 
 router = APIRouter(prefix="/channels/email", tags=["channels"])
@@ -263,12 +264,24 @@ async def action_submit(
             ),
         )
 
+    # Resolve completer attribution from the token's recipient field.
+    # Pre-feature tokens (signed before this field was added) carry
+    # recipient=None — we leave both completed_* fields null and the
+    # audit log shows "—", same behavior as before this change.
+    completer_email = claim.recipient
+    completer_user_id: str | None = None
+    if completer_email:
+        directory_user = await get_user_by_email(session, completer_email)
+        if directory_user is not None and directory_user.active:
+            completer_user_id = directory_user.id
+
     try:
         await complete_task(
             session,
             task_id=claim.task_id,
             response={claim.field_name: claim.value},
-            completed_by_email=None,
+            completed_by_email=completer_email,
+            completed_by_user_id=completer_user_id,
             completed_via_channel="email",
         )
     except TaskAlreadyTerminalError:

--- a/packages/python/tests/email/test_admin_and_action_routes.py
+++ b/packages/python/tests/email/test_admin_and_action_routes.py
@@ -218,12 +218,19 @@ async def test_action_post_completes_task(client: AsyncClient) -> None:
         task_id = task.id
         break
 
-    token = sign_action_token(task_id=task_id, field_name="approve", value=True)
+    token = sign_action_token(
+        task_id=task_id,
+        field_name="approve",
+        value=True,
+        recipient="reviewer@acme.com",
+    )
     resp = await client.post(f"/api/channels/email/action/{token}")
     assert resp.status_code == 200
     assert "recorded" in resp.text.lower() or "thanks" in resp.text.lower()
 
-    # Verify the task is actually completed with the signed value.
+    # Verify the task is actually completed with the signed value AND
+    # that the recipient email landed on `completed_by_email` so the
+    # audit log isn't a black hole for email completions.
     async for session in _direct_session(client):
         from awaithumans.server.services.task_service import get_task
 
@@ -231,6 +238,49 @@ async def test_action_post_completes_task(client: AsyncClient) -> None:
         assert updated.status == TaskStatus.COMPLETED
         assert updated.response == {"approve": True}
         assert updated.completed_via_channel == "email"
+        assert updated.completed_by_email == "reviewer@acme.com"
+        # No directory user with that email → user_id stays null;
+        # email-only attribution still wins over the previous
+        # null-everything behavior.
+        assert updated.completed_by_user_id is None
+        break
+
+
+@pytest.mark.asyncio
+async def test_action_post_pre_feature_token_leaves_completed_by_null(
+    client: AsyncClient,
+) -> None:
+    """A token signed without the new `recipient` field (i.e., before
+    this fix shipped) must still verify and complete the task — just
+    without the email attribution. Pre-feature in-flight tokens at
+    deploy time would otherwise 500."""
+    async for session in _direct_session(client):
+        task = await create_task(
+            session,
+            task="Approve wire",
+            payload={},
+            payload_schema={},
+            response_schema={},
+            timeout_seconds=3600,
+            idempotency_key="k-no-recipient",
+        )
+        task_id = task.id
+        break
+
+    # `recipient=None` (default) → token's signed body omits `r`.
+    token = sign_action_token(
+        task_id=task_id, field_name="approve", value=True
+    )
+    resp = await client.post(f"/api/channels/email/action/{token}")
+    assert resp.status_code == 200
+
+    async for session in _direct_session(client):
+        from awaithumans.server.services.task_service import get_task
+
+        updated = await get_task(session, task_id)
+        assert updated.status == TaskStatus.COMPLETED
+        assert updated.completed_by_email is None
+        assert updated.completed_by_user_id is None
         break
 
 

--- a/packages/python/tests/email/test_magic_links.py
+++ b/packages/python/tests/email/test_magic_links.py
@@ -109,6 +109,32 @@ def test_short_ttl_honored() -> None:
             verify_action_token(token)
 
 
+def test_recipient_round_trips_through_token() -> None:
+    """The renderer signs the recipient email into every action token.
+    The action route reads `claim.recipient` and stamps it as
+    `completed_by_email` so the audit log isn't a black hole for
+    email completions. Pin the round-trip."""
+    token = sign_action_token(
+        task_id="t1",
+        field_name="approve",
+        value=True,
+        recipient="alice@acme.com",
+    )
+    claim = verify_action_token(token)
+    assert claim.recipient == "alice@acme.com"
+
+
+def test_recipient_omitted_yields_none() -> None:
+    """Pre-feature tokens (no `r` field in the signed body) verify
+    cleanly — the audit log just shows "—" the way it did before
+    this change. Tested by signing without `recipient=`."""
+    token = sign_action_token(
+        task_id="t1", field_name="approve", value=True
+    )
+    claim = verify_action_token(token)
+    assert claim.recipient is None
+
+
 def test_malformed_inputs_rejected() -> None:
     with pytest.raises(InvalidActionTokenError):
         verify_action_token("")


### PR DESCRIPTION
## Symptom

Audit log shows "—" in the **Completed By** column for tasks completed via an email magic-link click — even though the task itself completed correctly. Same row's Slack-completed and dashboard-completed tasks show the user.

| Task | Completed by | Channel |
|---|---|---|
| Approve this real-delivery test | **—** | email |
| Approve this wire transfer | TA | dashboard |
| Approve this wire transfer | TA | slack |

## Root cause

`/api/channels/email/action/<token>` hardcoded `completed_by_email=None`:

```python
await complete_task(
    session,
    task_id=claim.task_id,
    response={claim.field_name: claim.value},
    completed_by_email=None,            # ← never set
    completed_via_channel="email",
)
```

The signed token carried `(task_id, field_name, value, expiry, jti)` but no recipient identity, so even when the renderer knew who it was sending to, that information was lost by the time the click landed back at the server.

This is the same shape as the Slack-only-completer gap closed in PR #41 — just on the other channel.

## Fix

Bake the recipient into the signed token. The renderer already has the `to` address (it's in the EmailMessage); thread it through `sign_action_token(recipient=...)`. On click, the action route reads `claim.recipient` and:

1. Stamps `completed_by_email = claim.recipient`
2. Looks up the directory user by that email; if found and active, also stamps `completed_by_user_id`

The `r` field in the signed body is **opt-in** for backward-compatibility: tokens minted without `recipient=` omit it entirely (byte-identical to the pre-fix shape), and `verify_action_token` returns `recipient=None` for those. Pre-fix in-flight tokens at deploy time still verify cleanly — the audit log just shows "—" for those, same as before this change.

## Tests

- 2 new cases in `tests/email/test_magic_links.py`:
  - recipient round-trips through sign / verify
  - missing `r` → `recipient=None` (backward-compat with old tokens)
- Existing `test_action_post_completes_task` extended — asserts `completed_by_email` and `completed_by_user_id` after click
- New `test_action_post_pre_feature_token_leaves_completed_by_null` for the deploy-time-rolling case

`477 passing` (was 474; +3). 76 in `tests/email/`.

## Test plan

- [ ] After merge + reinstall, run a fresh email-end-to-end test (Resend or SMTP)
- [ ] Click the magic-link button in your inbox
- [ ] Audit log shows your email in the "Completed By" column instead of "—"
- [ ] Old completed tasks (before this fix) still show "—" — no migration backfill, fixed forward only

🤖 Generated with [Claude Code](https://claude.com/claude-code)