### PR TITLE
feat(email): signed dashboard handoff + auto-provision recipients on first click

### DIFF
--- a/examples/email-end-to-end-py/send.py
+++ b/examples/email-end-to-end-py/send.py
@@ -185,11 +185,21 @@ class TestNote(BaseModel):
 
 
 class ApprovalResponse(BaseModel):
-    """Single boolean → server-side `extract_form` produces a Switch
-    primitive, which is what the email renderer uses to decide whether
-    to emit Approve/Reject magic-link buttons."""
+    """Multi-field response — exercises the email renderer's
+    *dashboard link-out* path (the magic-link button shortcut only
+    fires for single Switch / small SingleSelect responses).
+
+    The recipient gets an email with no inline buttons, just a
+    "Review in dashboard" link. They click → land at /task?id=…
+    → fill the form (Yes/No + reason) → Submit. The Python SDK's
+    long-poll resolves with both fields set.
+
+    To test the magic-link button path instead, drop the `reason`
+    field and re-run.
+    """
 
     approved: bool = Field(..., description="Approve this test?")
+    reason: str = Field(..., description="Why approve / reject? Short answer.")
 
 
 # ─── Run ───────────────────────────────────────────────────────────────
@@ -204,8 +214,13 @@ async def main() -> None:
 
     print("")
     print(
-        "→ creating task — check your inbox in a few seconds and click "
-        "the Approve button to complete it"
+        "→ creating task — multi-field response so you'll get a "
+        "'Review in dashboard' link-out (not inline magic-link "
+        "buttons)"
+    )
+    print(
+        "  Click the link in your inbox → log in to the dashboard → "
+        "fill the form → Submit"
     )
 
     decision: ApprovalResponse = await await_human(
@@ -217,18 +232,18 @@ async def main() -> None:
         ),
         response_schema=ApprovalResponse,
         # 30-minute window — generous so you have time to find the
-        # email, click through, and walk back. The post-completion
-        # updater will mark the message done either way.
+        # email, click through, log in, fill the form, and walk back.
+        # The post-completion updater will mark the message done
+        # either way.
         timeout_seconds=30 * 60,
         notify=[f"email+{IDENTITY_ID}:{RECIPIENT}"],
         idempotency_key=f"email-e2e-real-py:{int(__import__('time').time())}",
     )
 
     print("")
-    if decision.approved:
-        print("✓ Approved — task completed end-to-end via real email")
-    else:
-        print("✗ Rejected — task completed end-to-end via real email")
+    verdict = "✓ Approved" if decision.approved else "✗ Rejected"
+    print(f"{verdict} — task completed end-to-end via real email")
+    print(f"  reason: {decision.reason}")
 
 
 if __name__ == "__main__":

--- a/packages/python/awaithumans/server/channels/email/notifier.py
+++ b/packages/python/awaithumans/server/channels/email/notifier.py
@@ -54,6 +54,22 @@ async def notify_task(
     form = _parse_form(form_definition)
 
     async with factory() as session:
+        # Pull the task once so we can sign the dashboard handoff URL
+        # with the correct expiry. If the task was deleted between the
+        # route handler and this background run there's nothing to
+        # notify about — bail.
+        from awaithumans.server.services.task_service import get_task
+
+        try:
+            task = await get_task(session, task_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("notify_task (email): task %s missing: %s", task_id, exc)
+            return
+
+        handoff_exp_unix = (
+            int(task.timeout_at.timestamp()) if task.timeout_at else None
+        )
+
         for route in routes:
             try:
                 await _deliver_one(
@@ -64,6 +80,7 @@ async def notify_task(
                     task_payload=task_payload,
                     redact_payload=redact_payload,
                     form=form,
+                    handoff_exp_unix=handoff_exp_unix,
                 )
             except EmailTransportError as exc:
                 logger.error(
@@ -90,6 +107,7 @@ async def _deliver_one(
     task_payload: dict[str, Any] | None,
     redact_payload: bool,
     form: FormDefinition | None,
+    handoff_exp_unix: int | None = None,
 ) -> None:
     identity = await _resolve_identity(session, route.identity)
     transport = await _resolve_transport_for(identity)
@@ -122,6 +140,7 @@ async def _deliver_one(
         from_name=from_name,
         reply_to=reply_to,
         public_url=settings.PUBLIC_URL,
+        handoff_exp_unix=handoff_exp_unix,
     )
     result = await transport.send(message)
     logger.info(

--- a/packages/python/awaithumans/server/channels/email/renderer.py
+++ b/packages/python/awaithumans/server/channels/email/renderer.py
@@ -32,7 +32,49 @@ def _magic_link_url(public_url: str, token: str) -> str:
 
 
 def _review_url(public_url: str, task_id: str) -> str:
-    return f"{public_url.rstrip('/')}/tasks/{task_id}"
+    """Plain dashboard URL — used when no recipient handoff is available
+    (broadcast routes, email channel without a known recipient, etc.).
+
+    The dashboard's task detail page is `/task?id=<id>` — the
+    `/tasks/<id>` legacy form was removed when the dashboard switched
+    to a static-export build (dynamic segments don't survive
+    `output: "export"`). Slack's review URL was updated earlier; this
+    line is the email-side fix.
+    """
+    return f"{public_url.rstrip('/')}/task?id={task_id}"
+
+
+def _review_url_for_recipient(
+    *,
+    public_url: str,
+    task_id: str,
+    recipient: str,
+    handoff_exp_unix: int | None,
+) -> str:
+    """Dashboard URL signed for the recipient when an expiry is given,
+    plain URL otherwise.
+
+    The signed URL hits `/api/auth/email-handoff?to=...&t=...&e=...&s=...`
+    which mints a session for that email and redirects to /task. Lets
+    a recipient with no dashboard password through the login wall —
+    same DX the Slack channel has.
+    """
+    if handoff_exp_unix is None or not recipient:
+        return _review_url(public_url, task_id)
+
+    # Lazy import to avoid pulling the crypto path into modules that
+    # only need the renderer for tests / docs preview.
+    import urllib.parse
+
+    from awaithumans.server.core.email_handoff import sign_handoff
+
+    sig = sign_handoff(
+        recipient=recipient, task_id=task_id, exp_unix=handoff_exp_unix
+    )
+    qs = urllib.parse.urlencode(
+        {"to": recipient, "t": task_id, "e": handoff_exp_unix, "s": sig}
+    )
+    return f"{public_url.rstrip('/')}/api/auth/email-handoff?{qs}"
 
 
 def _find_single_input_primitive(form: FormDefinition) -> Any | None:
@@ -141,9 +183,24 @@ def build_notification_email(
     from_name: str | None,
     reply_to: str | None,
     public_url: str,
+    handoff_exp_unix: int | None = None,
 ) -> EmailMessage:
-    """Assemble the EmailMessage for one recipient."""
-    review_url = _review_url(public_url, task_id)
+    """Assemble the EmailMessage for one recipient.
+
+    `handoff_exp_unix` (when provided) signs the "Review in dashboard"
+    URL so the recipient lands authenticated even if they don't have
+    a dashboard password yet — the endpoint auto-provisions a
+    reviewer on first click. Pass `task.timeout_at` so the link
+    expires when the task does. None falls back to the unsigned
+    URL (existing behavior — recipients with no session bounce to
+    /login).
+    """
+    review_url = _review_url_for_recipient(
+        public_url=public_url,
+        task_id=task_id,
+        recipient=to,
+        handoff_exp_unix=handoff_exp_unix,
+    )
     buttons = _buttons_for_form(
         form, task_id=task_id, recipient=to, public_url=public_url
     )

--- a/packages/python/awaithumans/server/core/email_handoff.py
+++ b/packages/python/awaithumans/server/core/email_handoff.py
@@ -1,0 +1,128 @@
+"""Signed-URL handoff: email recipient → dashboard session.
+
+Mirror of `slack_handoff.py` for the email channel. Lets the
+"Review in dashboard" link in a notification email drop the
+recipient straight into the task page, authenticated, without
+requiring them to have a dashboard password.
+
+URL shape: `/api/auth/email-handoff?to=<email>&t=<task_id>&e=<exp>&s=<sig>`
+
+  - `to` is the recipient address the link was issued to. The
+    session is minted for the directory user with that email; if
+    no row exists, the endpoint auto-provisions a passwordless
+    reviewer (the agent's `notify=` already represents implicit
+    consent to provision — same trust boundary as task creation).
+  - `t` is the task_id the recipient was sent. We bind to it so a
+    leaked URL can't be reused to read other tasks.
+  - `e` is the Unix timestamp the URL stops being valid. Set to
+    `task.timeout_at` at sign time so the link works for the whole
+    task lifetime, just like the Slack handoff.
+  - `s` is HMAC-SHA256 over `to|t|e` with a key HKDF-derived from
+    PAYLOAD_KEY under an email-handoff salt — same root key never
+    signs two primitives.
+
+We deliberately don't enforce single-use here. The URL is delivered
+via email (recipient-only), the expiry caps the damage, and the
+session cookie that gets minted has its own short TTL. Adding a
+`consumed_token` row per click would block the legitimate "I closed
+the tab, click the link again" flow.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import logging
+import time
+
+from cryptography.hazmat.primitives.hashes import SHA256
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+from awaithumans.server.core.encryption import get_key
+from awaithumans.utils.constants import (
+    EMAIL_HANDOFF_HKDF_INFO,
+    EMAIL_HANDOFF_HKDF_SALT,
+    HMAC_SHA256_DIGEST_BYTES,
+)
+
+logger = logging.getLogger("awaithumans.server.core.email_handoff")
+
+
+class InvalidHandoffError(Exception):
+    """The signed URL failed format / HMAC / expiry validation."""
+
+
+def _hmac_key() -> bytes:
+    return HKDF(
+        algorithm=SHA256(),
+        length=HMAC_SHA256_DIGEST_BYTES,
+        salt=EMAIL_HANDOFF_HKDF_SALT,
+        info=EMAIL_HANDOFF_HKDF_INFO,
+    ).derive(get_key())
+
+
+def _canonical_message(recipient: str, task_id: str, exp: int) -> bytes:
+    """Stable byte-encoding for the signed payload.
+
+    Pipe-separator avoids JSON ambiguity for a 3-field tuple. Email
+    addresses can theoretically contain `|` (RFC 5321 quoted-string),
+    so we lowercase and reject the rare-but-possible bar character
+    at sign / verify boundaries — see `_normalize_recipient`.
+    """
+    return f"{recipient}|{task_id}|{exp}".encode()
+
+
+def _normalize_recipient(recipient: str) -> str:
+    """Lowercase + reject pipe-character to keep canonical-message
+    parsing unambiguous. Real-world senders never see `|` in a real
+    address; the few RFC corner cases that would are not worth
+    supporting in dev mode."""
+    if "|" in recipient:
+        raise InvalidHandoffError("recipient contains '|' — refused")
+    return recipient.lower()
+
+
+def sign_handoff(*, recipient: str, task_id: str, exp_unix: int) -> str:
+    """Produce the URL-safe signature for an email handoff URL.
+
+    Caller is responsible for assembling the full URL with the rest
+    of the params. `exp_unix` is typically `task.timeout_at` so the
+    link expires when the task does."""
+    normalized = _normalize_recipient(recipient)
+    mac = hmac.new(
+        _hmac_key(),
+        _canonical_message(normalized, task_id, exp_unix),
+        hashlib.sha256,
+    ).digest()
+    return base64.urlsafe_b64encode(mac).decode().rstrip("=")
+
+
+def verify_handoff(
+    *, recipient: str, task_id: str, exp_unix: int, signature: str
+) -> None:
+    """Validate the URL's signature + expiry. Raises on any failure."""
+    if not signature:
+        raise InvalidHandoffError("missing signature")
+
+    normalized = _normalize_recipient(recipient)
+
+    padded = signature + "=" * (-len(signature) % 4)
+    try:
+        mac = base64.urlsafe_b64decode(padded)
+    except Exception as exc:
+        raise InvalidHandoffError(f"signature not base64: {exc}") from exc
+
+    if len(mac) != HMAC_SHA256_DIGEST_BYTES:
+        raise InvalidHandoffError("signature wrong length")
+
+    expected = hmac.new(
+        _hmac_key(),
+        _canonical_message(normalized, task_id, exp_unix),
+        hashlib.sha256,
+    ).digest()
+    if not hmac.compare_digest(expected, mac):
+        raise InvalidHandoffError("signature mismatch")
+
+    if time.time() > exp_unix:
+        raise InvalidHandoffError("expired")

--- a/packages/python/awaithumans/server/routes/auth.py
+++ b/packages/python/awaithumans/server/routes/auth.py
@@ -24,6 +24,12 @@ from awaithumans.server.core.auth import (
     sign_session,
     verify_session,
 )
+from awaithumans.server.core.email_handoff import (
+    InvalidHandoffError as InvalidEmailHandoffError,
+)
+from awaithumans.server.core.email_handoff import (
+    verify_handoff as verify_email_handoff,
+)
 from awaithumans.server.core.slack_handoff import (
     InvalidHandoffError,
     verify_handoff,
@@ -37,7 +43,11 @@ from awaithumans.server.core.rate_limit import (
 )
 from awaithumans.server.db.connection import get_session
 from awaithumans.server.schemas.auth import LoginRequest, MeResponse
-from awaithumans.server.services.user_service import get_user, get_user_by_email
+from awaithumans.server.services.user_service import (
+    create_user,
+    get_user,
+    get_user_by_email,
+)
 from awaithumans.utils.constants import (
     DASHBOARD_SESSION_COOKIE_NAME,
     DASHBOARD_SESSION_MAX_AGE_SECONDS,
@@ -211,4 +221,91 @@ async def slack_handoff(
         path="/",
     )
     logger.info("Slack handoff: signed in user=%s for task=%s", user.id, t)
+    return response
+
+
+@router.get("/email-handoff")
+async def email_handoff(
+    request: Request,
+    to: str = Query(..., description="Recipient email the URL was issued to."),
+    t: str = Query(..., description="Task id the URL is bound to."),
+    e: int = Query(..., description="Unix expiry — usually task.timeout_at."),
+    s: str = Query(..., description="HMAC signature over (to|t|e)."),
+    session: AsyncSession = Depends(get_session),
+) -> Response:
+    """Sign in an email recipient and redirect to the task page.
+
+    Mirror of `/api/auth/slack-handoff` for the email channel. The
+    "Review in dashboard" link in a notification email points here so
+    the recipient can clear the dashboard login wall even when their
+    email isn't a registered reviewer yet.
+
+    Auto-provisioning: if no directory user has the recipient's email,
+    we create a passwordless reviewer on first click. Same trust
+    boundary as task creation — the agent's `notify=` already
+    expressed intent to delegate to that address. Operators can
+    deactivate or delete the row later if they don't want it.
+
+    The minted session is for that user exactly. The URL is not a
+    privilege escalator — auto-created users are reviewers, never
+    operators.
+    """
+    try:
+        verify_email_handoff(recipient=to, task_id=t, exp_unix=e, signature=s)
+    except InvalidEmailHandoffError as exc:
+        logger.info("Rejected email handoff: %s", exc)
+        raise HTTPException(
+            status_code=400,
+            detail="Sign-in link is invalid or expired. Open the latest "
+            "notification email for this task to get a fresh one.",
+        ) from exc
+
+    normalized_email = to.lower()
+    user = await get_user_by_email(session, normalized_email)
+
+    if user is None:
+        # Auto-provision a passwordless reviewer. The agent already
+        # vetted this address by passing it to `notify=`; we trust
+        # that boundary the same way we trust the agent's task
+        # creation.
+        user = await create_user(
+            session,
+            email=normalized_email,
+            display_name=None,
+            is_operator=False,
+            password=None,
+        )
+        logger.info(
+            "Email handoff: auto-provisioned reviewer for %s on task=%s",
+            normalized_email,
+            t,
+        )
+    elif not user.active:
+        # Don't auto-reactivate — the operator may have deliberately
+        # taken this user offline. Same response shape as the Slack
+        # handoff so attackers probing user state get a uniform 403.
+        logger.info(
+            "Email handoff rejected: user=%s inactive", normalized_email
+        )
+        raise HTTPException(
+            status_code=403,
+            detail="That reviewer is no longer active. Ask an operator "
+            "to re-add you to the directory.",
+        )
+
+    token = sign_session(user_id=user.id, is_operator=user.is_operator)
+    target = f"/task?id={t}"
+    response = RedirectResponse(url=target, status_code=303)
+    response.set_cookie(
+        key=DASHBOARD_SESSION_COOKIE_NAME,
+        value=token,
+        max_age=DASHBOARD_SESSION_MAX_AGE_SECONDS,
+        httponly=True,
+        secure=settings.PUBLIC_URL.startswith("https://"),
+        samesite="lax",
+        path="/",
+    )
+    logger.info(
+        "Email handoff: signed in user=%s for task=%s", user.id, t
+    )
     return response

--- a/packages/python/awaithumans/utils/constants.py
+++ b/packages/python/awaithumans/utils/constants.py
@@ -234,3 +234,12 @@ DASHBOARD_SESSION_HKDF_INFO = b"v1"
 # whole task lifetime, no matter how long that is.
 SLACK_HANDOFF_HKDF_SALT = b"awaithumans-slack-handoff"
 SLACK_HANDOFF_HKDF_INFO = b"v1"
+
+# HKDF parameters for the Email-handoff URL signature. Mirror of the
+# Slack-handoff but for the email channel — the link in a "Review in
+# dashboard" email is signed so the recipient can clear the dashboard
+# login wall even when their email isn't registered as a reviewer
+# yet. The endpoint auto-provisions a passwordless directory user on
+# first click (the agent's `notify=` is implicit consent to provision).
+EMAIL_HANDOFF_HKDF_SALT = b"awaithumans-email-handoff"
+EMAIL_HANDOFF_HKDF_INFO = b"v1"

--- a/packages/python/tests/auth/test_email_handoff_route.py
+++ b/packages/python/tests/auth/test_email_handoff_route.py
@@ -1,0 +1,245 @@
+"""End-to-end test for `/api/auth/email-handoff`.
+
+The renderer signs the "Review in dashboard" link in every notification
+email; the endpoint exchanges that signature for a session cookie. If
+the recipient isn't a directory user yet, it auto-provisions a
+passwordless reviewer (the agent's `notify=` is implicit consent).
+
+Tests run the real app + real DB so we catch wire-format and route-
+gating regressions, not just the signing layer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from awaithumans.server.app import create_app
+from awaithumans.server.core.email_handoff import sign_handoff
+from awaithumans.server.db.models import User
+from awaithumans.utils.constants import DASHBOARD_SESSION_COOKIE_NAME
+
+
+@pytest.fixture
+def client(operator_user: User) -> Iterator[TestClient]:
+    """Fresh app + DB. `follow_redirects=False` so we can inspect 303s."""
+    app = create_app(serve_dashboard=False)
+    with TestClient(app, follow_redirects=False) as c:
+        yield c
+
+
+def _far_future() -> int:
+    return int(time.time()) + 3600
+
+
+# ─── Happy path — known user ─────────────────────────────────────────
+
+
+def test_valid_signature_for_existing_user_signs_in(
+    client: TestClient, operator_user: User
+) -> None:
+    task_id = "task_existing_user"
+    exp = _far_future()
+    sig = sign_handoff(
+        recipient=operator_user.email, task_id=task_id, exp_unix=exp
+    )
+
+    resp = client.get(
+        "/api/auth/email-handoff",
+        params={"to": operator_user.email, "t": task_id, "e": exp, "s": sig},
+    )
+
+    assert resp.status_code == 303
+    assert resp.headers["location"] == f"/task?id={task_id}"
+    assert DASHBOARD_SESSION_COOKIE_NAME in resp.cookies
+
+    # The minted session is valid for /me.
+    me = client.get("/api/auth/me")
+    assert me.status_code == 200
+    assert me.json()["user_id"] == operator_user.id
+
+
+# ─── Happy path — auto-provision unknown user ────────────────────────
+
+
+def test_unknown_email_is_auto_provisioned_as_reviewer(
+    client: TestClient, operator_user: User
+) -> None:
+    """The agent's `notify=` is implicit consent to provision. First
+    click from an unknown address creates a passwordless reviewer
+    and signs them in. They show up in the directory afterward."""
+    new_email = "fresh-reviewer@example.com"
+    task_id = "task_provision"
+    exp = _far_future()
+    sig = sign_handoff(recipient=new_email, task_id=task_id, exp_unix=exp)
+
+    # Confirm the user doesn't exist yet.
+    from awaithumans.server.db.connection import get_async_session_factory
+
+    async def _exists(email: str) -> bool:
+        factory = get_async_session_factory()
+        async with factory() as session:
+            result = await session.execute(
+                select(User).where(User.email == email)
+            )
+            return result.scalar_one_or_none() is not None
+
+    assert (
+        asyncio.new_event_loop().run_until_complete(_exists(new_email))
+        is False
+    )
+
+    resp = client.get(
+        "/api/auth/email-handoff",
+        params={"to": new_email, "t": task_id, "e": exp, "s": sig},
+    )
+
+    assert resp.status_code == 303
+    assert DASHBOARD_SESSION_COOKIE_NAME in resp.cookies
+
+    # User now exists, is active, is NOT an operator (auto-provisioned
+    # users get reviewer-only privileges), has no password.
+    async def _fetch(email: str) -> User | None:
+        factory = get_async_session_factory()
+        async with factory() as session:
+            result = await session.execute(
+                select(User).where(User.email == email)
+            )
+            return result.scalar_one_or_none()
+
+    user = asyncio.new_event_loop().run_until_complete(_fetch(new_email))
+    assert user is not None
+    assert user.active is True
+    assert user.is_operator is False
+    assert user.password_hash is None
+
+
+def test_handoff_uses_existing_user_on_repeat_clicks(
+    client: TestClient,
+) -> None:
+    """First click provisions; second click finds the user and signs
+    them in without duplicate inserts (which would 500 on the unique
+    email constraint)."""
+    new_email = "repeat-clicker@example.com"
+    task_id = "task_repeat"
+    exp = _far_future()
+    sig = sign_handoff(recipient=new_email, task_id=task_id, exp_unix=exp)
+
+    a = client.get(
+        "/api/auth/email-handoff",
+        params={"to": new_email, "t": task_id, "e": exp, "s": sig},
+    )
+    assert a.status_code == 303
+
+    # Drop the cookie so the second call goes through the same
+    # provision-or-lookup branch, not "already-signed-in".
+    client.cookies.clear()
+
+    b = client.get(
+        "/api/auth/email-handoff",
+        params={"to": new_email, "t": task_id, "e": exp, "s": sig},
+    )
+    assert b.status_code == 303
+    assert DASHBOARD_SESSION_COOKIE_NAME in b.cookies
+
+
+# ─── Reject paths ────────────────────────────────────────────────────
+
+
+def test_bad_signature_rejected(client: TestClient) -> None:
+    task_id = "task_bad_sig"
+    exp = _far_future()
+    sig = sign_handoff(
+        recipient="someone-else@example.com",
+        task_id=task_id,
+        exp_unix=exp,
+    )
+
+    resp = client.get(
+        "/api/auth/email-handoff",
+        params={
+            "to": "victim@example.com",
+            "t": task_id,
+            "e": exp,
+            "s": sig,
+        },
+    )
+    assert resp.status_code == 400
+    assert DASHBOARD_SESSION_COOKIE_NAME not in resp.cookies
+
+
+def test_expired_link_rejected(client: TestClient) -> None:
+    task_id = "task_expired"
+    expired = int(time.time()) - 1
+    sig = sign_handoff(
+        recipient="alice@example.com",
+        task_id=task_id,
+        exp_unix=expired,
+    )
+
+    resp = client.get(
+        "/api/auth/email-handoff",
+        params={
+            "to": "alice@example.com",
+            "t": task_id,
+            "e": expired,
+            "s": sig,
+        },
+    )
+    assert resp.status_code == 400
+
+
+def test_inactive_existing_user_rejected(client: TestClient) -> None:
+    """An operator may have deliberately deactivated a reviewer.
+    The handoff doesn't auto-reactivate — same behavior as the
+    Slack handoff (#46)."""
+    from awaithumans.server.db.connection import get_async_session_factory
+    from awaithumans.server.services.user_service import (
+        create_user,
+        update_user,
+    )
+
+    email = "deactivated@example.com"
+
+    async def _seed_inactive() -> None:
+        factory = get_async_session_factory()
+        async with factory() as session:
+            user = await create_user(
+                session,
+                email=email,
+                display_name=None,
+                is_operator=False,
+                password=None,
+            )
+            await update_user(session, user_id=user.id, active=False)
+
+    asyncio.new_event_loop().run_until_complete(_seed_inactive())
+
+    task_id = "task_inactive"
+    exp = _far_future()
+    sig = sign_handoff(recipient=email, task_id=task_id, exp_unix=exp)
+
+    resp = client.get(
+        "/api/auth/email-handoff",
+        params={"to": email, "t": task_id, "e": exp, "s": sig},
+    )
+    assert resp.status_code == 403
+
+
+def test_missing_signature_rejected(client: TestClient) -> None:
+    """No `s` param → FastAPI's required-query-param validation 422s
+    before we touch the verifier."""
+    resp = client.get(
+        "/api/auth/email-handoff",
+        params={
+            "to": "alice@example.com",
+            "t": "task_x",
+            "e": _far_future(),
+        },
+    )
+    assert resp.status_code == 422

--- a/packages/python/tests/auth/test_email_handoff_signing.py
+++ b/packages/python/tests/auth/test_email_handoff_signing.py
@@ -1,0 +1,147 @@
+"""Email-handoff URL signing — proof-of-identity for email recipients.
+
+Mirror of `test_slack_handoff_signing.py`. The "Review in dashboard"
+link in a notification email is HMAC-signed by the renderer; the
+endpoint verifies and exchanges it for a session cookie. These
+tests pin the signing layer end-to-end without spinning up the
+HTTP server.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from awaithumans.server.core.email_handoff import (
+    InvalidHandoffError,
+    sign_handoff,
+    verify_handoff,
+)
+
+
+RECIPIENT = "alice@acme.com"
+TASK = "task_" + "b" * 27
+
+
+def _far_future() -> int:
+    return int(time.time()) + 3600
+
+
+# ─── Happy path ──────────────────────────────────────────────────────
+
+
+def test_roundtrip_accepts_valid_signature() -> None:
+    exp = _far_future()
+    sig = sign_handoff(recipient=RECIPIENT, task_id=TASK, exp_unix=exp)
+    verify_handoff(
+        recipient=RECIPIENT, task_id=TASK, exp_unix=exp, signature=sig
+    )
+
+
+def test_signature_is_deterministic() -> None:
+    exp = _far_future()
+    a = sign_handoff(recipient=RECIPIENT, task_id=TASK, exp_unix=exp)
+    b = sign_handoff(recipient=RECIPIENT, task_id=TASK, exp_unix=exp)
+    assert a == b
+
+
+def test_signature_is_case_insensitive_on_recipient() -> None:
+    """Real-world senders and recipients sometimes case-flip — the
+    same address has a stable signature regardless of casing so a
+    re-rendered email doesn't break inbox links."""
+    exp = _far_future()
+    a = sign_handoff(recipient="Alice@Acme.com", task_id=TASK, exp_unix=exp)
+    b = sign_handoff(recipient="alice@acme.com", task_id=TASK, exp_unix=exp)
+    assert a == b
+    # And verification accepts either form.
+    verify_handoff(
+        recipient="ALICE@ACME.COM", task_id=TASK, exp_unix=exp, signature=a
+    )
+
+
+def test_signature_changes_when_any_field_changes() -> None:
+    exp = _far_future()
+    base = sign_handoff(recipient=RECIPIENT, task_id=TASK, exp_unix=exp)
+    assert (
+        sign_handoff(recipient="other@acme.com", task_id=TASK, exp_unix=exp)
+        != base
+    )
+    assert (
+        sign_handoff(recipient=RECIPIENT, task_id="other", exp_unix=exp) != base
+    )
+    assert (
+        sign_handoff(recipient=RECIPIENT, task_id=TASK, exp_unix=exp + 1)
+        != base
+    )
+
+
+# ─── Tamper / replay ─────────────────────────────────────────────────
+
+
+def test_wrong_recipient_rejected() -> None:
+    exp = _far_future()
+    sig = sign_handoff(recipient=RECIPIENT, task_id=TASK, exp_unix=exp)
+    with pytest.raises(InvalidHandoffError, match="signature mismatch"):
+        verify_handoff(
+            recipient="someone-else@acme.com",
+            task_id=TASK,
+            exp_unix=exp,
+            signature=sig,
+        )
+
+
+def test_wrong_task_rejected() -> None:
+    exp = _far_future()
+    sig = sign_handoff(recipient=RECIPIENT, task_id=TASK, exp_unix=exp)
+    with pytest.raises(InvalidHandoffError, match="signature mismatch"):
+        verify_handoff(
+            recipient=RECIPIENT,
+            task_id="other_task",
+            exp_unix=exp,
+            signature=sig,
+        )
+
+
+def test_expiry_in_the_past_rejected() -> None:
+    expired = int(time.time()) - 1
+    sig = sign_handoff(recipient=RECIPIENT, task_id=TASK, exp_unix=expired)
+    with pytest.raises(InvalidHandoffError, match="expired"):
+        verify_handoff(
+            recipient=RECIPIENT,
+            task_id=TASK,
+            exp_unix=expired,
+            signature=sig,
+        )
+
+
+def test_pipe_in_recipient_rejected() -> None:
+    """Canonical message uses pipe separators; any `|` in the recipient
+    would break parsing. Real addresses never contain `|`; the few
+    RFC corner cases that would are not worth the complexity."""
+    with pytest.raises(InvalidHandoffError, match="contains '\\|'"):
+        sign_handoff(
+            recipient="alice|odd@acme.com",
+            task_id=TASK,
+            exp_unix=_far_future(),
+        )
+
+
+def test_garbage_signature_rejected() -> None:
+    with pytest.raises(InvalidHandoffError):
+        verify_handoff(
+            recipient=RECIPIENT,
+            task_id=TASK,
+            exp_unix=_far_future(),
+            signature="!!",
+        )
+
+
+def test_empty_signature_rejected() -> None:
+    with pytest.raises(InvalidHandoffError, match="missing signature"):
+        verify_handoff(
+            recipient=RECIPIENT,
+            task_id=TASK,
+            exp_unix=_far_future(),
+            signature="",
+        )

--- a/packages/python/tests/email/test_renderer.py
+++ b/packages/python/tests/email/test_renderer.py
@@ -79,7 +79,7 @@ def test_single_select_over_4_falls_back_to_link_out() -> None:
     )
     msg = _build(form)
     assert "/api/channels/email/action/" not in msg.html
-    assert "/tasks/t-abc" in msg.html  # link-out URL
+    assert "/task?id=t-abc" in msg.html  # link-out URL
 
 
 # ─── Forms that can't use magic links ───────────────────────────────────
@@ -89,7 +89,7 @@ def test_long_text_only_form_is_link_out() -> None:
     form = FormDefinition(fields=[_name(long_text(label="Why?"), "why")])
     msg = _build(form)
     assert "/api/channels/email/action/" not in msg.html
-    assert "/tasks/t-abc" in msg.html
+    assert "/task?id=t-abc" in msg.html
 
 
 def test_multi_input_form_is_link_out() -> None:
@@ -104,7 +104,7 @@ def test_multi_input_form_is_link_out() -> None:
     )
     msg = _build(form)
     assert "/api/channels/email/action/" not in msg.html
-    assert "/tasks/t-abc" in msg.html
+    assert "/task?id=t-abc" in msg.html
 
 
 def test_display_text_doesnt_count_as_input() -> None:


### PR DESCRIPTION
## Symptom

Email arrived for a multi-field response (so the renderer picked the dashboard link-out instead of inline buttons). Clicked "Open the full task in the dashboard" — got "Task not found", because the recipient's email address isn't a registered dashboard user.

## Two real bugs underneath

1. **Wrong URL pattern.** Renderer built `/tasks/{id}` — the legacy route. The dashboard moved to `/task?id={id}` (static-export-compatible) when we shipped the bundled-wheel build. Slack's notifier got fixed in that pass; email's didn't. Anyone clicking the email link-out hit a 404.
2. **No auth handoff for email recipients.** Slack has `/api/auth/slack-handoff` so Slack-only users clear the login wall. Email had no equivalent — recipients whose address wasn't a directory user bounced to /login with no way through.

This PR fixes both.

## What's in here

- **`/api/auth/email-handoff?to=...&t=...&e=...&s=...`** — new endpoint mirroring `slack-handoff`. Verifies HMAC over `(to|t|e)`, mints a session, redirects to `/task?id=...`. TTL bound to `task.timeout_at`.
- **Auto-provisioning unknown emails.** First click from an address that isn't in the directory creates a passwordless reviewer. The agent's `notify=` is implicit consent to provision — same trust boundary as task creation. Auto-provisioned users are reviewers (never operators). Inactive existing users still get rejected.
- **`core/email_handoff.py`** — sign / verify under a new `email-handoff` HKDF salt (per-primitive key separation). Recipient is normalized lowercase so casing doesn't break inbox links.
- **Renderer** — `_review_url_for_recipient` builds the signed handoff URL when `task.timeout_at` is known, falls back to the plain URL otherwise.
- **Notifier** — pulls the task once for `timeout_at` (mirrors the Slack notifier pattern), threads it through to the renderer.
- **Fix `/tasks/{id}` → `/task?id={id}`** in `_review_url`.

## Tests

| File | Cases | What it pins |
|---|---|---|
| `tests/auth/test_email_handoff_signing.py` | 10 | sign/verify, case-insensitive recipient, tampered fields, expiry, pipe rejection, malformed inputs |
| `tests/auth/test_email_handoff_route.py` | 7 | existing user signs in, unknown email auto-provisions, repeat clicks reuse, bad sig 400, expired 400, inactive 403, missing sig 422 |
| `tests/email/test_renderer.py` | 3 (updated) | URL assertion now `/task?id=...` not `/tasks/...` |

`477 → 494 passing` (+17). 76 email tests still green.

## Backward compat

- Tokens minted before this PR don't carry the recipient handoff URL. Old emails still work, recipients just bounce to /login if they're not authed. New emails get the full handoff.
- Auto-provisioned users land on the same dashboard surface as operator-created reviewers. No migration needed.
- Pre-feature in-flight magic-link tokens still verify cleanly (recipient field is opt-in via #52).

## Verified

User's exact failure (multi-field response → "no task found") now works:

1. Email arrives with "Review in dashboard" link → points at `/api/auth/email-handoff?to=...`
2. Click → server verifies, auto-provisions reviewer, redirects to `/task?id=...` with session cookie
3. Dashboard loads task, shows form (Yes/No + reason)
4. Submit → Python SDK's `await_human` resolves with both fields

## Related

- #46 — Slack handoff, the model this PR mirrors
- #52 — magic-link recipient attribution (the per-token `r` field)
- #41 — Slack-only completer display in audit log

The two channels now have full parity DX: agent runs `notify=`, recipient clicks an inbox link, lands authenticated, completes the task. No env-var dance, no operator pre-provisioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)