### PR TITLE
feat(langgraph-ts): implement TS LangGraph adapter + example

### DIFF
--- a/examples/langgraph-ts/README.md
+++ b/examples/langgraph-ts/README.md
@@ -1,0 +1,104 @@
+# langgraph-ts — TypeScript LangGraph + awaithumans
+
+A refund-approval graph with one human-in-the-loop interrupt. Mirrors
+the `temporal-ts/` example in shape but uses LangGraph's interrupt /
+resume model instead of Temporal signals.
+
+## What you'll see
+
+```
+[customer]
+   │
+   ▼
+[POST /start]           ─── 250  ──► [graph.invoke]
+                                       └─► checkPolicy → humanReview
+                                                          │
+                                                          │  awaitHuman()
+                                                          │  POSTs to awaithumans
+                                                          │  → interrupt() throws
+                                                          │
+                                       ◄── { __interrupt__ } ──┘
+                                       (graph paused;
+                                        state in checkpointer)
+
+[human approves in dashboard]
+   │
+   ▼
+[awaithumans server fires webhook]
+   │
+   ▼
+[POST /awaithumans/cb?thread=…]
+   │
+   ▼
+[handler verifies HMAC]
+   │
+   ▼
+[graph.invoke(Command({resume}))]
+   │
+   ▼
+[humanReview node returns]
+   │
+   ▼
+[final state visible via /threads/:id]
+```
+
+## Prerequisites
+
+- Node 20+
+- The awaithumans dev server running locally (`awaithumans dev`)
+
+## Run it
+
+In three terminals:
+
+```bash
+# Terminal 1 — awaithumans server
+awaithumans dev
+
+# Terminal 2 — this example's app (graph + checkpointer + callback)
+cd examples/langgraph-ts
+npm install
+export AWAITHUMANS_PAYLOAD_KEY=$(cat /tmp/<your-dev-cwd>/.awaithumans/payload.key)
+npm run app
+
+# Terminal 3 — kick off a run
+cd examples/langgraph-ts
+npm run kickoff -- 250 cus_demo    # over threshold → human review
+# or
+npm run kickoff -- 50 cus_small    # under threshold → auto-approves
+```
+
+Then approve in the awaithumans dashboard (http://localhost:3001) or
+via `curl -X POST .../api/tasks/{id}/complete`.
+
+## How the pieces fit
+
+- **`graph.ts`** — defines `RefundState`, three nodes (`checkPolicy`,
+  `humanReview`, `autoApprove`), a `MemorySaver` checkpointer, and a
+  conditional edge. The `humanReview` node calls `awaitHuman` from
+  `awaithumans/langgraph` — that's the entire HITL integration.
+
+- **`app.ts`** — single Hono process. Owns the compiled graph (so
+  `/start` and `/awaithumans/cb` share state via the checkpointer),
+  exposes `POST /start` to kick off, `POST /awaithumans/cb` to receive
+  the webhook, and `GET /threads/:id` for the kickoff client to poll.
+
+- **`kickoff.ts`** — POSTs `/start`, then polls `/threads/:id` until
+  the graph reports a final state.
+
+## Production notes
+
+- **Checkpointer**: this demo uses `MemorySaver` (in-process, lost on
+  restart). Production should swap in `@langchain/langgraph-checkpoint-sqlite`
+  or `@langchain/langgraph-checkpoint-postgres` so an interrupted graph
+  survives a redeploy.
+
+- **Webhook reachability**: the awaithumans server has to reach
+  `${callback_base}/awaithumans/cb`. For local dev with `awaithumans dev`
+  on the same machine that's `http://localhost:8765`. For a remote
+  awaithumans server pointing at a local app, expose this process via
+  ngrok and set `AWAITHUMANS_CALLBACK_BASE=https://<ngrok>.io`.
+
+- **Webhook delivery durability**: the awaithumans server retries
+  webhook POSTs with backoff for up to 3 days (PR #61), so a brief
+  app outage won't lose the resume signal.

--- a/examples/langgraph-ts/app.ts
+++ b/examples/langgraph-ts/app.ts
@@ -1,0 +1,193 @@
+/**
+ * Application — graph + checkpointer + HTTP surface, all in one process.
+ *
+ * Mirrors what a real LangGraph deployment looks like: ONE web server
+ * owns the graph, the checkpointer, and the awaithumans webhook
+ * receiver. A node calling `awaitHuman` ↔ a webhook that comes back
+ * later ↔ a `Command({resume})` invocation are all the same process,
+ * the same compiled graph, the same checkpointer.
+ *
+ * Two routes:
+ *
+ *   POST /start         {customerId, amountUsd}      → kicks off a graph
+ *                                                       run; returns the
+ *                                                       thread id and the
+ *                                                       interrupt info
+ *                                                       (or final result
+ *                                                       if auto-approved)
+ *
+ *   POST /awaithumans/cb?thread=<thread_id>           → awaithumans webhook;
+ *                                                       resumes the graph
+ *
+ * Run with:
+ *   AWAITHUMANS_PAYLOAD_KEY=$(cat <discovery>/payload.key) npm run app
+ *
+ * Then in another terminal:
+ *   npm run kickoff -- 250 cus_demo
+ */
+
+import { randomUUID } from "node:crypto";
+
+import { serve } from "@hono/node-server";
+import { Command, type CompiledStateGraph } from "@langchain/langgraph";
+import { resolveAdminToken, resolveServerUrl } from "awaithumans";
+import { createLangGraphCallbackHandler } from "awaithumans/langgraph";
+import { Hono } from "hono";
+
+import {
+	type RefundStateType,
+	buildRefundGraph,
+} from "./graph.js";
+
+const PORT = Number(process.env.PORT ?? "8765");
+const CALLBACK_BASE = process.env.AWAITHUMANS_CALLBACK_BASE ?? `http://localhost:${PORT}`;
+
+async function main(): Promise<void> {
+	const payloadKey = process.env.AWAITHUMANS_PAYLOAD_KEY;
+	if (!payloadKey) {
+		console.error(
+			"AWAITHUMANS_PAYLOAD_KEY is required.\n" +
+				"  Dev: export AWAITHUMANS_PAYLOAD_KEY=$(cat .awaithumans/payload.key) " +
+				"(from wherever you ran `awaithumans dev`).",
+		);
+		process.exit(1);
+	}
+
+	// awaithumans config — same chain `awaitHuman` uses internally.
+	// Explicit option → AWAITHUMANS_URL / TOKEN env vars → discovery
+	// file written by `awaithumans dev` → defaults.
+	const serverUrl = await resolveServerUrl();
+	const apiKey = await resolveAdminToken();
+	if (!apiKey) {
+		console.error(
+			"Couldn't find an admin token. Run `awaithumans dev` " +
+				"(writes ~/.awaithumans-dev.json) or export " +
+				"AWAITHUMANS_ADMIN_API_TOKEN.",
+		);
+		process.exit(1);
+	}
+
+	// The threadId-via-ref trick: `humanReviewNode` reads the current
+	// thread id off this object. We update it before each .invoke()
+	// call so the node knows which thread its callback URL should
+	// encode. A more idiomatic approach would thread `RunnableConfig`
+	// through node signatures — keeping this simple for the example.
+	const threadIdRef = { value: "<unset>" };
+	const graph = buildRefundGraph(
+		{
+			awaithumans: { serverUrl, apiKey, callbackBase: CALLBACK_BASE },
+			autoApproveThresholdUsd: 100,
+		},
+		threadIdRef,
+	) as unknown as CompiledStateGraph<
+		RefundStateType,
+		Partial<RefundStateType>
+	>;
+
+	const handleCallback = createLangGraphCallbackHandler({
+		graph,
+		command: Command,
+		payloadKey,
+	});
+
+	const app = new Hono();
+
+	// ── /start ────────────────────────────────────────────────────────
+	// Kicks off a refund run. Returns either the final state (if
+	// auto-approved) or the interrupt payload (if a human is needed).
+	app.post("/start", async (c) => {
+		const body = await c.req.json<{ customerId?: string; amountUsd?: number }>();
+		if (typeof body.amountUsd !== "number" || !body.customerId) {
+			return c.json({ error: "customerId and amountUsd required" }, 400);
+		}
+
+		const threadId = `refund-${randomUUID()}`;
+		threadIdRef.value = threadId;
+
+		const result = (await graph.invoke(
+			{ customerId: body.customerId, amountUsd: body.amountUsd },
+			{ configurable: { thread_id: threadId } },
+		)) as RefundStateType;
+
+		// `.invoke()` in LangGraph TS returns the state values that
+		// were committed up to the pause point — it does NOT surface
+		// a `__interrupt__` field (that's a `.stream()`-only shape).
+		// Pending interrupts live on `getState().tasks[].interrupts`,
+		// so the right "are we paused?" check is to look for any
+		// task that has an unresumed interrupt.
+		const state = await graph.getState({
+			configurable: { thread_id: threadId },
+		});
+		const interrupts = state.tasks.flatMap((t) => t.interrupts ?? []);
+		if (interrupts.length > 0) {
+			console.log(`[start] graph paused thread=${threadId}`);
+			return c.json({ threadId, status: "interrupted", interrupts });
+		}
+
+		console.log(
+			`[start] graph finished thread=${threadId} approved=${result.approved}`,
+		);
+		return c.json({ threadId, status: "completed", state: result });
+	});
+
+	// ── /awaithumans/cb ───────────────────────────────────────────────
+	// awaithumans server POSTs here when the human submits. The handler
+	// verifies HMAC, then calls graph.invoke(Command({resume: <body>}))
+	// against the right thread.
+	app.post("/awaithumans/cb", async (c) => {
+		const thread = c.req.query("thread");
+		if (!thread) {
+			return c.text("missing thread", 400);
+		}
+		const body = await c.req.arrayBuffer();
+		const sig = c.req.header("x-awaithumans-signature");
+
+		// Setting the ref BEFORE the resume isn't strictly needed —
+		// after this resume the humanReview node won't run again on
+		// this thread. But if the graph had MULTIPLE interrupts on
+		// the same thread, the next interrupt would need this set.
+		threadIdRef.value = thread;
+
+		const out = await handleCallback({
+			threadId: thread,
+			body,
+			signatureHeader: sig,
+		});
+
+		if (out.error) {
+			console.warn(`[cb] thread=${thread} ${out.status}: ${out.error}`);
+			return c.text(out.error, out.status as 200 | 400 | 401 | 500);
+		}
+		console.log(`[cb] thread=${thread} resumed`);
+
+		// Read the final state off the checkpointer and surface it so
+		// the kickoff client can poll for it (in a real system this
+		// would be exposed via a more idiomatic /threads/{id} route).
+		const finalState = await graph.getState({
+			configurable: { thread_id: thread },
+		});
+		return c.json({ ok: true, state: finalState.values });
+	});
+
+	// ── /threads/:id ──────────────────────────────────────────────────
+	// Lets the kickoff client poll for completion.
+	app.get("/threads/:id", async (c) => {
+		const id = c.req.param("id");
+		const state = await graph.getState({ configurable: { thread_id: id } });
+		return c.json({
+			threadId: id,
+			values: state.values,
+			interrupts: state.tasks.flatMap((t) => t.interrupts ?? []),
+		});
+	});
+
+	console.log(`[app] graph + callback at http://localhost:${PORT}`);
+	console.log(`[app] awaithumans server: ${serverUrl}`);
+	console.log(`[app] callback base (in webhook URL): ${CALLBACK_BASE}`);
+	serve({ fetch: app.fetch, port: PORT });
+}
+
+main().catch((err) => {
+	console.error("[app] fatal:", err);
+	process.exit(1);
+});

--- a/examples/langgraph-ts/graph.ts
+++ b/examples/langgraph-ts/graph.ts
@@ -1,0 +1,184 @@
+/**
+ * Refund-approval graph — three nodes, one human-in-the-loop interrupt.
+ *
+ * The shape:
+ *
+ *     [start] → checkPolicy → (autoApprove) → end
+ *                          ↘ humanReview ↗
+ *                            (calls awaitHuman)
+ *                            (graph pauses here on first run;
+ *                             resumes from the same line on Command(resume))
+ *
+ * `awaitHuman` from `awaithumans/langgraph` is a single line of code
+ * inside `humanReviewNode`. When it runs the first time, it POSTs the
+ * task to the awaithumans server and then calls LangGraph's
+ * `interrupt(...)`. That throws — `graph.invoke()` returns to the
+ * caller (our app.ts) with `__interrupt__` populated. The application
+ * comes back later (when the webhook fires) with `Command({resume})`,
+ * and the SAME line of code now returns the resume value.
+ *
+ * That's the whole story: one function, two phases, durable in
+ * between because LangGraph's checkpointer (the `MemorySaver` we
+ * pass at compile time) holds the state.
+ */
+
+import {
+	Annotation,
+	END,
+	MemorySaver,
+	START,
+	StateGraph,
+} from "@langchain/langgraph";
+import { awaitHuman } from "awaithumans/langgraph";
+import { z } from "zod";
+
+// ─── State ──────────────────────────────────────────────────────────
+
+// LangGraph state is a flat object whose keys are merged across nodes.
+// The `Annotation` types describe each key: a default value and (for
+// reducers) how to combine updates. For this example we just want
+// "the latest write wins", which is the default.
+export const RefundState = Annotation.Root({
+	customerId: Annotation<string>,
+	amountUsd: Annotation<number>,
+	autoApproved: Annotation<boolean | undefined>,
+	approved: Annotation<boolean | undefined>,
+	notes: Annotation<string | undefined>,
+});
+
+export type RefundStateType = typeof RefundState.State;
+
+// ─── Schemas (shared between adapter call + UI rendering) ───────────
+
+const RefundPayload = z.object({
+	customerId: z.string(),
+	amountUsd: z.number(),
+	reason: z.string(),
+});
+
+const RefundResponse = z.object({
+	approved: z.boolean(),
+	notes: z.string().optional(),
+});
+
+// ─── Build-time config the graph nodes need ────────────────────────
+
+export interface BuildGraphOptions {
+	awaithumans: {
+		serverUrl: string;
+		apiKey: string;
+		callbackBase: string; // e.g. "http://localhost:8765"
+	};
+	autoApproveThresholdUsd: number;
+}
+
+// ─── Nodes ──────────────────────────────────────────────────────────
+
+function makeCheckPolicy(opts: BuildGraphOptions) {
+	return async function checkPolicy(
+		state: RefundStateType,
+	): Promise<Partial<RefundStateType>> {
+		// Trivial policy: refunds under the threshold auto-approve. Real
+		// systems would do KYC, fraud-score, etc. — the point is just to
+		// show that NOT every path goes through the human.
+		const auto = state.amountUsd < opts.autoApproveThresholdUsd;
+		console.log(
+			`[node:checkPolicy] amount=$${state.amountUsd} threshold=$${opts.autoApproveThresholdUsd} → auto=${auto}`,
+		);
+		return { autoApproved: auto };
+	};
+}
+
+function makeHumanReview(opts: BuildGraphOptions, threadId: () => string) {
+	return async function humanReview(
+		state: RefundStateType,
+	): Promise<Partial<RefundStateType>> {
+		// Encode the thread id in the callback URL so the webhook
+		// handler in app.ts knows which graph instance to resume. The
+		// thread id changes per kickoff — we read it from a closure
+		// since LangGraph nodes don't have direct access to the
+		// runnable config in all node signatures.
+		const callbackUrl = `${opts.awaithumans.callbackBase.replace(
+			/\/$/,
+			"",
+		)}/awaithumans/cb?thread=${encodeURIComponent(threadId())}`;
+
+		// THIS is the line. First run: throws GraphInterrupt; graph
+		// pauses. Caller catches at .invoke() boundary and returns to
+		// the user. On resume (graph re-invoked with Command{resume}),
+		// the same line returns the validated decision.
+		//
+		// `idempotencyKey` includes the thread id so two graph runs
+		// with the same payload don't collide on the awaithumans
+		// server's per-key uniqueness. Without this, replaying the
+		// "$250 refund for cus_demo" demo a second time would get
+		// back the FIRST run's task (with its stale callback_url
+		// pointing at the previous thread) and the webhook would
+		// resume the wrong graph. The default content-hash key is
+		// fine for one-off runs but not for HITL across threads.
+		const decision = await awaitHuman({
+			task: `Approve $${state.amountUsd} refund for ${state.customerId}?`,
+			payloadSchema: RefundPayload,
+			payload: {
+				customerId: state.customerId,
+				amountUsd: state.amountUsd,
+				reason: "Customer reports duplicate charge.",
+			},
+			responseSchema: RefundResponse,
+			timeoutMs: 15 * 60 * 1000,
+			callbackUrl,
+			serverUrl: opts.awaithumans.serverUrl,
+			apiKey: opts.awaithumans.apiKey,
+			idempotencyKey: `langgraph:${threadId()}:humanReview`,
+		});
+
+		console.log(
+			`[node:humanReview] decision approved=${decision.approved} notes=${
+				decision.notes ?? "—"
+			}`,
+		);
+		return {
+			approved: decision.approved,
+			notes: decision.notes,
+		};
+	};
+}
+
+async function autoApproveNode(
+	state: RefundStateType,
+): Promise<Partial<RefundStateType>> {
+	console.log(`[node:autoApprove] $${state.amountUsd} → approved`);
+	return { approved: true, notes: "auto-approved (under threshold)" };
+}
+
+// ─── Graph factory ──────────────────────────────────────────────────
+
+/**
+ * Build a compiled graph wired to a checkpointer. The `threadIdRef`
+ * trick lets the human-review node know which thread it's on without
+ * us having to thread the runnable config through node signatures
+ * by hand — `app.ts` updates the ref before invoking the graph.
+ */
+export function buildRefundGraph(
+	opts: BuildGraphOptions,
+	threadIdRef: { value: string },
+): ReturnType<ReturnType<typeof makeBuilder>["compile"]> {
+	const builder = makeBuilder(opts, () => threadIdRef.value);
+	// MemorySaver is process-local, fine for the demo. Production
+	// would swap in `@langchain/langgraph-checkpoint-sqlite` so the
+	// state survives restarts of the callback receiver.
+	return builder.compile({ checkpointer: new MemorySaver() });
+}
+
+function makeBuilder(opts: BuildGraphOptions, threadId: () => string) {
+	return new StateGraph(RefundState)
+		.addNode("checkPolicy", makeCheckPolicy(opts))
+		.addNode("humanReview", makeHumanReview(opts, threadId))
+		.addNode("autoApprove", autoApproveNode)
+		.addEdge(START, "checkPolicy")
+		.addConditionalEdges("checkPolicy", (state) =>
+			state.autoApproved ? "autoApprove" : "humanReview",
+		)
+		.addEdge("autoApprove", END)
+		.addEdge("humanReview", END);
+}

--- a/examples/langgraph-ts/kickoff.ts
+++ b/examples/langgraph-ts/kickoff.ts
@@ -1,0 +1,80 @@
+/**
+ * Kickoff — start one refund run by hitting the app's /start endpoint.
+ *
+ * In a real system this would be a request from the user's product
+ * surface (e.g. "customer hits 'request refund'"). For the demo it's
+ * a CLI script that:
+ *
+ *   1. POSTs /start to kick off a graph run
+ *   2. If auto-approved: prints the final state and exits
+ *   3. If interrupted: polls /threads/{id} until it sees a final
+ *      state (the human submits via the dashboard, the awaithumans
+ *      webhook fires, the app resumes the graph, and the next poll
+ *      sees the result)
+ *
+ * Usage:
+ *   npm run kickoff -- 250 cus_demo
+ *   npm run kickoff -- 50 cus_small      # auto-approves under threshold
+ */
+
+const APP_URL = process.env.APP_URL ?? "http://localhost:8765";
+const POLL_INTERVAL_MS = 2000;
+const POLL_MAX_TRIES = 240; // 8 minutes — plenty for a demo
+
+async function main(): Promise<void> {
+	const amountUsd = Number(process.argv[2] ?? "250");
+	const customerId = process.argv[3] ?? "cus_demo";
+
+	const startResp = await fetch(`${APP_URL}/start`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ amountUsd, customerId }),
+	});
+	if (!startResp.ok) {
+		console.error(`[kickoff] /start returned ${startResp.status}: ${await startResp.text()}`);
+		process.exit(1);
+	}
+	const start = (await startResp.json()) as {
+		threadId: string;
+		status: "completed" | "interrupted";
+		state?: unknown;
+		interrupts?: unknown[];
+	};
+
+	if (start.status === "completed") {
+		console.log("[kickoff] result:", JSON.stringify(start.state, null, 2));
+		return;
+	}
+
+	console.log(`[kickoff] thread=${start.threadId} paused — awaiting human`);
+	console.log("[kickoff] interrupt payload:");
+	console.log(JSON.stringify(start.interrupts, null, 2));
+
+	for (let i = 0; i < POLL_MAX_TRIES; i++) {
+		await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+		const r = await fetch(`${APP_URL}/threads/${start.threadId}`);
+		if (!r.ok) {
+			console.error(`[kickoff] poll ${r.status}`);
+			continue;
+		}
+		const s = (await r.json()) as {
+			values?: { approved?: boolean; notes?: string };
+			interrupts?: unknown[];
+		};
+		// "Done" = no pending interrupt and `approved` is set.
+		if (
+			(!s.interrupts || s.interrupts.length === 0) &&
+			s.values?.approved !== undefined
+		) {
+			console.log("[kickoff] result:", JSON.stringify(s.values, null, 2));
+			return;
+		}
+	}
+	console.error("[kickoff] timed out waiting for human");
+	process.exit(1);
+}
+
+main().catch((err) => {
+	console.error("[kickoff] failed:", err);
+	process.exit(1);
+});

--- a/examples/langgraph-ts/package-lock.json
+++ b/examples/langgraph-ts/package-lock.json
@@ -1,0 +1,1085 @@
+{
+  "name": "awaithumans-langgraph-ts",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "awaithumans-langgraph-ts",
+      "version": "0.0.0",
+      "dependencies": {
+        "@hono/node-server": "^1.13.0",
+        "@langchain/core": "^0.3.0",
+        "@langchain/langgraph": "^0.2.0",
+        "awaithumans": "file:../../packages/typescript-sdk",
+        "hono": "^4.6.0",
+        "zod": "^3.23.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.7.0"
+      }
+    },
+    "../../packages/typescript-sdk": {
+      "name": "awaithumans",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.23.0",
+        "zod-to-json-schema": "^3.23.0"
+      },
+      "bin": {
+        "awaithumans": "bin/awaithumans.mjs"
+      },
+      "devDependencies": {
+        "@langchain/langgraph": "^0.2.0",
+        "@temporalio/client": "^1.0.0",
+        "@temporalio/workflow": "^1.0.0",
+        "typescript": "^5.7.0",
+        "vitest": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@langchain/langgraph": "^0.2.0",
+        "@temporalio/client": "^1.0.0",
+        "@temporalio/workflow": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@langchain/langgraph": {
+          "optional": true
+        },
+        "@temporalio/client": {
+          "optional": true
+        },
+        "@temporalio/workflow": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@langchain/core": {
+      "version": "0.3.80",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.80.tgz",
+      "integrity": "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.0.2",
+        "ansi-styles": "^5.0.0",
+        "camelcase": "6",
+        "decamelize": "1.2.0",
+        "js-tiktoken": "^1.0.12",
+        "langsmith": "^0.3.67",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
+        "p-retry": "4",
+        "uuid": "^10.0.0",
+        "zod": "^3.25.32",
+        "zod-to-json-schema": "^3.22.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@langchain/langgraph": {
+      "version": "0.2.74",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-0.2.74.tgz",
+      "integrity": "sha512-oHpEi5sTZTPaeZX1UnzfM2OAJ21QGQrwReTV6+QnX7h8nDCBzhtipAw1cK616S+X8zpcVOjgOtJuaJhXa4mN8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/langgraph-checkpoint": "~0.0.17",
+        "@langchain/langgraph-sdk": "~0.0.32",
+        "uuid": "^10.0.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": ">=0.2.36 <0.3.0 || >=0.3.40 < 0.4.0",
+        "zod-to-json-schema": "^3.x"
+      },
+      "peerDependenciesMeta": {
+        "zod-to-json-schema": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@langchain/langgraph-checkpoint": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-0.0.18.tgz",
+      "integrity": "sha512-IS7zJj36VgY+4pf8ZjsVuUWef7oTwt1y9ylvwu0aLuOn1d0fg05Om9DLm3v2GZ2Df6bhLV1kfWAM0IAl9O5rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": ">=0.2.31 <0.4.0"
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk": {
+      "version": "0.0.112",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-0.0.112.tgz",
+      "integrity": "sha512-/9W5HSWCqYgwma6EoOspL4BGYxGxeJP6lIquPSF4FA0JlKopaUv58ucZC3vAgdJyCgg6sorCIV/qg7SGpEcCLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "p-queue": "^6.6.2",
+        "p-retry": "4",
+        "uuid": "^9.0.0"
+      },
+      "peerDependencies": {
+        "@langchain/core": ">=0.2.31 <0.4.0",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@langchain/core": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.40",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.40.tgz",
+      "integrity": "sha512-xxx6M2IpSTnnKcR0cMvIiohkiCx20/oRPtWGbenFygKCGl3zqUzdNjQ/1V4solq1LU+dgv0nQzeGOuqkqZGg0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "license": "MIT"
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/awaithumans": {
+      "resolved": "../../packages/typescript-sdk",
+      "link": true
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/console-table-printer": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.15.0.tgz",
+      "integrity": "sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==",
+      "license": "MIT",
+      "dependencies": {
+        "simple-wcswidth": "^1.1.2"
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      }
+    },
+    "node_modules/langsmith": {
+      "version": "0.3.87",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.87.tgz",
+      "integrity": "sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "^10.0.0",
+        "chalk": "^4.1.2",
+        "console-table-printer": "^2.12.1",
+        "p-queue": "^6.6.2",
+        "semver": "^7.6.3",
+        "uuid": "^10.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "*",
+        "@opentelemetry/exporter-trace-otlp-proto": "*",
+        "@opentelemetry/sdk-trace-base": "*",
+        "openai": "*"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-wcswidth": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
+      "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/examples/langgraph-ts/package.json
+++ b/examples/langgraph-ts/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "awaithumans-langgraph-ts",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "app": "tsx app.ts",
+    "kickoff": "tsx kickoff.ts"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.13.0",
+    "@langchain/core": "^0.3.0",
+    "@langchain/langgraph": "^0.2.0",
+    "awaithumans": "file:../../packages/typescript-sdk",
+    "hono": "^4.6.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/langgraph-ts/tsconfig.json
+++ b/examples/langgraph-ts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["*.ts"]
+}

--- a/packages/typescript-sdk/src/adapters/langgraph/index.ts
+++ b/packages/typescript-sdk/src/adapters/langgraph/index.ts
@@ -1,53 +1,506 @@
 /**
  * LangGraph adapter — interrupt/resume durable HITL.
  *
- * @example
+ * Two halves, deployed in two different processes (or two paths inside
+ * one process):
+ *
+ *   1. **Inside a graph node** — call `awaitHuman(...)` from this
+ *      module. We POST the task to the awaithumans server, then call
+ *      `interrupt(...)` from `@langchain/langgraph`. The graph throws
+ *      a `GraphInterrupt`; the caller (your application) catches that
+ *      at the `graph.invoke()` boundary, persists nothing of its own
+ *      (LangGraph's checkpointer already saved state), and returns to
+ *      its event loop. The process can crash and the state survives.
+ *
+ *   2. **Inside the user's web server** — `createLangGraphCallbackHandler`
+ *      returns a framework-agnostic handler. It verifies the HMAC,
+ *      extracts the thread id from the request URL (which the
+ *      workflow encoded into `callbackUrl` when it called awaitHuman),
+ *      and re-invokes the graph with `new Command({resume})`. The
+ *      replayed `interrupt(...)` returns the response and the node
+ *      continues like nothing happened.
+ *
+ * Mirrors `awaithumans.adapters.langgraph` (Python). Wire format
+ * matches the Temporal adapter so a single awaithumans server can
+ * back any mix of frameworks.
+ *
+ * @example Graph-side
  * ```ts
  * import { awaitHuman } from "awaithumans/langgraph";
+ * import { z } from "zod";
  *
- * // Inside a LangGraph node:
- * const result = await awaitHuman({
- *   task: "Approve this KYC?",
- *   payloadSchema: KYCPayload,
- *   payload: kycData,
- *   responseSchema: KYCResponse,
- *   timeoutMs: 15 * 60 * 1000,
+ * async function approveNode(state: RefundState, config: RunnableConfig) {
+ *   const decision = await awaitHuman({
+ *     task: "Approve refund?",
+ *     payloadSchema: z.object({ amount: z.number() }),
+ *     payload: { amount: state.amount },
+ *     responseSchema: z.object({ approved: z.boolean() }),
+ *     timeoutMs: 15 * 60 * 1000,
+ *     callbackUrl:
+ *       "https://my-app.com/awaithumans/cb?thread=" +
+ *       config.configurable!.thread_id,
+ *     serverUrl: "http://localhost:3001",
+ *     apiKey: process.env.AWAITHUMANS_ADMIN_API_TOKEN,
+ *   });
+ *   return { decision: decision.approved };
+ * }
+ * ```
+ *
+ * @example Callback-side (in your web server)
+ * ```ts
+ * import { Hono } from "hono";
+ * import { createLangGraphCallbackHandler } from "awaithumans/langgraph";
+ *
+ * const app = new Hono();
+ * const handle = createLangGraphCallbackHandler({
+ *   graph,
+ *   payloadKey: process.env.AWAITHUMANS_PAYLOAD_KEY!,
+ * });
+ *
+ * app.post("/awaithumans/cb", async (c) => {
+ *   const thread = c.req.query("thread");
+ *   if (!thread) return c.text("missing thread", 400);
+ *   const body = await c.req.arrayBuffer();
+ *   const sig = c.req.header("x-awaithumans-signature");
+ *   const status = await handle({ threadId: thread, body, signatureHeader: sig });
+ *   return c.text(status === 200 ? "ok" : "bad", status);
  * });
  * ```
  *
- * Requires: npm install @langchain/langgraph
+ * Requires:
+ *   npm install @langchain/langgraph
+ *   (peer dependency — declared as optional in this SDK so the base
+ *    install doesn't pull LangGraph in for users who don't need it.)
  */
 
-import type { AwaitHumanOptions } from "../../types/index.js";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+import {
+	SchemaValidationError,
+	TaskCancelledError,
+	TaskCreateError,
+	TaskTimeoutError,
+	VerificationExhaustedError,
+} from "../../errors.js";
+import { generateIdempotencyKey } from "../../internal/idempotency.js";
+import {
+	serializeAssignTo,
+	serializeVerifierConfig,
+} from "../../internal/wire.js";
+import type { AssignTo, AwaitHumanOptions, VerifierConfig } from "../../types/index.js";
+
+// Idempotency-key prefix — namespace so a content-hash collision
+// across adapters can't accidentally land on the same task. Mirrors
+// `temporal:` in the Temporal adapter.
+const IDEMPOTENCY_PREFIX = "langgraph";
+
+// ─── Graph-side: awaitHuman ─────────────────────────────────────────
+
+export interface AwaitHumanLangGraphOptions<TPayload, TResponse>
+	extends AwaitHumanOptions<TPayload, TResponse> {
+	/**
+	 * Where the awaithumans server should POST the completion webhook.
+	 * Encode the LangGraph thread id in this URL so the callback
+	 * handler can resume the right graph instance:
+	 *   `https://my-app.com/awaithumans/cb?thread=${threadId}`
+	 */
+	callbackUrl: string;
+
+	/**
+	 * Base URL of the awaithumans server. In dev: `http://localhost:3001`.
+	 * Required because nodes can't reach for env vars in a sandboxed
+	 * runtime — pass via your graph state, your runnable config, or
+	 * read once at module load.
+	 */
+	serverUrl: string;
+
+	/** Bearer token for `serverUrl`. Same value the direct-mode SDK reads. */
+	apiKey?: string;
+}
+
+// The interrupt payload shape — what comes out of `interrupt()` when
+// the graph is paused, before resume. The user's web UI / dashboard
+// can read this to render "task X is pending review".
+export interface AwaitHumanInterrupt {
+	taskId: string;
+	idempotencyKey: string;
+	task: string;
+	payload: unknown;
+	callbackUrl: string;
+}
+
+// What the resume value is expected to look like — exactly the shape
+// the awaithumans webhook body has, which is what `dispatchResume`
+// passes through to `Command({resume: ...})` below. Receiving the
+// full payload (not just the response) means the node can disambiguate
+// `completed` vs `timed_out` vs `cancelled` and surface the right
+// typed error.
+export interface CompletionResume {
+	task_id?: string;
+	idempotency_key?: string;
+	status?: string;
+	response?: unknown;
+	completed_at?: string | null;
+	timed_out_at?: string | null;
+	completed_by_email?: string | null;
+	completed_via_channel?: string | null;
+	verification_attempt?: number;
+}
+
+// Static import: the interrupt symbol IS LangGraph's resume protocol.
+// We can't dynamic-import inside a node call (interrupt has to be the
+// EXACT module instance the host runtime uses, like CancellationScope
+// in Temporal — see PR #60 for the analogous lesson there).
+import { interrupt } from "@langchain/langgraph";
 
 /**
- * LangGraph-durable version of awaitHuman.
+ * Awaitable: pause the running graph until a human completes the task.
+ * See module docstring for the architecture.
  *
- * Uses LangGraph interrupt/resume with checkpoint-based durability.
+ * @throws TaskCreateError if the awaithumans server rejects the create call.
+ * @throws TaskTimeoutError if the server reports `timed_out` on resume.
+ * @throws TaskCancelledError if the server reports `cancelled` on resume.
+ * @throws VerificationExhaustedError if the verifier rejected every attempt.
+ * @throws SchemaValidationError if the human's response doesn't match `responseSchema`.
  */
 export async function awaitHuman<TPayload, TResponse>(
-	options: AwaitHumanOptions<TPayload, TResponse>,
+	options: AwaitHumanLangGraphOptions<TPayload, TResponse>,
 ): Promise<TResponse> {
-	// TODO: implement
-	// 1. Create task on the awaithumans server (HTTP POST)
-	// 2. Use langgraph interrupt(taskId) to suspend the graph
-	// 3. Server fires webhook on completion → callback handler resumes graph
-	// 4. Validate response against responseSchema, return typed result
-	// Idempotency key: threadId + nodeId from checkpoint
-	throw new Error("LangGraph adapter not yet implemented.");
+	const idempotencyKey =
+		options.idempotencyKey ??
+		`${IDEMPOTENCY_PREFIX}:${(
+			await generateIdempotencyKey(options.task, options.payload)
+		).slice(0, 32)}`;
+
+	// Create the task on the server FIRST. It's idempotent on the
+	// `idempotency_key` so if this node replays after a checkpoint
+	// restore, the second create returns the same task without
+	// duplicating notifications.
+	//
+	// We do this BEFORE interrupt() so the task is visible to the
+	// human (Slack ping, dashboard, email) immediately. If we put
+	// interrupt() first, the graph would pause before the task even
+	// existed — a tree-falls-in-the-forest race.
+	const payloadJsonSchema = zodToJsonSchema(options.payloadSchema);
+	const responseJsonSchema = zodToJsonSchema(options.responseSchema);
+	const timeoutSeconds = Math.round(options.timeoutMs / 1000);
+
+	const body = {
+		task: options.task,
+		payload: options.payload,
+		payload_schema: payloadJsonSchema,
+		response_schema: responseJsonSchema,
+		form_definition: null,
+		timeout_seconds: timeoutSeconds,
+		idempotency_key: idempotencyKey,
+		assign_to: serializeAssignTo(options.assignTo as AssignTo | undefined),
+		notify: options.notify ?? null,
+		verifier_config: serializeVerifierConfig(
+			options.verifier as VerifierConfig | undefined,
+		),
+		redact_payload: options.redactPayload ?? false,
+		callback_url: options.callbackUrl,
+	};
+
+	const task = await createTaskOnServer({
+		serverUrl: options.serverUrl,
+		apiKey: options.apiKey,
+		body,
+	});
+
+	// `interrupt()` does double duty: on first run it throws a
+	// GraphInterrupt (caller catches at the .invoke boundary, graph
+	// pauses, checkpointer persists state); on resume the same line
+	// returns the value passed via `Command({resume: …})`. So this
+	// "await" actually resolves on the SECOND graph invocation, not
+	// the first.
+	const resumeValue = interrupt<AwaitHumanInterrupt, CompletionResume>({
+		taskId: task.id,
+		idempotencyKey,
+		task: options.task,
+		payload: options.payload,
+		callbackUrl: options.callbackUrl,
+	});
+
+	const status = resumeValue.status;
+	if (status === "completed") {
+		const validated = options.responseSchema.safeParse(resumeValue.response);
+		if (!validated.success) {
+			throw new SchemaValidationError("response", validated.error.message);
+		}
+		return validated.data;
+	}
+	if (status === "timed_out") {
+		throw new TaskTimeoutError(options.task, options.timeoutMs);
+	}
+	if (status === "cancelled") {
+		throw new TaskCancelledError(options.task);
+	}
+	if (status === "verification_exhausted") {
+		throw new VerificationExhaustedError(
+			options.task,
+			resumeValue.verification_attempt ?? 0,
+		);
+	}
+	throw new Error(
+		`LangGraph adapter saw unknown terminal status '${status ?? "<missing>"}' for task '${options.task}'`,
+	);
+}
+
+interface CreateTaskInput {
+	serverUrl: string;
+	apiKey: string | undefined;
+	body: Record<string, unknown>;
+}
+
+interface CreateTaskResult {
+	id: string;
+	idempotencyKey: string;
+}
+
+async function createTaskOnServer(input: CreateTaskInput): Promise<CreateTaskResult> {
+	const headers: Record<string, string> = {
+		"Content-Type": "application/json",
+	};
+	if (input.apiKey) {
+		headers["Authorization"] = `Bearer ${input.apiKey}`;
+	}
+
+	const url = `${input.serverUrl.replace(/\/$/, "")}/api/tasks`;
+	const resp = await fetch(url, {
+		method: "POST",
+		headers,
+		body: JSON.stringify(input.body),
+	});
+
+	if (resp.status !== 200 && resp.status !== 201) {
+		const text = await resp.text();
+		throw new TaskCreateError(resp.status, text);
+	}
+	const data = (await resp.json()) as { id: string; idempotency_key: string };
+	return { id: data.id, idempotencyKey: data.idempotency_key };
+}
+
+// ─── User-web-server-side: createLangGraphCallbackHandler ────────────
+
+/**
+ * Minimal interface satisfied by `CompiledStateGraph` from
+ * `@langchain/langgraph`. Typed structurally so the SDK doesn't pull
+ * the heavy class for users who only call awaitHuman from a node and
+ * never wire up the callback handler — and so tests can pass a fake.
+ */
+export interface LangGraphInvokable {
+	invoke(
+		input: unknown,
+		config?: { configurable?: Record<string, unknown> } & Record<
+			string,
+			unknown
+		>,
+	): Promise<unknown>;
 }
 
 /**
- * Pre-built callback handler for resuming a LangGraph graph.
- *
- * @example
- * ```ts
- * import { createLangGraphCallbackHandler } from "awaithumans/langgraph";
- *
- * app.post("/awaithumans/callback", createLangGraphCallbackHandler(graphClient));
- * ```
+ * Minimal interface for the `Command` constructor we accept. Same
+ * reason as above — structural so callers can pass either the real
+ * `Command` from `@langchain/langgraph` or a wrapper.
  */
-export function createLangGraphCallbackHandler(_graphClient: unknown): unknown {
-	// TODO: implement
-	throw new Error("LangGraph callback handler not yet implemented.");
+export interface CommandConstructorLike {
+	new (params: { resume: unknown }): unknown;
+}
+
+export interface CallbackHandlerOptions {
+	/**
+	 * The compiled graph that runs your application. The handler
+	 * `invoke`s it once per webhook to resume the paused thread.
+	 */
+	graph: LangGraphInvokable;
+
+	/**
+	 * The `Command` class from `@langchain/langgraph`. Pass it in
+	 * directly (`Command`) — we accept it as a parameter so the SDK
+	 * itself doesn't need to import the runtime symbol; that import
+	 * happens inside YOUR app, in YOUR module-resolution tree, which
+	 * sidesteps the dual-package hazard the Temporal adapter ran into.
+	 */
+	command: CommandConstructorLike;
+
+	/**
+	 * The HMAC key the awaithumans server signs webhooks with. Read
+	 * from `AWAITHUMANS_PAYLOAD_KEY` on the server side; receivers
+	 * MUST have the same value. The server uses HKDF-SHA256 with
+	 * salt `b"awaithumans-webhook-v1"` and info `b"v1"` over this
+	 * key to derive the actual signing key — we mirror that derivation
+	 * below.
+	 */
+	payloadKey: string;
+}
+
+export interface HandleCallbackInput {
+	/** The LangGraph thread id to resume. Read from a query param. */
+	threadId: string;
+
+	/** Raw request body bytes — needed for HMAC verification. */
+	body: ArrayBuffer | Uint8Array | string;
+
+	/** The `X-Awaithumans-Signature` header value (or null/undefined). */
+	signatureHeader: string | null | undefined;
+}
+
+export interface HandleCallbackResult {
+	/** HTTP-status-shaped outcome — let the caller wire it to their framework. */
+	status: number;
+	error?: string;
+}
+
+/**
+ * Build a framework-agnostic webhook handler closed over your graph.
+ * Wrap the returned function in a Hono / Express / Fastify route.
+ *
+ * The handler:
+ *   1. Verifies the HMAC signature against `payloadKey`. Bad sig → 401.
+ *   2. Parses the body. Bad JSON → 400.
+ *   3. Calls `graph.invoke(new Command({resume: <body>}), {configurable:{thread_id}})`.
+ *   4. Returns 200 on success. Any thrown error → 500.
+ *
+ * We pass the FULL webhook body as the resume value (not just
+ * `response`) so the node can branch on `status` and surface the
+ * right typed error for timed-out / cancelled / verification-exhausted.
+ */
+export function createLangGraphCallbackHandler(
+	options: CallbackHandlerOptions,
+): (input: HandleCallbackInput) => Promise<HandleCallbackResult> {
+	return async function handleCallback(
+		input: HandleCallbackInput,
+	): Promise<HandleCallbackResult> {
+		const bodyBytes = toUint8Array(input.body);
+		const ok = await verifySignature({
+			body: bodyBytes,
+			signatureHeader: input.signatureHeader,
+			payloadKey: options.payloadKey,
+		});
+		if (!ok) {
+			return { status: 401, error: "Invalid awaithumans webhook signature." };
+		}
+
+		let payload: CompletionResume;
+		try {
+			payload = JSON.parse(new TextDecoder().decode(bodyBytes));
+		} catch (cause) {
+			return {
+				status: 400,
+				error: `Webhook body is not JSON: ${(cause as Error).message}`,
+			};
+		}
+
+		try {
+			const command = new options.command({ resume: payload });
+			await options.graph.invoke(command, {
+				configurable: { thread_id: input.threadId },
+			});
+		} catch (cause) {
+			return {
+				status: 500,
+				error: `Graph resume failed: ${(cause as Error).message}`,
+			};
+		}
+
+		return { status: 200 };
+	};
+}
+
+// ─── HMAC verification (matches the Python server's HKDF derivation) ─
+//
+// Identical to the Temporal adapter's verify path — kept inline rather
+// than imported so the langgraph subpath stays a self-contained leaf.
+// If we grow a third adapter, this should move to `internal/webhook.ts`.
+
+interface VerifySignatureInput {
+	body: Uint8Array;
+	signatureHeader: string | null | undefined;
+	payloadKey: string;
+}
+
+async function verifySignature(input: VerifySignatureInput): Promise<boolean> {
+	if (!input.signatureHeader) return false;
+	const expected = await signBody(input.body, input.payloadKey);
+	const supplied = input.signatureHeader.startsWith("sha256=")
+		? input.signatureHeader
+		: `sha256=${input.signatureHeader}`;
+	return constantTimeEqual(expected, supplied);
+}
+
+/**
+ * Compute the `sha256=<hex>` signature over `body`. Public so users
+ * who want to drive the dispatch loop themselves can verify the same
+ * way the SDK helper does.
+ */
+export async function signBody(
+	body: Uint8Array,
+	payloadKey: string,
+): Promise<string> {
+	const hkdfKey = await deriveHmacKey(payloadKey);
+	const cryptoKey = await crypto.subtle.importKey(
+		"raw",
+		hkdfKey as unknown as BufferSource,
+		{ name: "HMAC", hash: "SHA-256" },
+		false,
+		["sign"],
+	);
+	const sig = await crypto.subtle.sign(
+		"HMAC",
+		cryptoKey,
+		body as unknown as BufferSource,
+	);
+	return `sha256=${bytesToHex(new Uint8Array(sig))}`;
+}
+
+async function deriveHmacKey(payloadKey: string): Promise<Uint8Array> {
+	const enc = new TextEncoder();
+	const rawIkm = base64UrlDecode(payloadKey);
+	const ikmRaw = await crypto.subtle.importKey(
+		"raw",
+		rawIkm as unknown as BufferSource,
+		{ name: "HKDF" },
+		false,
+		["deriveBits"],
+	);
+	const derived = await crypto.subtle.deriveBits(
+		{
+			name: "HKDF",
+			hash: "SHA-256",
+			salt: enc.encode("awaithumans-webhook-v1") as unknown as BufferSource,
+			info: enc.encode("v1") as unknown as BufferSource,
+		},
+		ikmRaw,
+		32 * 8, // 32 bytes
+	);
+	return new Uint8Array(derived);
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+	if (a.length !== b.length) return false;
+	let result = 0;
+	for (let i = 0; i < a.length; i++) {
+		result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+	}
+	return result === 0;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+	return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function base64UrlDecode(s: string): Uint8Array {
+	const padded = s + "=".repeat((4 - (s.length % 4)) % 4);
+	const normalized = padded.replace(/-/g, "+").replace(/_/g, "/");
+	const binary = atob(normalized);
+	const bytes = new Uint8Array(binary.length);
+	for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+	return bytes;
+}
+
+function toUint8Array(body: ArrayBuffer | Uint8Array | string): Uint8Array {
+	if (body instanceof Uint8Array) return body;
+	if (body instanceof ArrayBuffer) return new Uint8Array(body);
+	return new TextEncoder().encode(body);
 }


### PR DESCRIPTION
## Summary

The TS LangGraph adapter shipped in #57 was a stub. This wires up the real `awaitHuman` and `createLangGraphCallbackHandler`, plus a runnable example (`examples/langgraph-ts/`) that mirrors `temporal-ts/` end-to-end.

```
[node]
awaitHuman()
  → POST /api/tasks            (creates task on awaithumans)
  → interrupt({taskId, ...})   (graph pauses; checkpointer saves state)
                                  ⏸
                                  human submits in dashboard
                                  awaithumans webhook fires (with retry queue from #61)
                                  ⏵
              POST /awaithumans/cb?thread=…
                → handler verifies HMAC
                → graph.invoke(new Command({resume: <body>}))
                → interrupt() returns the resume value
                → response validated against Zod responseSchema
[node continues with typed decision]
```

## What's in the adapter
- **`awaitHuman(...)`** — creates the task, calls `interrupt(...)`, validates the resume value, throws `TaskTimeoutError` / `TaskCancelledError` / `VerificationExhaustedError` / `SchemaValidationError` matching the temporal adapter's surface.
- **`createLangGraphCallbackHandler({graph, command, payloadKey})`** — framework-agnostic. Returns `(input) => Promise<{status, error?}>` so any HTTP framework (Hono, Express, Fastify) can wrap it in three lines.
- **`signBody`** exported for users who want to drive verification by hand.

## Two design decisions
1. **Resume value is the full webhook body**, not just `response`. The node branches on `status` to surface the right typed error for `timed_out` / `cancelled` / `verification_exhausted` — same mental model as the temporal adapter.
2. **`Command` is injected, not imported.** Sidesteps the dual-package hazard that bit the temporal adapter (#60) — only the user's copy of `@langchain/langgraph` is ever loaded.

## Example shape
Single Hono process with three routes:
- `POST /start` — kicks off a refund-approval graph run
- `POST /awaithumans/cb` — receives webhook, resumes matching thread
- `GET /threads/:id` — kickoff client polls for final state

## E2E verification
- [x] Auto-approve path (amount < $100): graph completes in one `.invoke()`, never touches awaithumans.
- [x] Human-review path (amount $250):
  - `checkPolicy` → routes to `humanReview` → `awaitHuman` → task created on server (id captured)
  - Graph reports `status: interrupted` with the task ID and callback URL
  - Admin completes task via `/api/tasks/{id}/complete`
  - Webhook delivery row reaches `succeeded` (HTTP 200)
  - App logs `[node:humanReview] decision approved=true notes=…`
  - Final state via `GET /threads/:id`: `{customerId, amountUsd, autoApproved: false, approved: true, notes: "..."}`

## Risk note
LangGraph threads need a thread-scoped idempotency key. The SDK's default (`hash(task+payload)`) collides across threads, which surfaced during e2e testing — a second run with the same payload re-fetched the first run's task and routed the webhook to a stale thread. The example passes `idempotencyKey: \`langgraph:\${threadId}:humanReview\`` and documents this in `graph.ts`. We may want to expose a `langgraph-friendly` default (read thread ID from `getCurrentTaskInput` / `RunnableConfig`) in a follow-up, but for now the explicit-key path is correct and well-documented.