### PR TITLE
Expandable timeline entries with verifier feedback

### DIFF
--- a/packages/dashboard/app/(dashboard)/task/page.tsx
+++ b/packages/dashboard/app/(dashboard)/task/page.tsx
@@ -2,6 +2,7 @@
 
 import { Suspense, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { ChevronDown } from "lucide-react";
 import {
 	fetchTask,
 	fetchAuditTrail,
@@ -58,6 +59,18 @@ function TaskDetailPageInner() {
 	const [error, setError] = useState<string | null>(null);
 	const [submitting, setSubmitting] = useState(false);
 	const [formData, setFormData] = useState<FormValue>({});
+	const [expandedAuditIds, setExpandedAuditIds] = useState<Set<string>>(
+		new Set(),
+	);
+
+	const toggleAuditEntry = (id: string) => {
+		setExpandedAuditIds((prev) => {
+			const next = new Set(prev);
+			if (next.has(id)) next.delete(id);
+			else next.add(id);
+			return next;
+		});
+	};
 
 	useEffect(() => {
 		loadTask();
@@ -339,36 +352,13 @@ function TaskDetailPageInner() {
 					) : (
 						<div className="space-y-4">
 							{audit.map((entry, i) => (
-								<div key={entry.id} className="relative">
-									{i < audit.length - 1 && (
-										<div className="absolute left-[7px] top-5 bottom-0 w-px bg-white/10" />
-									)}
-									<div className="flex items-start gap-3">
-										<div
-											className={cn(
-												"w-[15px] h-[15px] rounded-full border-2 mt-0.5 flex-shrink-0",
-												entry.to_status === "completed"
-													? "bg-brand/20 border-brand"
-													: entry.to_status === "timed_out" ||
-														  entry.to_status === "cancelled"
-														? "bg-red-400/20 border-red-400"
-														: "bg-white/10 border-white/30",
-											)}
-										/>
-										<div>
-											<div className="text-sm font-medium">{entry.action}</div>
-											<div className="text-white/30 text-xs mt-0.5">
-												{entry.actor_type === "human" && entry.actor_email
-													? entry.actor_email
-													: entry.actor_type}
-												{entry.channel && ` via ${entry.channel}`}
-											</div>
-											<div className="text-white/20 text-xs mt-0.5">
-												{formatRelativeTime(entry.created_at)}
-											</div>
-										</div>
-									</div>
-								</div>
+								<TimelineEntry
+									key={entry.id}
+									entry={entry}
+									isLast={i === audit.length - 1}
+									expanded={expandedAuditIds.has(entry.id)}
+									onToggle={() => toggleAuditEntry(entry.id)}
+								/>
 							))}
 						</div>
 					)}
@@ -401,6 +391,161 @@ function TaskDetailPageInner() {
 					</div>
 				</div>
 			</div>
+		</div>
+	);
+}
+
+// ─── Timeline entry ──────────────────────────────────────────────────
+
+function TimelineEntry({
+	entry,
+	isLast,
+	expanded,
+	onToggle,
+}: {
+	entry: AuditEntry;
+	isLast: boolean;
+	expanded: boolean;
+	onToggle: () => void;
+}) {
+	const hasDetails = entry.extra_data != null;
+	const dotClass =
+		entry.to_status === "completed"
+			? "bg-brand/20 border-brand"
+			: entry.to_status === "timed_out" ||
+				  entry.to_status === "cancelled" ||
+				  entry.to_status === "verification_exhausted"
+				? "bg-red-400/20 border-red-400"
+				: entry.to_status === "rejected"
+					? "bg-amber-400/20 border-amber-400"
+					: "bg-white/10 border-white/30";
+
+	return (
+		<div className="relative">
+			{!isLast && (
+				<div className="absolute left-[7px] top-5 bottom-0 w-px bg-white/10" />
+			)}
+			<div className="flex items-start gap-3">
+				<div
+					className={cn(
+						"w-[15px] h-[15px] rounded-full border-2 mt-0.5 flex-shrink-0",
+						dotClass,
+					)}
+				/>
+				<div className="flex-1 min-w-0">
+					{hasDetails ? (
+						<button
+							type="button"
+							onClick={onToggle}
+							className="flex items-center gap-1.5 text-left group"
+							aria-expanded={expanded}
+						>
+							<span className="text-sm font-medium">{entry.action}</span>
+							<ChevronDown
+								className={cn(
+									"w-3.5 h-3.5 text-white/30 transition-transform group-hover:text-white/60",
+									expanded && "rotate-180",
+								)}
+							/>
+						</button>
+					) : (
+						<div className="text-sm font-medium">{entry.action}</div>
+					)}
+					<div className="text-white/30 text-xs mt-0.5">
+						{entry.actor_type === "human" && entry.actor_email
+							? entry.actor_email
+							: entry.actor_type}
+						{entry.channel && ` via ${entry.channel}`}
+					</div>
+					<div className="text-white/20 text-xs mt-0.5">
+						{formatRelativeTime(entry.created_at)}
+					</div>
+					{expanded && hasDetails && (
+						<TimelineEntryDetails entry={entry} />
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function TimelineEntryDetails({ entry }: { entry: AuditEntry }) {
+	const data = entry.extra_data ?? {};
+	const verifierReason =
+		typeof data.verifier_reason === "string" ? data.verifier_reason : null;
+	const verificationAttempt =
+		typeof data.verification_attempt === "number"
+			? data.verification_attempt
+			: null;
+	const responseKeys = Array.isArray(data.response_keys)
+		? (data.response_keys as unknown[]).filter(
+				(k): k is string => typeof k === "string",
+			)
+		: null;
+
+	// Verifier-specific keys get dedicated UI; everything else in
+	// extra_data falls through to the generic key-value list below.
+	const VERIFIER_KEYS = new Set([
+		"verifier_reason",
+		"verification_attempt",
+		"verifier_passed",
+		"response_keys",
+	]);
+	const otherEntries = Object.entries(data).filter(
+		([k]) => !VERIFIER_KEYS.has(k),
+	);
+
+	const showVerifierBlock =
+		verifierReason !== null || verificationAttempt !== null;
+
+	return (
+		<div className="mt-3 space-y-3 text-xs">
+			{showVerifierBlock && (
+				<div className="rounded border border-amber-400/20 bg-amber-400/5 p-3 space-y-2">
+					<div className="text-amber-400/80 font-medium">
+						Verifier feedback
+						{verificationAttempt !== null && (
+							<span className="text-amber-400/50 font-normal">
+								{" "}
+								— attempt {verificationAttempt}
+							</span>
+						)}
+					</div>
+					{verifierReason && (
+						<div className="text-white/70 whitespace-pre-wrap break-words">
+							{verifierReason}
+						</div>
+					)}
+					{responseKeys && responseKeys.length > 0 && (
+						<div className="text-white/30">
+							Submitted fields:{" "}
+							<span className="font-mono text-white/50">
+								{responseKeys.join(", ")}
+							</span>
+						</div>
+					)}
+				</div>
+			)}
+			{!showVerifierBlock && responseKeys && responseKeys.length > 0 && (
+				<div className="rounded border border-white/10 p-3 text-white/30">
+					Submitted fields:{" "}
+					<span className="font-mono text-white/50">
+						{responseKeys.join(", ")}
+					</span>
+				</div>
+			)}
+			{otherEntries.length > 0 && (
+				<dl className="rounded border border-white/10 p-3 space-y-1.5">
+					{otherEntries.map(([k, v]) => (
+						<div key={k} className="flex gap-2">
+							<dt className="text-white/40 font-mono">{k}:</dt>
+							<dd className="text-white/70 font-mono break-all">
+								{typeof v === "string" ? v : JSON.stringify(v)}
+							</dd>
+						</div>
+					))}
+				</dl>
+			)}
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

Click-to-expand audit entries on the task detail timeline. The audit data already exposes `extra_data` over the API; the timeline component just never rendered it. Surfaced when manually walking the verifier examples in #53 — a rejection shows up as a dot on the timeline but the operator can't see *why* the verifier rejected without going to the raw audit log.

## What this changes

- Any audit entry with non-null `extra_data` becomes a `<button>` toggle (chevron + keyboard-accessible). Entries without `extra_data` render exactly as before.
- For `rejected` entries (verifier rejections), the expanded panel renders an amber-tinted block with:
  - **Verifier feedback** — the LLM's rejection reason verbatim
  - **Attempt number** — e.g. *attempt 1*
  - **Submitted fields** — the keys of the response that was rejected
- For other entries with `extra_data` (e.g. `timed_out` carries `timeout_seconds`), a generic key-value list renders.
- New amber dot color for `rejected` so it's distinguishable from terminal failures (`timed_out`, `cancelled`, `verification_exhausted`) which stay red.

## What this does *not* change

The actual rejected response *values* (what the human typed in each form field) are still not preserved. The audit log only stores `response_keys` — that's a deliberate PII / log-bloat trade-off in `task_service.py`. Preserving values would need either a new table or a flag opt-in gated on `redact_payload=false`. Out of scope here.

## How to verify

1. Need PR #53 merged, or run from a branch that has the verifier examples + SDK fix.
2. `awaithumans dev` with `ANTHROPIC_API_KEY` set.
3. From `examples/verifier-py/`, run `python refund.py`.
4. In the dashboard, submit `approved=true, reason="ok"` — verifier rejects.
5. Resubmit with a good reason — verifier passes.
6. On the completed task page, the timeline now shows the `rejected` entry with a chevron. Click it: the LLM's rejection text is visible inline, with the attempt number and the keys of the rejected response.

## Test plan

- [x] `npx tsc --noEmit` in `packages/dashboard` — clean
- [x] `npx biome check` on the changed file — clean
- [ ] Manual: walk the rejection path against `awaithumans dev` and confirm the verifier reason shows on click
- [ ] Manual: confirm a `timed_out` entry expands to show `timeout_seconds`
- [ ] Manual: confirm an entry with no `extra_data` (e.g. `created`) still renders without a chevron and is not clickable
- [ ] Keyboard: tab onto a clickable entry and press Enter — should toggle (button is keyboard-accessible)

## Related

- Builds on #53 (verifier examples + TS SDK camelCase wire fix). Independent — both PRs touch separate files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)