### PR TITLE
feat(examples): temporal-ts — TS counterpart of the temporal example

### DIFF
--- a/examples/temporal-ts/README.md
+++ b/examples/temporal-ts/README.md
@@ -1,0 +1,139 @@
+# Temporal × awaithumans — TypeScript example
+
+A real Temporal workflow that pauses for a human approval through awaithumans, then continues. TypeScript counterpart of [`../temporal/`](../temporal/) (Python).
+
+This is the canonical durable-HITL pattern: the workflow's `awaitHuman()` call gives Temporal back to the scheduler ("park me until a signal arrives"), the human reviews via the awaithumans dashboard / Slack / email, and a webhook from the awaithumans server signals the workflow back to life. Zero compute consumed while waiting; full Temporal durability if the worker restarts mid-await.
+
+## Architecture
+
+```
+┌──────────────────┐  HTTP POST /api/tasks   ┌──────────────────────┐
+│ Temporal worker  │ ─────────────────────►  │ awaithumans server   │
+│ (refundWorkflow) │                         │ (awaithumans dev)    │
+│                  │                         │                      │
+│ awaitHuman()     │                         │ — human reviews ──►  │
+│   parked         │                         │ — completes task ──► │
+│                  │  webhook (signed)       │                      │
+│                  │ ◄───────────────────────│                      │
+└─────┬────────────┘                         └──────────────────────┘
+      │ Temporal signal
+      │ (via dispatchSignal)
+┌─────▼────────────────┐
+│ Hono callback server │
+│ (callback-server.ts) │
+└──────────────────────┘
+```
+
+Three processes:
+
+| Process              | What it does                                    | Command                       |
+|----------------------|-------------------------------------------------|-------------------------------|
+| awaithumans server   | Stores tasks, hosts dashboard, fires webhooks   | `awaithumans dev`             |
+| Temporal worker      | Runs the workflow                               | `npm run worker`              |
+| Callback receiver    | Converts webhooks → Temporal signals            | `npm run callback-server`     |
+
+Plus a one-shot kickoff to start a workflow run:
+
+```sh
+npm run kickoff -- 250 cus_demo
+```
+
+## Run it locally
+
+### 1. Boot Temporal (separate terminal)
+
+```sh
+brew install temporal           # or see temporal.io/setup-cli
+temporal server start-dev       # localhost:7233 + UI at :8233
+```
+
+### 2. Boot the awaithumans server (separate terminal)
+
+```sh
+awaithumans dev
+```
+
+Open the printed `/setup?token=...` URL and create your operator user.
+
+### 3. Install this example
+
+```sh
+cd examples/temporal-ts
+npm install
+```
+
+### 4. Boot the callback receiver (separate terminal)
+
+The callback receiver verifies the webhook signature using `AWAITHUMANS_PAYLOAD_KEY`, which `awaithumans dev` generated for you. Both processes need the same value.
+
+```sh
+export AWAITHUMANS_PAYLOAD_KEY=$(cat <wherever-you-ran-awaithumans-dev>/.awaithumans/payload.key)
+npm run callback-server
+# → [callback] listening on http://localhost:8765
+```
+
+### 5. Boot the Temporal worker (separate terminal)
+
+```sh
+cd examples/temporal-ts
+npm run worker
+# → [worker] task_queue=awaithumans-refunds
+# → [worker] running — Ctrl-C to stop
+```
+
+### 6. Kick off a workflow run
+
+```sh
+cd examples/temporal-ts
+npm run kickoff -- 250 cus_demo
+# → [kickoff] started workflow id=refund-...
+# → [kickoff] waiting for human via dashboard / Slack / email
+```
+
+The kickoff script reads `AWAITHUMANS_URL` + `AWAITHUMANS_ADMIN_API_TOKEN` from env or the dev server's discovery file (`~/.awaithumans-dev.json`) — no manual export needed if `awaithumans dev` is running.
+
+### 7. Review
+
+Open http://localhost:3001 — you'll see "Approve $250 refund for cus_demo?" in the queue. Click through, fill the form, Submit.
+
+The kickoff terminal prints the workflow result as a JSON object, then exits:
+
+```
+[kickoff] workflow result: {
+  "refundId": "refund-1234abcd-...",
+  "outcome": "approved",
+  "notes": "Looks legitimate"
+}
+```
+
+The Temporal UI at http://localhost:8233 shows the full workflow event history — `awaitHuman` activity, signal received, `processRefund` activity, completion.
+
+## What this exercises that smoke tests don't
+
+- **Real Temporal sandbox** — the workflow file imports `awaithumans/temporal`, which has to be sandbox-safe (no top-level fs / network)
+- **Real signal round-trip** — `awaithumans` server → HMAC-signed webhook → `dispatchSignal` → Temporal client → workflow signal handler → `workflow.condition()` resolves
+- **Cross-language wire compatibility** — wire format and signal naming match the Python adapter exactly. A Python receiver can signal a TS workflow and vice versa.
+- **Workflow durability** — kill the worker mid-await and restart it; the workflow picks up where it left off when the signal arrives.
+
+## Tunnel for non-localhost setups
+
+If `awaithumans dev` runs anywhere except your local machine (Docker, hosted, Slack-OAuth-friendly ngrok), the server can't reach `http://localhost:8765`. Expose the callback receiver:
+
+```sh
+ngrok http 8765
+# → https://<your-id>.ngrok.io
+export AWAITHUMANS_CALLBACK_BASE=https://<your-id>.ngrok.io
+npm run kickoff -- 250
+```
+
+The kickoff script bakes `AWAITHUMANS_CALLBACK_BASE` into the workflow input, which the workflow uses to construct the per-run callback URL (`<base>/awaithumans/callback?wf=<workflow_id>`).
+
+## Common gotchas
+
+| Symptom | Fix |
+|---|---|
+| `Couldn't find an admin token` | Start `awaithumans dev` first |
+| `AWAITHUMANS_PAYLOAD_KEY is required` (callback server) | Export it from the same `awaithumans dev` payload key file |
+| Workflow hangs forever | Callback receiver isn't running, or `AWAITHUMANS_CALLBACK_BASE` doesn't reach it |
+| `[callback] rejected bad signature` | The two processes have different `PAYLOAD_KEY`s — make sure both read the same value |
+| Workflow times out | Default timeout is 15 min; for testing, complete the task in the dashboard before that |

--- a/examples/temporal-ts/activities/process-refund.ts
+++ b/examples/temporal-ts/activities/process-refund.ts
@@ -1,0 +1,28 @@
+/**
+ * Downstream activity: stand-in for "actually move the money."
+ *
+ * Lives outside the workflow sandbox so it can do real I/O — call
+ * a payments provider, write to a DB, hit a third-party API. The
+ * workflow file (where determinism matters) imports just the type
+ * signature.
+ */
+
+import { randomUUID } from "node:crypto";
+
+export interface ProcessRefundInput {
+	customerId: string;
+	amountUsd: number;
+	decisionNotes: string | null;
+}
+
+export async function processRefund(
+	input: ProcessRefundInput,
+): Promise<string> {
+	console.log(
+		`[activity] processing refund customer=${input.customerId} ` +
+			`amount=$${input.amountUsd} notes=${input.decisionNotes ?? "(none)"}`,
+	);
+	// Real implementation would charge / refund here. For the demo,
+	// pretend we got an ID back from the payments API.
+	return `refund-${randomUUID()}`;
+}

--- a/examples/temporal-ts/callback-server.ts
+++ b/examples/temporal-ts/callback-server.ts
@@ -1,0 +1,111 @@
+/**
+ * Callback receiver — converts awaithumans webhooks to Temporal signals.
+ *
+ * Mirror of `examples/temporal/callback_server.py` (Python). The two
+ * receivers are interchangeable: a Python workflow can be signaled by
+ * the TS receiver and vice versa, because the wire format and signal
+ * naming are identical across SDKs.
+ *
+ * Three things this does:
+ *
+ *   1. Receives POST /awaithumans/callback?wf=<workflow_id>
+ *   2. Verifies the HMAC signature header against PAYLOAD_KEY
+ *   3. Looks up the workflow by ID and signals it with the response
+ *
+ * Uses Hono — small, runtime-portable web framework. Same shape would
+ * work with Express, Fastify, Bun.serve, etc.
+ *
+ * Run with:
+ *   npm run callback-server
+ *
+ * For the awaithumans server (running locally) to reach this from
+ * Docker / a hosted deployment, expose it via a tunnel:
+ *   ngrok http 8765
+ *   export AWAITHUMANS_CALLBACK_BASE=https://<ngrok-id>.ngrok.io
+ *
+ * AWAITHUMANS_PAYLOAD_KEY must be set on BOTH this process and the
+ * awaithumans server — that's how HMAC keys derive to the same value.
+ */
+
+import { serve } from "@hono/node-server";
+import { Client, Connection } from "@temporalio/client";
+import { dispatchSignal } from "awaithumans/temporal";
+import { Hono } from "hono";
+
+const TEMPORAL_ADDRESS = process.env.TEMPORAL_ADDRESS ?? "localhost:7233";
+const PORT = Number(process.env.PORT ?? "8765");
+
+async function main(): Promise<void> {
+	const payloadKey = process.env.AWAITHUMANS_PAYLOAD_KEY;
+	if (!payloadKey) {
+		// In dev, `awaithumans dev` writes the key to a discovery file
+		// AND exports it as an env var inside its own process. The
+		// callback receiver runs separately and needs the same key —
+		// either export it manually, or read the dev key file.
+		console.error(
+			"AWAITHUMANS_PAYLOAD_KEY is required.\n" +
+				"  Dev: export AWAITHUMANS_PAYLOAD_KEY=$(cat .awaithumans/payload.key) " +
+				"(from wherever you ran `awaithumans dev`).",
+		);
+		process.exit(1);
+	}
+
+	// Long-lived Temporal client — opening one per request would
+	// burn ~50ms on handshake.
+	const connection = await Connection.connect({ address: TEMPORAL_ADDRESS });
+	const temporalClient = new Client({ connection });
+	console.log(`[callback] connected to Temporal at ${TEMPORAL_ADDRESS}`);
+
+	// Wrap the Temporal client in the structural interface
+	// `dispatchSignal` expects — keeps the SDK adapter free of a
+	// hard `@temporalio/client` import.
+	const clientLike = {
+		getHandle(workflowId: string) {
+			return temporalClient.workflow.getHandle(workflowId);
+		},
+	};
+
+	const app = new Hono();
+
+	app.post("/awaithumans/callback", async (c) => {
+		const workflowId = c.req.query("wf");
+		if (!workflowId) {
+			return c.json({ error: "missing wf query param" }, 400);
+		}
+
+		const body = await c.req.arrayBuffer();
+		const signature = c.req.header("x-awaithumans-signature") ?? null;
+
+		try {
+			await dispatchSignal({
+				temporalClient: clientLike,
+				workflowId,
+				body,
+				signatureHeader: signature,
+				payloadKey,
+			});
+		} catch (err) {
+			const msg = (err as Error).message;
+			// Bad signature is a security event; malformed body is a
+			// misconfig. Both bubble to the awaithumans server's
+			// webhook-failed log.
+			if (msg.includes("Invalid awaithumans webhook signature")) {
+				console.warn("[callback] rejected bad signature");
+				return c.json({ error: msg }, 401);
+			}
+			console.warn("[callback] rejected:", msg);
+			return c.json({ error: msg }, 400);
+		}
+
+		return c.json({ ok: true });
+	});
+
+	serve({ fetch: app.fetch, port: PORT }, (info) => {
+		console.log(`[callback] listening on http://localhost:${info.port}`);
+	});
+}
+
+main().catch((err) => {
+	console.error("[callback] fatal:", err);
+	process.exit(1);
+});

--- a/examples/temporal-ts/kickoff.ts
+++ b/examples/temporal-ts/kickoff.ts
@@ -1,0 +1,82 @@
+/**
+ * Kickoff — start one refund workflow run.
+ *
+ * In real production this is the place a web request from your app
+ * would land. For the demo, we read the amount from argv and use
+ * the dev server's discovery file for URL + token.
+ *
+ * Usage:
+ *   npm run kickoff -- 250
+ *   # or:
+ *   npm run kickoff       # defaults to $100
+ */
+
+import { randomUUID } from "node:crypto";
+
+import { Client, Connection } from "@temporalio/client";
+import { resolveAdminToken, resolveServerUrl } from "awaithumans";
+
+import type {
+	RefundWorkflowInput,
+	RefundWorkflowResult,
+} from "./workflows/refund-workflow.js";
+
+const TASK_QUEUE = "awaithumans-refunds";
+const TEMPORAL_ADDRESS = process.env.TEMPORAL_ADDRESS ?? "localhost:7233";
+
+async function main(): Promise<void> {
+	const amountUsd = Number(process.argv[2] ?? "100");
+	const customerId = process.argv[3] ?? "cus_demo";
+
+	// awaithumans config — same chain `awaitHuman` uses internally.
+	// Explicit option → AWAITHUMANS_URL / TOKEN env vars → discovery
+	// file written by `awaithumans dev` → defaults.
+	const serverUrl = await resolveServerUrl();
+	const apiKey = await resolveAdminToken();
+	if (!apiKey) {
+		console.error(
+			"Couldn't find an admin token. Run `awaithumans dev` " +
+				"(writes ~/.awaithumans-dev.json) or export " +
+				"AWAITHUMANS_ADMIN_API_TOKEN.",
+		);
+		process.exit(1);
+	}
+
+	// Where the awaithumans server posts its completion webhook.
+	// Has to be reachable from wherever `awaithumans dev` runs —
+	// for local-with-ngrok-tunnel, override with the ngrok URL.
+	const callbackBase =
+		process.env.AWAITHUMANS_CALLBACK_BASE ?? "http://localhost:8765";
+
+	const connection = await Connection.connect({ address: TEMPORAL_ADDRESS });
+	const client = new Client({ connection });
+
+	const workflowId = `refund-${randomUUID()}`;
+	const input: RefundWorkflowInput = {
+		amountUsd,
+		customerId,
+		callbackBase,
+		serverUrl,
+		apiKey,
+	};
+
+	const handle = await client.workflow.start("refundWorkflow", {
+		args: [input],
+		taskQueue: TASK_QUEUE,
+		workflowId,
+	});
+
+	console.log(`[kickoff] started workflow id=${workflowId}`);
+	console.log("[kickoff] waiting for human via dashboard / Slack / email");
+	console.log(
+		`[kickoff] (review at ${serverUrl.replace(/\/$/, "")}/task?id=...)`,
+	);
+
+	const result = (await handle.result()) as RefundWorkflowResult;
+	console.log("[kickoff] workflow result:", JSON.stringify(result, null, 2));
+}
+
+main().catch((err) => {
+	console.error("[kickoff] failed:", err);
+	process.exit(1);
+});

--- a/examples/temporal-ts/package.json
+++ b/examples/temporal-ts/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "awaithumans-temporal-ts",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "worker": "tsx worker.ts",
+    "kickoff": "tsx kickoff.ts",
+    "callback-server": "tsx callback-server.ts"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.13.0",
+    "@temporalio/activity": "^1.13.0",
+    "@temporalio/client": "^1.13.0",
+    "@temporalio/worker": "^1.13.0",
+    "@temporalio/workflow": "^1.13.0",
+    "awaithumans": "file:../../packages/typescript-sdk",
+    "hono": "^4.6.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/temporal-ts/tsconfig.json
+++ b/examples/temporal-ts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["*.ts", "workflows/*.ts"]
+}

--- a/examples/temporal-ts/worker.ts
+++ b/examples/temporal-ts/worker.ts
@@ -1,0 +1,65 @@
+/**
+ * Temporal worker — runs the refund workflow.
+ *
+ * Three things to know:
+ *
+ *   1. The worker bundles the workflow files via Temporal's
+ *      sandbox-friendly bundler (`workflowsPath`). Files referenced
+ *      from the workflow can't reach `process.env`, `fs`, network,
+ *      etc. — anything that needs those goes in `activities/`.
+ *
+ *   2. Activities run in a normal Node context. They DO see env
+ *      vars, can hit databases, call third parties, etc. The
+ *      `processRefund` stand-in lives in `activities/process-refund.ts`.
+ *
+ *   3. The temporal adapter's `awaitHuman` is also workflow-safe
+ *      (it uses `proxyActivities` internally to POST the task).
+ *      Workflow code calls it directly; the adapter handles the
+ *      sandbox crossing.
+ *
+ * Run with:
+ *   npm install
+ *   npm run worker
+ *
+ * In separate terminals:
+ *   - `temporal server start-dev`              — Temporal cluster
+ *   - `awaithumans dev`                        — awaithumans server
+ *   - `npm run callback-server`                — callback receiver
+ *   - `npm run kickoff -- 250`                 — start a workflow run
+ */
+
+import { fileURLToPath } from "node:url";
+
+import { NativeConnection, Worker } from "@temporalio/worker";
+
+import { processRefund } from "./activities/process-refund.js";
+
+const TASK_QUEUE = "awaithumans-refunds";
+const TEMPORAL_ADDRESS = process.env.TEMPORAL_ADDRESS ?? "localhost:7233";
+
+async function main(): Promise<void> {
+	const connection = await NativeConnection.connect({
+		address: TEMPORAL_ADDRESS,
+	});
+
+	const worker = await Worker.create({
+		connection,
+		taskQueue: TASK_QUEUE,
+		// Temporal's TS bundler reads workflow files at startup. We
+		// pass the directory absolute so it works regardless of the
+		// caller's cwd.
+		workflowsPath: fileURLToPath(new URL("./workflows", import.meta.url)),
+		activities: { processRefund },
+	});
+
+	console.log(`[worker] task_queue=${TASK_QUEUE}`);
+	console.log(`[worker] Temporal at ${TEMPORAL_ADDRESS}`);
+	console.log("[worker] running — Ctrl-C to stop");
+
+	await worker.run();
+}
+
+main().catch((err) => {
+	console.error("[worker] fatal:", err);
+	process.exit(1);
+});

--- a/examples/temporal-ts/workflows/refund-workflow.ts
+++ b/examples/temporal-ts/workflows/refund-workflow.ts
@@ -1,0 +1,123 @@
+/**
+ * Temporal workflow that pauses for a human approval through awaithumans.
+ *
+ * Mirrors the Python `refund_workflow.py`:
+ *
+ *   1. `awaitHuman()` from the temporal adapter parks the workflow
+ *      until either a signal (carrying the human's response) arrives
+ *      or the timeout fires.
+ *   2. On approval, the workflow calls a downstream activity to
+ *      "actually move the money" — a stand-in for your payments
+ *      provider call.
+ *   3. On rejection, the workflow ends with an outcome record.
+ *   4. On timeout, the SDK throws `TaskTimeoutError` so the operator's
+ *      monitoring sees the abandoned approval.
+ *
+ * Determinism: the workflow file is loaded inside Temporal's sandbox.
+ * Anything non-deterministic (process.env, fs, network, randomness)
+ * happens via:
+ *   - The temporal adapter's activity that POSTs the task at start
+ *   - The downstream `processRefund` activity
+ *   - The kickoff script that injects callback URL + API key as
+ *     workflow inputs
+ *
+ * The workflow itself only orchestrates.
+ */
+
+import { proxyActivities, workflowInfo } from "@temporalio/workflow";
+import { awaitHuman } from "awaithumans/temporal";
+import { z } from "zod";
+
+import type { ProcessRefundInput } from "../activities/process-refund.js";
+
+// ─── Activity proxy ────────────────────────────────────────────────────
+
+const { processRefund } = proxyActivities<{
+	processRefund(input: ProcessRefundInput): Promise<string>;
+}>({
+	startToCloseTimeout: "30 seconds",
+});
+
+// ─── Schemas the human sees / sends ───────────────────────────────────
+
+const RefundPayload = z.object({
+	amountUsd: z.number(),
+	customerId: z.string(),
+	reason: z.string(),
+});
+
+const RefundDecision = z.object({
+	approved: z.boolean().describe("Approve this refund?"),
+	notes: z.string().optional(),
+});
+
+// ─── Workflow input ────────────────────────────────────────────────────
+
+export interface RefundWorkflowInput {
+	amountUsd: number;
+	customerId: string;
+	/** Where the awaithumans server can reach the callback receiver. */
+	callbackBase: string;
+	/** awaithumans server URL (so the activity knows where to POST). */
+	serverUrl: string;
+	/**
+	 * Bearer token for the awaithumans server. Threaded as input rather
+	 * than read from env because the workflow sandbox doesn't see
+	 * `process.env`. Real deployments inject this from the kickoff
+	 * caller (a web server / CLI / scheduler that DOES have env).
+	 */
+	apiKey: string;
+}
+
+export interface RefundWorkflowResult {
+	refundId: string | null;
+	outcome: "approved" | "rejected";
+	notes: string | null;
+}
+
+// ─── Workflow ──────────────────────────────────────────────────────────
+
+export async function refundWorkflow(
+	input: RefundWorkflowInput,
+): Promise<RefundWorkflowResult> {
+	const { workflowId } = workflowInfo();
+	const callbackUrl = `${input.callbackBase.replace(/\/$/, "")}/awaithumans/callback?wf=${workflowId}`;
+
+	const decision = await awaitHuman({
+		task: `Approve $${input.amountUsd} refund for ${input.customerId}?`,
+		payloadSchema: RefundPayload,
+		payload: {
+			amountUsd: input.amountUsd,
+			customerId: input.customerId,
+			reason: "Customer reports duplicate charge.",
+		},
+		responseSchema: RefundDecision,
+		// 15-minute window — plenty of time for a human review during
+		// business hours, short enough that abandoned tasks surface
+		// in monitoring before the day is out.
+		timeoutMs: 15 * 60 * 1000,
+		callbackUrl,
+		serverUrl: input.serverUrl,
+		apiKey: input.apiKey,
+	});
+
+	if (!decision.approved) {
+		return {
+			refundId: null,
+			outcome: "rejected",
+			notes: decision.notes ?? null,
+		};
+	}
+
+	const refundId = await processRefund({
+		customerId: input.customerId,
+		amountUsd: input.amountUsd,
+		decisionNotes: decision.notes ?? null,
+	});
+
+	return {
+		refundId,
+		outcome: "approved",
+		notes: decision.notes ?? null,
+	};
+}


### PR DESCRIPTION
## Why

Closes the language-parity gap on the durable-HITL pattern. `examples/temporal/` was Python-only — the TS temporal adapter has been sitting in the SDK without a runnable demo.

## What's in here

Mirrors the Python example shape-for-shape:

```
examples/temporal-ts/
  workflows/refund-workflow.ts    # workflow definition (sandbox-safe)
  activities/process-refund.ts    # downstream activity (real I/O OK)
  worker.ts                       # boots the Temporal worker
  callback-server.ts              # Hono receiver: webhook → signal
  kickoff.ts                      # one-shot CLI to start a workflow run
  README.md                       # 5-process boot recipe + tunnel notes
  package.json                    # file: link to local SDK
  tsconfig.json
```

The workflow:
1. Calls `awaitHuman()` which parks Temporal until a signal arrives
2. On approval → calls `processRefund` activity (stand-in for "actually move the money")
3. On rejection → returns an outcome record
4. On timeout → throws `TaskTimeoutError`

Hono is the receiver framework — small, runtime-portable, swappable for Express/Fastify/Bun.serve.

## Cross-language compatibility

Wire format and signal naming match the Python adapter exactly. A Python receiver can signal a TS workflow and vice versa — verified via the unit tests in `packages/typescript-sdk/tests/temporal-adapter.test.ts` which pin signal-name derivation and HMAC verification against fixtures shared with Python.

## What this exercises that smoke tests don't

- Real Temporal sandbox bundling (workflow file goes through `Worker.create({ workflowsPath })`, fails noisily on any non-deterministic top-level import)
- Real signal round-trip: server → HMAC webhook → `dispatchSignal` → workflow signal handler → `workflow.condition()` resolves
- Workflow durability: kill the worker mid-await, restart, the workflow picks up where it left off when the signal arrives

## Run

```sh
# Terminal 1: Temporal cluster
temporal server start-dev

# Terminal 2: awaithumans server
awaithumans dev

# Terminal 3: callback receiver
cd examples/temporal-ts && npm install
export AWAITHUMANS_PAYLOAD_KEY=$(cat .awaithumans/payload.key)
npm run callback-server

# Terminal 4: Temporal worker
cd examples/temporal-ts && npm run worker

# Terminal 5: kickoff a run
cd examples/temporal-ts && npm run kickoff -- 250 cus_demo
```

Open http://localhost:3001, review the task, submit. Kickoff terminal prints the workflow result.

## Verified

`npm install` clean, `npx tsc --noEmit` clean. End-to-end manual test pending against a live Temporal cluster (the README walks through every step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)