### PR TITLE
feat(email): always render an "Open task" button — no more tiny hyper…

### DIFF
--- a/packages/python/awaithumans/server/channels/email/templates/html/notification.html
+++ b/packages/python/awaithumans/server/channels/email/templates/html/notification.html
@@ -19,7 +19,6 @@
         $payload_html
         $buttons_section
         <p style="margin:20px 0 0;color:$text_muted;font-size:12px;line-height:1.5;">
-          Or <a href="$review_url" style="color:$text_link;">open the full task in the dashboard</a>.
           You're receiving this because your team asked awaithumans to send review requests here.
         </p>
       </td>

--- a/packages/python/awaithumans/server/channels/email/templates/html/notification.txt
+++ b/packages/python/awaithumans/server/channels/email/templates/html/notification.txt
@@ -4,4 +4,4 @@ $task_title
 
 $payload_block
 $buttons_block
-Or open the dashboard: $review_url
+Open task: $review_url

--- a/packages/python/awaithumans/server/channels/email/templates/renderers.py
+++ b/packages/python/awaithumans/server/channels/email/templates/renderers.py
@@ -43,12 +43,28 @@ def notification_html(
     buttons: list[ButtonSpec],
     review_url: str,
 ) -> str:
-    """The primary email: task title, payload preview, buttons, link-out footer."""
+    """The primary email: task title, payload preview, buttons.
+
+    The buttons row always carries an "Open task" CTA pointing at the
+    dashboard. When the form has magic-link shortcuts (single Switch /
+    small SingleSelect → Approve / Reject style buttons), they render
+    first and "Open task" rides alongside as an alternative path. When
+    the form has no shortcuts (multi-field response, file upload,
+    etc.), "Open task" is the only call to action — clearer than the
+    tiny inline hyperlink the previous template used.
+    """
     payload_html = _render_payload_html(payload_lines, redacted)
-    buttons_inner = "".join(render_button(b) for b in buttons)
-    buttons_section = (
-        f'<div style="margin:24px 0;">{buttons_inner}</div>' if buttons else ""
+    # `neutral` style for "Open task" when there's already a primary
+    # action button (Approve/Reject) — don't compete for the eye.
+    # `primary` when it's the only call to action so the brand color
+    # makes it the obvious next step.
+    open_button_style = "neutral" if buttons else "primary"
+    open_task_button = ButtonSpec(
+        label="Open task", url=review_url, style=open_button_style
     )
+    all_buttons = [*buttons, open_task_button]
+    buttons_inner = "".join(render_button(b) for b in all_buttons)
+    buttons_section = f'<div style="margin:24px 0;">{buttons_inner}</div>'
 
     return _load("notification.html").substitute(
         task_title=escape(task_title),

--- a/packages/python/tests/email/test_renderer.py
+++ b/packages/python/tests/email/test_renderer.py
@@ -124,6 +124,64 @@ def test_no_form_is_link_out() -> None:
     assert "/api/channels/email/action/" not in msg.html
 
 
+# ─── "Open task" button presence ────────────────────────────────────────
+
+
+def test_open_task_button_always_renders() -> None:
+    """The Open-task button is the always-present CTA — whether the
+    form has magic-link shortcuts (Approve/Reject) or not. Pinning
+    the label so a renderer refactor doesn't silently regress to the
+    old tiny inline hyperlink."""
+    # No form → only the Open task CTA.
+    msg_link_out = _build(None)
+    assert "Open task" in msg_link_out.html
+    assert "/task?id=t-abc" in msg_link_out.html
+
+    # Single Switch → magic-link buttons AND Open task alongside.
+    form = FormDefinition(fields=[_name(switch(label="OK?"), "ok")])
+    msg_buttons = _build(form)
+    assert "Open task" in msg_buttons.html
+    # Approve + Reject + Open task = 3 buttons.
+    assert msg_buttons.html.count("display:inline-block") == 3
+
+
+def test_open_task_button_styled_primary_when_alone() -> None:
+    """When there's no Approve/Reject competing for the eye, the
+    Open-task button gets the brand color so it's the obvious CTA.
+    With magic-link buttons present it's neutral so it doesn't
+    out-shout the primary action."""
+    from awaithumans.server.channels.email.templates.palette import (
+        DARK_PALETTE,
+    )
+
+    brand = DARK_PALETTE["bg_primary"]
+
+    # Link-out only — Open task is primary (brand background).
+    msg_link_out = _build(None)
+    assert brand in msg_link_out.html
+
+    # Approve/Reject present — Open task uses neutral, Approve uses
+    # primary (brand). Brand still appears (because Approve), but
+    # the Open task line specifically should NOT use it.
+    form = FormDefinition(fields=[_name(switch(label="OK?"), "ok")])
+    msg_buttons = _build(form)
+    # Locate the Open-task <a> by searching for the label.
+    open_anchor_start = msg_buttons.html.index("Open task")
+    open_anchor_chunk = msg_buttons.html[
+        open_anchor_start - 200 : open_anchor_start
+    ]
+    assert brand not in open_anchor_chunk
+
+
+def test_open_task_url_in_plain_text_body() -> None:
+    """Plain-text alternate (deliverability + accessibility) must
+    surface the Open-task URL so screen readers and text-only clients
+    have the same affordance the HTML buttons give."""
+    msg = _build(None)
+    assert "Open task:" in msg.text
+    assert "/task?id=t-abc" in msg.text
+
+
 # ─── Payload rendering ──────────────────────────────────────────────────
 
 


### PR DESCRIPTION
…link

The notification email had two ways to reach the dashboard:

  1. Magic-link buttons (Approve / Reject) — only present for single-Switch / small-SingleSelect responses
  2. Tiny inline hyperlink in the footer text: "Or open the full task in the dashboard"

For multi-field forms (the dashboard-only path), only #2 was present. That hyperlink got buried in the gray footer and was easy to miss — operators reported clicking through the email and not seeing a clear next step.

This change always renders an "Open task" button (using the existing `render_button` helper, same inline-styled <a> the magic-link buttons use):

  - **No form** / **multi-field** / **link-out fallback** → "Open task" is the only button, styled `primary` (brand color) so it's the obvious CTA
  - **Single Switch** / **small SingleSelect** → "Open task" appears alongside Approve/Reject, styled `neutral` so it doesn't out-shout the primary action

The footer text is now just "You're receiving this because…" — the link-out moved up into the buttons row.

Plain-text alternate (deliverability + accessibility) gets the same treatment: `Open task: <url>` instead of "Or open the dashboard: <url>".

## Tests

  - 3 new cases in `test_renderer.py`: - "Open task" always renders, both with and without magic-link buttons (3-button layout when paired) - styled `primary` when alone, `neutral` when paired (asserted by checking the brand color near the anchor) - URL is in the plain-text body too
  - 76 → 79 email tests passing

497 total passing (was 494; +3).