### PR TITLE
fix(email): claim task for recipient on first handoff click + email implicit assignee

### DIFF
--- a/packages/python/awaithumans/server/routes/auth.py
+++ b/packages/python/awaithumans/server/routes/auth.py
@@ -293,6 +293,18 @@ async def email_handoff(
             "to re-add you to the directory.",
         )
 
+    # Claim the task for the recipient when nobody owns it yet.
+    # Without this, the auto-provisioned reviewer would land on the
+    # dashboard and immediately see "Couldn't load task" — they're
+    # signed in but `require_task_read` denies them because they're
+    # neither operator nor assignee. The handoff URL is itself proof
+    # they had access to the email; promoting them to assignee on
+    # first click is the same intent shape the Slack DM flow
+    # encodes via the implicit-assignee derivation at create time.
+    await _claim_task_for_recipient_if_unassigned(
+        session, task_id=t, user_id=user.id, user_email=normalized_email
+    )
+
     token = sign_session(user_id=user.id, is_operator=user.is_operator)
     target = f"/task?id={t}"
     response = RedirectResponse(url=target, status_code=303)
@@ -309,3 +321,41 @@ async def email_handoff(
         "Email handoff: signed in user=%s for task=%s", user.id, t
     )
     return response
+
+
+async def _claim_task_for_recipient_if_unassigned(
+    session: AsyncSession,
+    *,
+    task_id: str,
+    user_id: str,
+    user_email: str,
+) -> None:
+    """First-writer-wins update — sets `assigned_to_user_id` only when
+    the row is currently null. Two recipients clicking simultaneously
+    is exceedingly rare for email (typical notify list is one address)
+    but we still race-safe via the WHERE clause.
+
+    Best-effort: if the task was deleted, terminal, or already assigned
+    we no-op. The handoff still mints the session — operators who want
+    to read other people's tasks are operators, not auto-provisioned
+    reviewers.
+    """
+    from sqlalchemy import update
+
+    from awaithumans.server.db.models import Task
+    from awaithumans.utils.constants import TERMINAL_STATUSES_SET
+
+    result = await session.execute(
+        update(Task)
+        .where(Task.id == task_id)
+        .where(Task.assigned_to_user_id.is_(None))
+        .where(Task.status.notin_(list(TERMINAL_STATUSES_SET)))
+        .values(assigned_to_user_id=user_id, assigned_to_email=user_email)
+    )
+    if result.rowcount > 0:
+        await session.commit()
+        logger.info(
+            "Email handoff: claimed task=%s for user=%s",
+            task_id,
+            user_id,
+        )

--- a/packages/python/awaithumans/server/services/task_router.py
+++ b/packages/python/awaithumans/server/services/task_router.py
@@ -222,7 +222,21 @@ async def derive_implicit_assignee(
     from awaithumans.server.channels.slack.resolution import resolve_slack_target
 
     route = parse_route(notify[0])
-    if route is None or route.channel != "slack":
+    if route is None:
+        return RoutingResult(user_id=None, email=None)
+
+    # Email path — `notify=["email+id:reviewer@acme.com"]` means
+    # "send a review email to that address." If the address is
+    # already in the directory we pin them as the assignee at
+    # task-create time. If not, the email handoff endpoint
+    # claims the task on first click (see `routes/auth.py`).
+    if route.channel == "email":
+        user = await _get_by_email(session, route.target.lower())
+        if user is None or not user.active:
+            return RoutingResult(user_id=None, email=route.target)
+        return _result_from_user(user)
+
+    if route.channel != "slack":
         return RoutingResult(user_id=None, email=None)
 
     # Channel sigils (`#general`, raw `C…`/`G…`) are broadcasts; the

--- a/packages/python/tests/auth/test_email_handoff_route.py
+++ b/packages/python/tests/auth/test_email_handoff_route.py
@@ -243,3 +243,117 @@ def test_missing_signature_rejected(client: TestClient) -> None:
         },
     )
     assert resp.status_code == 422
+
+
+# ─── Handoff-claim path ──────────────────────────────────────────────
+
+
+def test_handoff_claims_unassigned_task_for_recipient(
+    client: TestClient,
+) -> None:
+    """An auto-provisioned reviewer who clicks the handoff URL must
+    be able to actually READ the task they were sent. Without
+    handoff-claim, the recipient lands signed-in but with no perms
+    (not operator, not assignee → 403 from `require_task_read`).
+
+    The fix: when the task has no assignee yet, the handoff route
+    sets `assigned_to_user_id` to the recipient. Same intent the
+    Slack DM flow encodes via implicit-assignee derivation at
+    create time."""
+    from awaithumans.server.db.connection import get_async_session_factory
+    from awaithumans.server.services.task_service import (
+        create_task,
+        get_task,
+    )
+
+    new_email = "claim-recipient@example.com"
+
+    async def _make_task() -> str:
+        factory = get_async_session_factory()
+        async with factory() as session:
+            task = await create_task(
+                session,
+                task="Approve refund",
+                payload={},
+                payload_schema={},
+                response_schema={},
+                timeout_seconds=3600,
+                idempotency_key="claim-test-1",
+            )
+            return task.id
+
+    task_id = asyncio.new_event_loop().run_until_complete(_make_task())
+
+    exp = _far_future()
+    sig = sign_handoff(recipient=new_email, task_id=task_id, exp_unix=exp)
+
+    resp = client.get(
+        "/api/auth/email-handoff",
+        params={"to": new_email, "t": task_id, "e": exp, "s": sig},
+    )
+    assert resp.status_code == 303
+
+    # Task is now assigned to the auto-provisioned reviewer.
+    async def _read() -> tuple[str | None, str | None]:
+        factory = get_async_session_factory()
+        async with factory() as session:
+            task = await get_task(session, task_id)
+            return task.assigned_to_user_id, task.assigned_to_email
+
+    user_id, email = asyncio.new_event_loop().run_until_complete(_read())
+    assert email == new_email
+    assert user_id is not None  # the just-provisioned user
+
+
+def test_handoff_does_not_steal_existing_assignee(
+    client: TestClient, operator_user: User
+) -> None:
+    """If the task already has an assignee, the handoff signs the
+    user in (so they can read the task if they're an operator) but
+    DOESN'T overwrite the assignee. First-writer-wins protects
+    against a second recipient stealing the queue position from
+    the first."""
+    from awaithumans.server.db.connection import get_async_session_factory
+    from awaithumans.server.services.task_service import (
+        create_task,
+        get_task,
+    )
+
+    async def _make_assigned_task() -> str:
+        factory = get_async_session_factory()
+        async with factory() as session:
+            task = await create_task(
+                session,
+                task="Approve",
+                payload={},
+                payload_schema={},
+                response_schema={},
+                timeout_seconds=3600,
+                idempotency_key="claim-test-2",
+                assign_to={"email": operator_user.email},  # pre-assigned
+            )
+            return task.id
+
+    task_id = asyncio.new_event_loop().run_until_complete(
+        _make_assigned_task()
+    )
+
+    # Sign for a different recipient than the assignee.
+    other_email = "later-clicker@example.com"
+    exp = _far_future()
+    sig = sign_handoff(recipient=other_email, task_id=task_id, exp_unix=exp)
+
+    resp = client.get(
+        "/api/auth/email-handoff",
+        params={"to": other_email, "t": task_id, "e": exp, "s": sig},
+    )
+    assert resp.status_code == 303  # session minted
+
+    async def _read() -> str | None:
+        factory = get_async_session_factory()
+        async with factory() as session:
+            task = await get_task(session, task_id)
+            return task.assigned_to_user_id
+
+    user_id = asyncio.new_event_loop().run_until_complete(_read())
+    assert user_id == operator_user.id  # original assignee untouched

--- a/packages/python/tests/users/test_implicit_assignee.py
+++ b/packages/python/tests/users/test_implicit_assignee.py
@@ -201,16 +201,49 @@ async def test_inactive_directory_user_skipped(
 
 
 @pytest.mark.asyncio
-async def test_email_channel_does_not_derive(session: AsyncSession) -> None:
-    """`notify=["email:alice@..."]` doesn't go through the Slack
-    resolver — different channel, different lookup story. Stay
-    unassigned. (Future: add an email-channel derivation if there's
-    demand.)"""
-    await _seed_user(session, email="alice@acme.com")
+async def test_email_channel_derives_when_recipient_is_directory_user(
+    session: AsyncSession,
+) -> None:
+    """`notify=["email:alice@..."]` → look up alice in the directory
+    and pin her as assignee, mirroring the Slack DM derivation.
+    Without this, the auto-provisioned-on-handoff flow would always
+    have to claim — for recipients who already have directory rows
+    the create-time path is cleaner."""
+    user = await _seed_user(session, email="alice@acme.com")
     result = await derive_implicit_assignee(
         session, ["email:alice@acme.com"]
     )
+    assert result.user_id == user.id
+    assert result.email == user.email
+
+
+@pytest.mark.asyncio
+async def test_email_channel_with_unknown_recipient_stays_unassigned(
+    session: AsyncSession,
+) -> None:
+    """Recipient isn't in the directory yet → derivation can't pin
+    a user_id but still threads the address through so the email
+    channel knows where to send. The handoff endpoint claims at
+    click time when the user is auto-provisioned."""
+    result = await derive_implicit_assignee(
+        session, ["email:nobody@acme.com"]
+    )
     assert result.user_id is None
+    assert result.email == "nobody@acme.com"
+
+
+@pytest.mark.asyncio
+async def test_email_channel_handles_identity_suffix(
+    session: AsyncSession,
+) -> None:
+    """`notify=["email+acme:alice@..."]` (identity-suffixed) works
+    the same way — derivation looks up the recipient regardless of
+    which identity routes the email."""
+    user = await _seed_user(session, email="alice@acme.com")
+    result = await derive_implicit_assignee(
+        session, ["email+acme-prod:alice@acme.com"]
+    )
+    assert result.user_id == user.id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Symptom

After PR #54 + #57 landed, the email "Open task" button works and the handoff URL signs the recipient in correctly. BUT the dashboard then shows an error — the user lands on /task?id=… with a session cookie set, but the page can't load the task data.

## Root cause

The auto-provisioned reviewer is a non-operator. For non-operators, `require_task_read` only allows the task's assignee. The task's `assigned_to_user_id` was null because:

1. `derive_implicit_assignee` only handles Slack routes — the email channel was a documented `Future: add ...` gap
2. Email-handoff endpoint signed users in without claiming the task for them

End result: session minted ✓, but no permission to read what they were sent → 403 → "Couldn't load task".

## Fix

### 1. Email channel in `derive_implicit_assignee` (task_router.py)

Mirrors the existing Slack handling. `notify=["email+id:user@x.com"]`:
- Recipient already in directory → pin as `assigned_to_user_id` at create time
- Not in directory → email is threaded through but user_id stays null

### 2. Handoff-claim path (auth.py)

`/api/auth/email-handoff` now runs an atomic UPDATE after the session is minted:

```sql
UPDATE tasks SET assigned_to_user_id = <recipient>
  WHERE id = <task_id>
    AND assigned_to_user_id IS NULL
    AND status NOT IN (terminal)
```

First-writer-wins. Already-assigned tasks aren't stolen; terminal tasks aren't claimed.

## Why this is safe

The handoff URL is HMAC-signed proof that the recipient had access to the email the agent sent them. `notify=["email:..."]` already represented the agent's intent that this person should review this specific task. Promoting them to assignee on first click is the same trust shape the Slack DM flow already uses via implicit-assignee derivation at create time.

## Tests

| File | Cases | Pin |
|---|---|---|
| `tests/users/test_implicit_assignee.py` | +3 | email recipient in directory becomes assignee, unknown recipient stays unassigned, identity-suffix works |
| `tests/auth/test_email_handoff_route.py` | +2 | unassigned task claimed for recipient, already-assigned task untouched |
| (existing `test_email_channel_does_not_derive` removed) | -1 | was pinning the deliberate gap; now obsolete |

`497 → 501 passing` (+4). 76 email tests still green.

## Test plan

After merge + rebuild + reinstall + restart `awaithumans dev`:

- [ ] Run `examples/email-end-to-end-py/send.py` to your real inbox with a recipient that's NOT a directory user
- [ ] Click "Open task" in the email → land on the task page authenticated AND with the form rendering (not "Couldn't load task")
- [ ] Fill + submit → Python SDK resolves
- [ ] Audit log shows the auto-provisioned reviewer in "Completed by"

🤖 Generated with [Claude Code](https://claude.com/claude-code)