### PR TITLE
Verifier examples + fix TS SDK camelCase wire translation

### DIFF
--- a/examples/verifier-py/README.md
+++ b/examples/verifier-py/README.md
@@ -1,0 +1,84 @@
+# Verifier example (Python)
+
+Smallest end-to-end demo of `awaithumans` AI verification: a refund
+decision is gated by a Claude verifier before the agent unblocks.
+
+The verifier runs **server-side** — this example just attaches a
+`VerifierConfig` to the `await_human` call. The server reads
+`ANTHROPIC_API_KEY` and runs the LLM check against the human's
+submission.
+
+Mirrors [`../verifier/`](../verifier/) (TypeScript).
+
+## Prerequisites
+
+- Python 3.10+
+- A Claude API key exported in the **server's** shell as
+  `ANTHROPIC_API_KEY` — the verifier runs server-side.
+
+## Run
+
+**Terminal 1** — the server (must see your API key):
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+pip install "awaithumans[server,verifier-claude]"
+awaithumans dev
+```
+
+**Terminal 2** — this example agent:
+
+```bash
+pip install -r requirements.txt
+python refund.py
+```
+
+You should see:
+
+```
+→ creating refund task with a Claude verifier attached...
+  Open http://localhost:3001 to review.
+```
+
+## What to test
+
+Open <http://localhost:3001> and walk the three verifier paths:
+
+| Goal | Submit this | Result |
+|---|---|---|
+| **Pass** | Approve, reason references *damage / policy / evidence* | Verifier passes → task COMPLETED → script unblocks |
+| **Reject + retry** | Approve, reason `"ok"` | Verifier rejects → task REJECTED (non-terminal) → resubmit |
+| **Exhaust** | Submit bad reasons 3×in a row | After `max_attempts` → task VERIFICATION_EXHAUSTED → script raises `VerificationExhaustedError` |
+
+The dashboard shows the rejection text from the verifier on each
+failed attempt — that text comes straight from the LLM and is what
+the human sees in the UI.
+
+## What the code looks like
+
+```python
+from awaithumans import await_human_sync
+from awaithumans.verifiers.claude import claude_verifier
+
+decision = await_human_sync(
+    task="Approve refund (verified)",
+    payload_schema=RefundRequest,
+    payload=RefundRequest(...),
+    response_schema=Decision,
+    timeout_seconds=900,
+    verifier=claude_verifier(
+        instructions="...quality gate prompt...",
+        max_attempts=3,
+    ),
+)
+```
+
+That's the whole verifier integration — one extra kwarg.
+
+## Next steps
+
+- Swap providers: `awaithumans.verifiers.openai`, `.gemini`,
+  `.azure_openai`. Same shape; different API key env var.
+- Combine with `notify=["slack:#ops"]` — the verifier still runs no
+  matter which channel the human used to submit.
+- TypeScript version: [`../verifier/`](../verifier/).

--- a/examples/verifier-py/refund.py
+++ b/examples/verifier-py/refund.py
@@ -1,0 +1,119 @@
+"""
+awaithumans verifier example (Python) — refund approval gated by an
+LLM verifier.
+
+Scenario: the human's decision must pass an LLM quality check before
+the agent unblocks. The verifier reads the original request, the
+decision, and a strict policy, then either passes (→ COMPLETED) or
+rejects (→ REJECTED, can resubmit; → VERIFICATION_EXHAUSTED after the
+attempt limit).
+
+Prerequisites
+-------------
+1. In another terminal, with `ANTHROPIC_API_KEY` exported in that
+   shell so the SERVER can call Claude:
+
+       export ANTHROPIC_API_KEY=sk-ant-...
+       pip install "awaithumans[server,verifier-claude]"
+       awaithumans dev
+
+2. Then in this terminal:
+
+       pip install -r requirements.txt
+       python refund.py
+
+What to do (manual verifier test)
+---------------------------------
+Open http://localhost:3001 and review the task. Try the three paths:
+
+  Pass        — approve the refund and write a reason that mentions
+                "damage" / "policy" / "evidence". Verifier passes;
+                this script unblocks with the typed Decision.
+
+  Reject+retry— write a vague reason like "ok". Verifier rejects on
+                the first attempt; the dashboard shows the rejection
+                reason and lets you resubmit. Up to `max_attempts`.
+
+  Exhaust     — keep submitting bad reasons. After max_attempts the
+                task transitions to VERIFICATION_EXHAUSTED (terminal)
+                and this script raises VerificationExhaustedError.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from awaithumans import await_human_sync
+from awaithumans.errors import VerificationExhaustedError
+from awaithumans.verifiers.claude import claude_verifier
+
+
+class RefundRequest(BaseModel):
+    order_id: str
+    customer: str
+    amount_usd: float
+    reason: str
+
+
+class Decision(BaseModel):
+    approved: bool = Field(..., description="Approve the refund?")
+    reason: str = Field(
+        ...,
+        description=(
+            "Why? If approving, mention damage / policy / evidence. "
+            "If rejecting, at least 20 characters explaining why."
+        ),
+    )
+
+
+VERIFIER_INSTRUCTIONS = """\
+You are a quality gate for refund decisions. Read the original
+request (in `payload`) and the human's decision (in `response`).
+
+PASS only if BOTH hold:
+  1. If `response.approved` is true, `response.reason` must mention
+     at least one of: "damage", "policy", "evidence" (case-insensitive).
+  2. If `response.approved` is false, `response.reason` must be at
+     least 20 characters and substantively explain the rejection.
+
+Otherwise REJECT with a short, actionable reason the human will see.
+"""
+
+
+def main() -> None:
+    order_id = "A-9921"
+
+    print("→ creating refund task with a Claude verifier attached...")
+    print("  Open http://localhost:3001 to review.\n")
+
+    try:
+        decision = await_human_sync(
+            task="Approve refund (verified)",
+            payload_schema=RefundRequest,
+            payload=RefundRequest(
+                order_id=order_id,
+                customer="riley@example.com",
+                amount_usd=420.00,
+                reason="Item arrived broken; customer sent two photos.",
+            ),
+            response_schema=Decision,
+            timeout_seconds=900,
+            verifier=claude_verifier(
+                instructions=VERIFIER_INSTRUCTIONS,
+                max_attempts=3,
+            ),
+            idempotency_key=f"refund-verified:{order_id}",
+        )
+    except VerificationExhaustedError as exc:
+        print(f"✗ Verifier exhausted after {exc.attempts} attempts.")
+        print("  The agent is unblocked but the task did not pass review.")
+        return
+
+    if decision.approved:
+        print(f"✓ Refund approved (verifier passed). Reason: {decision.reason}")
+    else:
+        print(f"✗ Refund rejected (verifier passed). Reason: {decision.reason}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/verifier-py/requirements.txt
+++ b/examples/verifier-py/requirements.txt
@@ -1,0 +1,3 @@
+awaithumans
+httpx>=0.27
+pydantic>=2.0

--- a/examples/verifier/README.md
+++ b/examples/verifier/README.md
@@ -1,0 +1,86 @@
+# Verifier example (TypeScript)
+
+Smallest end-to-end demo of `awaithumans` AI verification: a refund
+decision is gated by a Claude verifier before the agent unblocks.
+
+The verifier runs **server-side** — this example just attaches a
+verifier config to the `awaitHuman` call. The server reads
+`ANTHROPIC_API_KEY` and runs the LLM check against the human's
+submission.
+
+Mirrors [`../verifier-py/`](../verifier-py/) (Python).
+
+## Prerequisites
+
+- Node 20+
+- A Claude API key exported in the **server's** shell as
+  `ANTHROPIC_API_KEY` — the verifier runs server-side.
+
+## Run
+
+**Terminal 1** — the server (must see your API key):
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+npx awaithumans dev
+```
+
+**Terminal 2** — this example agent:
+
+```bash
+npm install
+npm start
+```
+
+You should see:
+
+```
+→ creating refund task with a Claude verifier attached...
+  Open http://localhost:3001 to review.
+```
+
+## What to test
+
+Open <http://localhost:3001> and walk the three verifier paths:
+
+| Goal | Submit this | Result |
+|---|---|---|
+| **Pass** | Approve, reason references *damage / policy / evidence* | Verifier passes → task COMPLETED → script unblocks |
+| **Reject + retry** | Approve, reason `"ok"` | Verifier rejects → task REJECTED (non-terminal) → resubmit |
+| **Exhaust** | Submit bad reasons 3× in a row | After `max_attempts` → task VERIFICATION_EXHAUSTED → script throws `VerificationExhaustedError` |
+
+The dashboard shows the rejection text from the verifier on each
+failed attempt — that text comes straight from the LLM and is what
+the human sees in the UI.
+
+## What the code looks like
+
+```ts
+import { awaitHuman } from "awaithumans";
+
+const decision = await awaitHuman({
+  task: "Approve refund (verified)",
+  payloadSchema: RefundRequest,
+  payload: { ... },
+  responseSchema: Decision,
+  timeoutMs: 900_000,
+  verifier: {
+    provider: "claude",
+    model: "claude-sonnet-4-20250514",
+    instructions: "...quality gate prompt...",
+    maxAttempts: 3,
+    apiKeyEnv: "ANTHROPIC_API_KEY",
+  },
+});
+```
+
+The SDK translates the camelCase config into the server's snake_case
+`verifier_config` wire shape for you.
+
+## Next steps
+
+- Swap providers: change `provider` to `"openai"`, `"gemini"`, or
+  `"azure_openai"`. Each provider reads a different API key env var.
+- Combine with `notify: ["slack:#ops"]` — the verifier still runs no
+  matter which channel the human used to submit.
+- Python version: [`../verifier-py/`](../verifier-py/).

--- a/examples/verifier/package.json
+++ b/examples/verifier/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "awaithumans-verifier",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "tsx refund.ts"
+  },
+  "dependencies": {
+    "awaithumans": "file:../../packages/typescript-sdk",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/verifier/refund.ts
+++ b/examples/verifier/refund.ts
@@ -1,0 +1,132 @@
+/**
+ * awaithumans verifier example (TypeScript) — refund approval gated
+ * by an LLM verifier.
+ *
+ * Scenario: the human's decision must pass an LLM quality check before
+ * the agent unblocks. The verifier reads the original request, the
+ * decision, and a strict policy, then either passes (→ COMPLETED) or
+ * rejects (→ REJECTED, can resubmit; → VERIFICATION_EXHAUSTED after
+ * the attempt limit).
+ *
+ * Prerequisites
+ * -------------
+ * 1. In another terminal, with `ANTHROPIC_API_KEY` exported in that
+ *    shell so the SERVER can call Claude:
+ *
+ *        export ANTHROPIC_API_KEY=sk-ant-...
+ *        npx awaithumans dev
+ *
+ * 2. Then in this terminal:
+ *
+ *        npm install
+ *        npm start
+ *
+ * What to do (manual verifier test)
+ * ---------------------------------
+ * Open http://localhost:3001 and review the task. Try the three paths:
+ *
+ *   Pass         — approve the refund and write a reason that mentions
+ *                  "damage" / "policy" / "evidence". Verifier passes;
+ *                  this script unblocks with the typed Decision.
+ *
+ *   Reject+retry — write a vague reason like "ok". Verifier rejects on
+ *                  the first attempt; the dashboard shows the rejection
+ *                  reason and lets you resubmit. Up to max_attempts.
+ *
+ *   Exhaust      — keep submitting bad reasons. After max_attempts the
+ *                  task transitions to VERIFICATION_EXHAUSTED (terminal)
+ *                  and this script throws VerificationExhaustedError.
+ */
+
+import { z } from "zod";
+import {
+	awaitHuman,
+	VerificationExhaustedError,
+	type VerifierConfig,
+} from "awaithumans";
+
+const RefundRequest = z.object({
+	orderId: z.string(),
+	customer: z.string(),
+	amountUsd: z.number(),
+	reason: z.string(),
+});
+
+const Decision = z.object({
+	approved: z.boolean().describe("Approve the refund?"),
+	reason: z
+		.string()
+		.describe(
+			"Why? If approving, mention damage / policy / evidence. " +
+				"If rejecting, at least 20 characters explaining why.",
+		),
+});
+
+const VERIFIER_INSTRUCTIONS = `\
+You are a quality gate for refund decisions. Read the original
+request (in \`payload\`) and the human's decision (in \`response\`).
+
+PASS only if BOTH hold:
+  1. If response.approved is true, response.reason must mention
+     at least one of: "damage", "policy", "evidence" (case-insensitive).
+  2. If response.approved is false, response.reason must be at least
+     20 characters and substantively explain the rejection.
+
+Otherwise REJECT with a short, actionable reason the human will see.
+`;
+
+const verifierConfig: VerifierConfig = {
+	provider: "claude",
+	model: "claude-sonnet-4-20250514",
+	instructions: VERIFIER_INSTRUCTIONS,
+	maxAttempts: 3,
+	apiKeyEnv: "ANTHROPIC_API_KEY",
+};
+
+async function main(): Promise<void> {
+	const orderId = "A-9921";
+
+	console.log("→ creating refund task with a Claude verifier attached...");
+	console.log("  Open http://localhost:3001 to review.\n");
+
+	try {
+		const decision = await awaitHuman({
+			task: "Approve refund (verified)",
+			payloadSchema: RefundRequest,
+			payload: {
+				orderId,
+				customer: "riley@example.com",
+				amountUsd: 420.0,
+				reason: "Item arrived broken; customer sent two photos.",
+			},
+			responseSchema: Decision,
+			timeoutMs: 900_000,
+			verifier: verifierConfig,
+			idempotencyKey: `refund-verified:${orderId}`,
+		});
+
+		if (decision.approved) {
+			console.log(
+				`✓ Refund approved (verifier passed). Reason: ${decision.reason}`,
+			);
+		} else {
+			console.log(
+				`✗ Refund rejected (verifier passed). Reason: ${decision.reason}`,
+			);
+		}
+	} catch (err) {
+		if (err instanceof VerificationExhaustedError) {
+			console.log(`✗ ${err.message}`);
+			console.log(
+				"  The agent is unblocked but the task did not pass review.",
+			);
+			return;
+		}
+		throw err;
+	}
+}
+
+main().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/examples/verifier/tsconfig.json
+++ b/examples/verifier/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["*.ts"]
+}

--- a/packages/typescript-sdk/src/adapters/temporal/index.ts
+++ b/packages/typescript-sdk/src/adapters/temporal/index.ts
@@ -80,7 +80,10 @@ import {
 	VerificationExhaustedError,
 } from "../../errors.js";
 import { generateIdempotencyKey } from "../../internal/idempotency.js";
-import { serializeAssignTo } from "../../internal/wire.js";
+import {
+	serializeAssignTo,
+	serializeVerifierConfig,
+} from "../../internal/wire.js";
 import type { AssignTo, AwaitHumanOptions, VerifierConfig } from "../../types/index.js";
 
 // Signal-name prefix — must match the Python adapter exactly.
@@ -197,8 +200,9 @@ export async function awaitHuman<TPayload, TResponse>(
 		idempotency_key: idempotencyKey,
 		assign_to: serializeAssignTo(options.assignTo as AssignTo | undefined),
 		notify: options.notify ?? null,
-		verifier_config:
-			(options.verifier as VerifierConfig | undefined) ?? null,
+		verifier_config: serializeVerifierConfig(
+			options.verifier as VerifierConfig | undefined,
+		),
 		redact_payload: options.redactPayload ?? false,
 		callback_url: options.callbackUrl,
 	};

--- a/packages/typescript-sdk/src/await-human.ts
+++ b/packages/typescript-sdk/src/await-human.ts
@@ -32,6 +32,7 @@ import {
 	type CreateTaskResponseWire,
 	type PollResponseWire,
 	serializeAssignTo,
+	serializeVerifierConfig,
 } from "./internal/wire.js";
 import {
 	MarketplaceNotAvailableError,
@@ -127,7 +128,7 @@ export async function awaitHuman<TPayload, TResponse>(
 		idempotency_key: idempotencyKey,
 		assign_to: serializeAssignTo(options.assignTo),
 		notify: options.notify ?? null,
-		verifier_config: options.verifier ?? null,
+		verifier_config: serializeVerifierConfig(options.verifier),
 		redact_payload: options.redactPayload ?? false,
 		callback_url: null,
 	};

--- a/packages/typescript-sdk/src/internal/wire.ts
+++ b/packages/typescript-sdk/src/internal/wire.ts
@@ -10,7 +10,7 @@
  * and only validates user inputs (payload/response against caller schemas).
  */
 
-import type { TaskStatus } from "../types/index.js";
+import type { TaskStatus, VerifierConfig } from "../types/index.js";
 
 // ─── POST /api/tasks ─────────────────────────────────────────────────
 
@@ -58,4 +58,36 @@ export function serializeAssignTo(assignTo: unknown): unknown | null {
 	if (Array.isArray(assignTo)) return { emails: assignTo };
 	if (typeof assignTo === "object") return assignTo;
 	return { value: String(assignTo) };
+}
+
+// ─── Verifier translation ────────────────────────────────────────────
+
+interface VerifierConfigWire {
+	provider: string;
+	model?: string;
+	instructions: string;
+	max_attempts: number;
+	api_key_env?: string;
+}
+
+/**
+ * Convert the caller-facing `VerifierConfig` (camelCase, idiomatic TS)
+ * into the snake_case wire shape the Python server's Pydantic
+ * `VerifierConfig` validates against. Without this translation the
+ * server's `extra="ignore"` default silently drops camelCase fields
+ * and the verifier runs with `max_attempts=3` regardless of the
+ * caller's choice.
+ */
+export function serializeVerifierConfig(
+	config: VerifierConfig | undefined | null,
+): VerifierConfigWire | null {
+	if (config == null) return null;
+	const wire: VerifierConfigWire = {
+		provider: config.provider,
+		instructions: config.instructions,
+		max_attempts: config.maxAttempts,
+	};
+	if (config.model !== undefined) wire.model = config.model;
+	if (config.apiKeyEnv !== undefined) wire.api_key_env = config.apiKeyEnv;
+	return wire;
 }

--- a/packages/typescript-sdk/tests/await-human.test.ts
+++ b/packages/typescript-sdk/tests/await-human.test.ts
@@ -212,6 +212,73 @@ describe("happy path", () => {
 		});
 	});
 
+	it("translates verifier camelCase fields into snake_case wire shape", async () => {
+		// The server's Pydantic VerifierConfig expects snake_case keys.
+		// Without translation the SDK silently drops `maxAttempts` /
+		// `apiKeyEnv` and the server defaults `max_attempts` to 3.
+		const fetchMock = installFetchSequence([
+			makeResponse(200, { id: "t", status: "created" }),
+			makeResponse(200, { status: "completed", response: { approved: true } }),
+		]);
+
+		await awaitHuman({
+			...BASE_OPTIONS,
+			verifier: {
+				provider: "claude",
+				model: "claude-sonnet-4-20250514",
+				instructions: "Check consistency.",
+				maxAttempts: 5,
+				apiKeyEnv: "ANTHROPIC_API_KEY",
+			},
+		});
+
+		const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+		expect(body.verifier_config).toEqual({
+			provider: "claude",
+			model: "claude-sonnet-4-20250514",
+			instructions: "Check consistency.",
+			max_attempts: 5,
+			api_key_env: "ANTHROPIC_API_KEY",
+		});
+	});
+
+	it("omits optional verifier fields when not provided", async () => {
+		const fetchMock = installFetchSequence([
+			makeResponse(200, { id: "t", status: "created" }),
+			makeResponse(200, { status: "completed", response: { approved: true } }),
+		]);
+
+		await awaitHuman({
+			...BASE_OPTIONS,
+			verifier: {
+				provider: "claude",
+				instructions: "Check it.",
+				maxAttempts: 3,
+			},
+		});
+
+		const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+		expect(body.verifier_config).toEqual({
+			provider: "claude",
+			instructions: "Check it.",
+			max_attempts: 3,
+		});
+		expect(body.verifier_config.model).toBeUndefined();
+		expect(body.verifier_config.api_key_env).toBeUndefined();
+	});
+
+	it("passes null verifier_config when no verifier is provided", async () => {
+		const fetchMock = installFetchSequence([
+			makeResponse(200, { id: "t", status: "created" }),
+			makeResponse(200, { status: "completed", response: { approved: true } }),
+		]);
+
+		await awaitHuman(BASE_OPTIONS);
+
+		const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+		expect(body.verifier_config).toBeNull();
+	});
+
 	it("passes through explicit idempotency key", async () => {
 		const fetchMock = installFetchSequence([
 			makeResponse(200, { id: "t", status: "created" }),


### PR DESCRIPTION
## Summary

- Add a runnable Python + TypeScript example pair (`examples/verifier-py/`, `examples/verifier/`) for manually testing the AI verifier flow end-to-end. Each README documents three verifier outcomes the operator can reproduce from the dashboard: **pass**, **reject + retry**, **exhaust**.
- Fix a TS SDK / Python-server wire-format mismatch on `verifier_config`: the SDK exposes camelCase fields (`maxAttempts`, `apiKeyEnv`) but the server's Pydantic `VerifierConfig` only validates snake_case keys. The SDK was forwarding `options.verifier` straight through, so `extra="ignore"` was silently dropping the caller's `maxAttempts` and the verifier ran with `max_attempts=3` regardless. The fix mirrors the existing `serializeAssignTo` translation pattern in `wire.ts`.
- Update both `awaitHuman` and the Temporal adapter to call the new `serializeVerifierConfig` translator. The TS example uses the natural camelCase `VerifierConfig` interface — no casts.

## What's in here

**Commit 1 — `fix(sdk): translate verifier camelCase fields to snake_case wire`**
- `packages/typescript-sdk/src/internal/wire.ts` — new `serializeVerifierConfig`. Optional fields (`model`, `apiKeyEnv`) are omitted from the wire shape when not provided so the server's defaults still apply.
- `packages/typescript-sdk/src/await-human.ts` — call the translator when building the create-task body.
- `packages/typescript-sdk/src/adapters/temporal/index.ts` — same change for the Temporal adapter path.
- `packages/typescript-sdk/tests/await-human.test.ts` — three new unit tests pinning the translation, the optional-field omission, and the null-passthrough when no verifier is configured.

**Commit 2 — `feat(examples): verifier example (Python + TS) for AI verification`**
- `examples/verifier-py/` — Python, uses `awaithumans.verifiers.claude.claude_verifier`.
- `examples/verifier/` — TypeScript, uses the SDK's `VerifierConfig` directly.
- Both attach a Claude verifier with `max_attempts=3` and instructions strict enough that the manual operator can reproduce pass / reject-and-resubmit / verification-exhausted by varying the dashboard submission.

## Test plan

- [x] `npx vitest run` in `packages/typescript-sdk` — 66 passing, including 3 new tests
- [x] `npx tsc --noEmit` in `packages/typescript-sdk` and in `examples/verifier/`
- [x] `npx biome check` on all modified TS files — clean
- [x] `python -m py_compile examples/verifier-py/refund.py` — clean
- [ ] Manual: run `npx awaithumans dev` (with `ANTHROPIC_API_KEY`), then `python refund.py` from `examples/verifier-py/` — reproduce all three verifier outcomes from the dashboard
- [ ] Manual: same loop with `npm start` from `examples/verifier/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)