### PR TITLE
feat(langgraph-py): implement Python LangGraph adapter + example

### DIFF
--- a/examples/langgraph-py/README.md
+++ b/examples/langgraph-py/README.md
@@ -1,0 +1,106 @@
+# langgraph-py — Python LangGraph + awaithumans
+
+A refund-approval graph with one human-in-the-loop interrupt. Mirrors
+`examples/langgraph-ts/` in Python: same shape, same routes, same
+end-to-end flow.
+
+## What you'll see
+
+```
+[customer]
+   │
+   ▼
+[POST /start]           ─── 250  ──► [graph.ainvoke]
+                                       └─► check_policy → human_review
+                                                          │
+                                                          │  await_human()
+                                                          │  POSTs to awaithumans
+                                                          │  → interrupt() throws
+                                                          │
+                                       ◄── interrupted ──┘
+                                       (graph paused;
+                                        state in checkpointer)
+
+[human approves in dashboard]
+   │
+   ▼
+[awaithumans server fires webhook]
+   │
+   ▼
+[POST /awaithumans/cb?thread=…]
+   │
+   ▼
+[handler verifies HMAC]
+   │
+   ▼
+[graph.ainvoke(Command(resume=…))]
+   │
+   ▼
+[human_review node returns]
+   │
+   ▼
+[final state visible via /threads/:id]
+```
+
+## Prerequisites
+
+- Python 3.10+
+- The awaithumans dev server running locally (`awaithumans dev`)
+
+## Run it
+
+In three terminals:
+
+```bash
+# Terminal 1 — awaithumans server
+awaithumans dev
+
+# Terminal 2 — this example's app (graph + checkpointer + callback)
+cd examples/langgraph-py
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+export AWAITHUMANS_PAYLOAD_KEY=$(cat /tmp/<your-dev-cwd>/.awaithumans/payload.key)
+uvicorn app:app --host 0.0.0.0 --port 8765
+
+# Terminal 3 — kick off a run
+cd examples/langgraph-py
+source .venv/bin/activate
+python kickoff.py 250 cus_demo    # over threshold → human review
+# or
+python kickoff.py 50 cus_small    # under threshold → auto-approves
+```
+
+Then approve in the awaithumans dashboard (http://localhost:3001) or
+via `curl -X POST .../api/tasks/{id}/complete`.
+
+## How the pieces fit
+
+- **`graph.py`** — defines `RefundState`, three nodes, a `MemorySaver`
+  checkpointer, and a conditional edge. `human_review` calls
+  `await_human` from `awaithumans.adapters.langgraph` — that's the
+  whole HITL integration.
+
+- **`app.py`** — single FastAPI process. Owns the compiled graph (so
+  `/start` and `/awaithumans/cb` share state via the checkpointer),
+  exposes `POST /start` to kick off, `POST /awaithumans/cb` to receive
+  the webhook, and `GET /threads/:id` for the kickoff client to poll.
+
+- **`kickoff.py`** — POSTs `/start`, then polls `/threads/:id` until
+  the graph reports a final state.
+
+## Production notes
+
+- **Checkpointer**: this demo uses `MemorySaver` (in-process, lost on
+  restart). Production should swap in `langgraph.checkpoint.sqlite`
+  or `langgraph.checkpoint.postgres` so an interrupted graph survives
+  a redeploy.
+
+- **Webhook reachability**: the awaithumans server has to reach
+  `${callback_base}/awaithumans/cb`. For local dev with `awaithumans dev`
+  on the same machine that's `http://localhost:8765`. For a remote
+  awaithumans server pointing at a local app, expose this process via
+  ngrok and set `AWAITHUMANS_CALLBACK_BASE=https://<ngrok>.io`.
+
+- **Webhook delivery durability**: the awaithumans server retries
+  webhook POSTs with backoff for up to 3 days, so a brief app outage
+  won't lose the resume signal.

--- a/examples/langgraph-py/app.py
+++ b/examples/langgraph-py/app.py
@@ -1,0 +1,200 @@
+"""Application — graph + checkpointer + HTTP surface, all in one process.
+
+Mirrors `examples/langgraph-ts/app.ts`. ONE FastAPI process owns the
+graph, the checkpointer, and the awaithumans webhook receiver. A node
+calling `await_human` ↔ a webhook that comes back later ↔ a
+`Command(resume=…)` invocation are all the same process, the same
+compiled graph, the same checkpointer.
+
+Two routes:
+
+  POST /start         {customer_id, amount_usd}      → kicks off a run
+                                                       returns thread id +
+                                                       interrupt info
+                                                       (or final state if
+                                                       auto-approved)
+
+  POST /awaithumans/cb?thread=<thread_id>             → awaithumans webhook;
+                                                       resumes the graph
+
+Run with:
+    AWAITHUMANS_PAYLOAD_KEY=$(cat <discovery>/payload.key) \\
+        uvicorn app:app --host 0.0.0.0 --port 8765
+
+Then in another terminal:
+    python kickoff.py 250 cus_demo
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+from fastapi import FastAPI, HTTPException, Request
+from pydantic import BaseModel
+
+from awaithumans.adapters.langgraph import dispatch_resume
+from awaithumans.utils.discovery import resolve_admin_token, resolve_server_url
+
+from graph import GraphConfig, build_refund_graph
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("examples.langgraph_py.app")
+
+PORT = int(os.environ.get("PORT", "8765"))
+CALLBACK_BASE = os.environ.get(
+    "AWAITHUMANS_CALLBACK_BASE", f"http://localhost:{PORT}"
+)
+
+
+# Module-level holders. We can't construct the graph at import time
+# because we need to resolve the awaithumans config asynchronously
+# (discovery file lookups are async) — so the lifespan populates them.
+_graph: object | None = None
+_thread_id_ref: list[str] = ["<unset>"]
+_payload_key: str | None = None
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    global _graph, _payload_key
+
+    _payload_key = os.environ.get("AWAITHUMANS_PAYLOAD_KEY")
+    if not _payload_key:
+        raise RuntimeError(
+            "AWAITHUMANS_PAYLOAD_KEY is required.\n"
+            "  Dev: export AWAITHUMANS_PAYLOAD_KEY="
+            "$(cat .awaithumans/payload.key) "
+            "(from wherever you ran `awaithumans dev`)."
+        )
+
+    server_url = resolve_server_url()
+    api_key = resolve_admin_token()
+    if not api_key:
+        raise RuntimeError(
+            "Couldn't find an admin token. Run `awaithumans dev` "
+            "(writes ~/.awaithumans-dev.json) or export "
+            "AWAITHUMANS_ADMIN_API_TOKEN."
+        )
+
+    cfg = GraphConfig(
+        awaithumans_server_url=server_url,
+        awaithumans_api_key=api_key,
+        callback_base=CALLBACK_BASE,
+        auto_approve_threshold_usd=100.0,
+    )
+    _graph = build_refund_graph(cfg, _thread_id_ref)
+    logger.info("[app] graph + callback at http://localhost:%s", PORT)
+    logger.info("[app] awaithumans server: %s", server_url)
+    logger.info("[app] callback base: %s", CALLBACK_BASE)
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+class StartRequest(BaseModel):
+    customer_id: str
+    amount_usd: float
+
+
+@app.post("/start")
+async def start(req: StartRequest) -> dict:
+    """Kicks off a refund run. Returns either the final state (if
+    auto-approved) or the interrupt payload (if a human is needed)."""
+    if _graph is None:
+        raise HTTPException(status_code=503, detail="Graph not ready.")
+
+    thread_id = f"refund-{uuid.uuid4()}"
+    _thread_id_ref[0] = thread_id
+
+    config = {"configurable": {"thread_id": thread_id}}
+    initial_state = {"customer_id": req.customer_id, "amount_usd": req.amount_usd}
+    result = await _graph.ainvoke(initial_state, config=config)
+
+    # Same shape as the TS example: `.ainvoke()` returns the committed
+    # state values, NOT a `__interrupt__` field. To know if we paused,
+    # ask the checkpointer via `aget_state`.
+    state = await _graph.aget_state(config)
+    interrupts: list[object] = []
+    for task in state.tasks:
+        interrupts.extend(task.interrupts or [])
+
+    if interrupts:
+        logger.info("[start] graph paused thread=%s", thread_id)
+        return {
+            "thread_id": thread_id,
+            "status": "interrupted",
+            # Pydantic-friendly serialisation of the Interrupt objects.
+            "interrupts": [
+                {
+                    "value": getattr(i, "value", None),
+                    "ns": list(getattr(i, "ns", []) or []),
+                    "resumable": getattr(i, "resumable", True),
+                }
+                for i in interrupts
+            ],
+        }
+
+    logger.info(
+        "[start] graph finished thread=%s approved=%s",
+        thread_id,
+        result.get("approved"),
+    )
+    return {"thread_id": thread_id, "status": "completed", "state": result}
+
+
+@app.post("/awaithumans/cb")
+async def awaithumans_callback(request: Request, thread: str) -> dict:
+    """Receives the awaithumans webhook. Verifies HMAC, resumes graph."""
+    if _graph is None or _payload_key is None:
+        raise HTTPException(status_code=503, detail="Graph not ready.")
+
+    body = await request.body()
+    signature = request.headers.get("x-awaithumans-signature")
+
+    # Setting the ref BEFORE the resume isn't strictly needed — after
+    # this resume the human_review node won't run again on this
+    # thread. But if the graph had MULTIPLE interrupts on the same
+    # thread, the next one would need this set.
+    _thread_id_ref[0] = thread
+
+    try:
+        await dispatch_resume(
+            graph=_graph,
+            thread_id=thread,
+            body=body,
+            signature_header=signature,
+        )
+    except PermissionError as exc:
+        logger.warning("Rejected webhook with bad signature: %s", exc)
+        raise HTTPException(status_code=401, detail=str(exc)) from exc
+    except ValueError as exc:
+        logger.warning("Rejected malformed webhook: %s", exc)
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    logger.info("[cb] thread=%s resumed", thread)
+
+    state = await _graph.aget_state({"configurable": {"thread_id": thread}})
+    return {"ok": True, "state": state.values}
+
+
+@app.get("/threads/{thread_id}")
+async def get_thread(thread_id: str) -> dict:
+    """Lets the kickoff client poll for completion."""
+    if _graph is None:
+        raise HTTPException(status_code=503, detail="Graph not ready.")
+    state = await _graph.aget_state({"configurable": {"thread_id": thread_id}})
+    interrupts: list[object] = []
+    for task in state.tasks:
+        interrupts.extend(task.interrupts or [])
+    return {
+        "thread_id": thread_id,
+        "values": state.values,
+        "interrupts": [
+            {"value": getattr(i, "value", None)} for i in interrupts
+        ],
+    }

--- a/examples/langgraph-py/graph.py
+++ b/examples/langgraph-py/graph.py
@@ -1,0 +1,189 @@
+"""Refund-approval graph — three nodes, one human-in-the-loop interrupt.
+
+The shape:
+
+    [start] → check_policy → (auto_approve) → end
+                          ↘ human_review ↗
+                            (calls await_human)
+                            (graph pauses here on first run;
+                             resumes from the same line on Command(resume))
+
+`await_human` from `awaithumans.adapters.langgraph` is a single
+function call inside `human_review`. When it runs the first time, it
+POSTs the task to the awaithumans server and then calls LangGraph's
+`interrupt(...)`. That throws a GraphInterrupt — `graph.ainvoke()`
+returns to the caller (our app.py) and the application returns to
+its event loop. Later, when the awaithumans webhook fires, the
+callback handler re-invokes the graph with `Command(resume=…)`, the
+node replays, and the SAME `await await_human(...)` line returns
+the validated decision.
+
+That's the whole story: one function, two phases, durable in
+between because LangGraph's checkpointer holds the state.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated, TypedDict
+
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import END, START, StateGraph
+from pydantic import BaseModel
+
+from awaithumans.adapters.langgraph import await_human
+
+logger = logging.getLogger("examples.langgraph_py.graph")
+
+
+# ─── State ──────────────────────────────────────────────────────────
+
+
+class RefundState(TypedDict, total=False):
+    """LangGraph state — keys merged across nodes (latest write wins).
+
+    `total=False` so partial updates are valid; the type checker
+    won't complain when a node only sets a few fields."""
+
+    customer_id: str
+    amount_usd: float
+    auto_approved: bool
+    approved: bool
+    notes: str
+
+
+# ─── Schemas (shared between adapter call + UI rendering) ──────────
+
+
+class RefundPayload(BaseModel):
+    customer_id: str
+    amount_usd: float
+    reason: str
+
+
+class RefundResponse(BaseModel):
+    approved: bool
+    notes: str = ""
+
+
+# ─── Build-time config ─────────────────────────────────────────────
+
+
+class GraphConfig(BaseModel):
+    """Everything the nodes need that's NOT part of the per-run state.
+
+    Captured by closures inside `build_refund_graph` so node functions
+    don't have to thread it through the LangGraph runtime config."""
+
+    awaithumans_server_url: str
+    awaithumans_api_key: str
+    callback_base: str          # e.g. "http://localhost:8765"
+    auto_approve_threshold_usd: float
+
+
+# ─── Nodes ─────────────────────────────────────────────────────────
+
+
+def _make_check_policy(cfg: GraphConfig):
+    async def check_policy(state: RefundState) -> RefundState:
+        # Trivial policy: under threshold = auto-approve. Real systems
+        # would do KYC, fraud-score, etc. — the point is just to show
+        # that NOT every path goes through the human.
+        amount = state.get("amount_usd", 0.0)
+        auto = amount < cfg.auto_approve_threshold_usd
+        logger.info(
+            "[node:check_policy] amount=$%s threshold=$%s → auto=%s",
+            amount,
+            cfg.auto_approve_threshold_usd,
+            auto,
+        )
+        return {"auto_approved": auto}
+
+    return check_policy
+
+
+def _make_human_review(cfg: GraphConfig, thread_id_ref: list[str]):
+    """Closure-bound node — `thread_id_ref[0]` is updated by app.py
+    before each `.ainvoke()` so the node knows which thread it's on.
+
+    A more idiomatic approach would thread `RunnableConfig` through
+    the node signature; keeping this simple for the example."""
+
+    async def human_review(state: RefundState) -> RefundState:
+        thread_id = thread_id_ref[0]
+        callback_url = (
+            f"{cfg.callback_base.rstrip('/')}/awaithumans/cb?thread={thread_id}"
+        )
+
+        # THIS is the line. First run: throws GraphInterrupt; graph
+        # pauses. Caller catches at .ainvoke() boundary and returns
+        # to the user. On resume (graph re-invoked with
+        # Command(resume=…)), the same call returns the validated
+        # decision.
+        #
+        # idempotency_key is thread-scoped so two graph runs with
+        # identical payload don't collide on the awaithumans server's
+        # per-key uniqueness. Without this, replaying the demo a
+        # second time would get back the FIRST run's task (with a
+        # stale callback_url) and the webhook would resume the wrong
+        # thread.
+        decision = await await_human(
+            task=f"Approve ${state['amount_usd']} refund "
+                 f"for {state['customer_id']}?",
+            payload_schema=RefundPayload,
+            payload=RefundPayload(
+                customer_id=state["customer_id"],
+                amount_usd=state["amount_usd"],
+                reason="Customer reports duplicate charge.",
+            ),
+            response_schema=RefundResponse,
+            timeout_seconds=15 * 60,
+            callback_url=callback_url,
+            server_url=cfg.awaithumans_server_url,
+            api_key=cfg.awaithumans_api_key,
+            idempotency_key=f"langgraph:{thread_id}:human_review",
+        )
+
+        logger.info(
+            "[node:human_review] decision approved=%s notes=%s",
+            decision.approved,
+            decision.notes or "—",
+        )
+        return {"approved": decision.approved, "notes": decision.notes}
+
+    return human_review
+
+
+async def auto_approve(state: RefundState) -> RefundState:
+    logger.info("[node:auto_approve] $%s → approved", state["amount_usd"])
+    return {"approved": True, "notes": "auto-approved (under threshold)"}
+
+
+# ─── Graph factory ─────────────────────────────────────────────────
+
+
+def build_refund_graph(cfg: GraphConfig, thread_id_ref: list[str]):
+    """Build a compiled graph wired to a `MemorySaver` checkpointer.
+
+    Returns the compiled graph object. The caller (app.py) holds it
+    for the lifetime of the process — both `/start` (kick off) and
+    `/awaithumans/cb` (resume) invoke this same compiled graph against
+    different thread ids.
+    """
+    builder = (
+        StateGraph(RefundState)
+        .add_node("check_policy", _make_check_policy(cfg))
+        .add_node("human_review", _make_human_review(cfg, thread_id_ref))
+        .add_node("auto_approve", auto_approve)
+        .add_edge(START, "check_policy")
+        .add_conditional_edges(
+            "check_policy",
+            lambda state: "auto_approve" if state.get("auto_approved") else "human_review",
+        )
+        .add_edge("auto_approve", END)
+        .add_edge("human_review", END)
+    )
+    # MemorySaver = process-local checkpointer. Fine for the demo;
+    # production should swap for `langgraph.checkpoint.sqlite.SqliteSaver`
+    # so the state survives restarts of the app process.
+    return builder.compile(checkpointer=MemorySaver())

--- a/examples/langgraph-py/kickoff.py
+++ b/examples/langgraph-py/kickoff.py
@@ -1,0 +1,74 @@
+"""Kickoff — start one refund run by hitting the app's /start endpoint.
+
+In a real system this would be a request from the user's product
+surface (e.g. "customer hits 'request refund'"). For the demo it's
+a CLI script that:
+
+  1. POSTs /start to kick off a graph run
+  2. If auto-approved: prints the final state and exits
+  3. If interrupted: polls /threads/{id} until it sees a final state
+     (the human submits via the dashboard, the awaithumans webhook
+     fires, the app resumes the graph, and the next poll sees the
+     result)
+
+Usage:
+    python kickoff.py 250 cus_demo
+    python kickoff.py 50 cus_small      # auto-approves under threshold
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+
+import httpx
+
+APP_URL = os.environ.get("APP_URL", "http://localhost:8765")
+POLL_INTERVAL_SECONDS = 2.0
+POLL_MAX_TRIES = 240  # 8 minutes — plenty for a demo
+
+
+async def main() -> None:
+    amount_usd = float(sys.argv[1] if len(sys.argv) > 1 else "250")
+    customer_id = sys.argv[2] if len(sys.argv) > 2 else "cus_demo"
+
+    async with httpx.AsyncClient(timeout=10) as client:
+        start_resp = await client.post(
+            f"{APP_URL}/start",
+            json={"customer_id": customer_id, "amount_usd": amount_usd},
+        )
+        if start_resp.status_code >= 400:
+            print(f"[kickoff] /start returned {start_resp.status_code}: "
+                  f"{start_resp.text}")
+            sys.exit(1)
+        start = start_resp.json()
+
+        if start["status"] == "completed":
+            print("[kickoff] result:", json.dumps(start["state"], indent=2))
+            return
+
+        thread_id = start["thread_id"]
+        print(f"[kickoff] thread={thread_id} paused — awaiting human")
+        print("[kickoff] interrupt payload:")
+        print(json.dumps(start["interrupts"], indent=2))
+
+        for _ in range(POLL_MAX_TRIES):
+            await asyncio.sleep(POLL_INTERVAL_SECONDS)
+            r = await client.get(f"{APP_URL}/threads/{thread_id}")
+            if r.status_code >= 400:
+                print(f"[kickoff] poll {r.status_code}")
+                continue
+            s = r.json()
+            # "Done" = no pending interrupt and `approved` is set.
+            if not s.get("interrupts") and s.get("values", {}).get("approved") is not None:
+                print("[kickoff] result:", json.dumps(s["values"], indent=2))
+                return
+
+    print("[kickoff] timed out waiting for human")
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/langgraph-py/requirements.txt
+++ b/examples/langgraph-py/requirements.txt
@@ -1,0 +1,20 @@
+# Run from the repo root with:
+#   pip install -r examples/langgraph-py/requirements.txt
+
+# Local dev: install the in-tree adapter (with [langgraph] extra) from
+# this checkout. Pre-PyPI this gets you the LangGraph adapter import.
+# Post-launch users can replace with `awaithumans[langgraph]>=0.1.0`.
+#
+# We also pull [server] because dispatch_resume reuses the canonical
+# HMAC verification from awaithumans.server.services.webhook_dispatch
+# (same trade-off the Temporal adapter makes — see adapter docstring).
+-e ../../packages/python[langgraph,server]
+
+# FastAPI + uvicorn for the app process. The awaithumans package
+# already depends on these via [server], but listing them explicitly
+# documents what this process actually runs on.
+fastapi>=0.115.0
+uvicorn[standard]>=0.32.0
+
+# Pin pydantic >= 2 for BaseModel.model_dump etc.
+pydantic>=2.0.0

--- a/packages/python/awaithumans/adapters/langgraph/__init__.py
+++ b/packages/python/awaithumans/adapters/langgraph/__init__.py
@@ -1,40 +1,342 @@
 """LangGraph adapter — interrupt/resume durable HITL.
 
-Usage:
-    from awaithumans.adapters.langgraph import await_human
+Two halves, deployed in two paths inside the same web process:
 
-    # Inside a LangGraph node:
-    result = await await_human(
-        task="Approve this KYC?",
-        payload_schema=KYCPayload,
-        payload=kycData,
-        response_schema=KYCResponse,
-        timeout_seconds=900,
-    )
+  1. **Inside a graph node** — the agent calls `await_human(...)` from
+     this module. We POST the task to the awaithumans server and then
+     call `interrupt(...)` from `langgraph.types`. That throws a
+     `GraphInterrupt`; the caller (the user's app) catches it at the
+     `graph.ainvoke()` boundary, persists nothing of its own (the
+     checkpointer already saved state), and returns to its event loop.
+     The process can crash and the state survives.
 
-Requires: pip install "awaithumans[langgraph]"
+  2. **Inside the user's web server** — `dispatch_resume` is the
+     framework-agnostic helper they wrap in a route. It verifies the
+     HMAC, parses the body, and calls `graph.ainvoke(Command(resume=
+     payload), config={"configurable": {"thread_id": ...}})`. The
+     replayed `interrupt(...)` returns the response and the node
+     continues.
+
+Wire diagram:
+
+    graph node               awaithumans server          user web server
+    ──────────               ──────────────────          ───────────────
+    await_human() ─────►     POST /api/tasks
+                             store with callback_url
+                             return task_id
+    interrupt(taskId) ─x      (graph throws,
+                              caller catches at .ainvoke)
+                             ── human completes ──►
+                             POST callback_url ──►       verify HMAC
+                                                         graph.ainvoke(Command)
+                                                         ─── replays node ───
+                                                         interrupt() returns
+                                                         await_human returns
+
+Mirrors `awaithumans.adapters.langgraph` (TypeScript). Wire format
+matches the Temporal adapter so a single awaithumans server can back
+a mix of frameworks.
+
+Idempotency note: the SDK's default key is `hash(task, payload)`,
+which collides across graph threads. For per-thread tickets,
+pass `idempotency_key=f"langgraph:{thread_id}:{node_name}"` so each
+thread's interrupt creates its own server task and webhook URL.
+
+Requires: `pip install "awaithumans[langgraph]"`. The whole module is
+import-safe without langgraph installed; the call site fails-fast
+with a clear ImportError when actually invoked.
 """
 
 from __future__ import annotations
 
+import hashlib
+import json
+import logging
+from typing import Any, Awaitable, Callable, TypeVar
 
-async def await_human(**kwargs: object) -> object:
-    """LangGraph-durable version of await_human.
+import httpx
+from pydantic import BaseModel
 
-    Uses LangGraph interrupt/resume with checkpoint-based durability.
-    """
+from awaithumans.errors import (
+    SchemaValidationError,
+    TaskCancelledError,
+    TaskTimeoutError,
+    VerificationExhaustedError,
+)
+from awaithumans.types import VerifierConfig
+
+logger = logging.getLogger("awaithumans.adapters.langgraph")
+
+T = TypeVar("T", bound=BaseModel)
+
+# Idempotency-key prefix — namespace so a content-hash collision
+# across adapters can't accidentally land on the same task. Mirrors
+# `temporal:` in the Temporal adapter.
+_IDEMPOTENCY_PREFIX = "langgraph"
+
+
+def _require_langgraph() -> None:
+    """Lazy import gate — langgraph is an optional extra."""
     try:
         import langgraph  # noqa: F401
-    except ImportError:
+    except ImportError as exc:
         raise ImportError(
             "The LangGraph adapter requires the [langgraph] extra.\n"
             'Install with: pip install "awaithumans[langgraph]"'
-        ) from None
+        ) from exc
 
-    # TODO: implement
-    # 1. Create task on the awaithumans server (HTTP POST)
-    # 2. Use langgraph interrupt(task_id) to suspend the graph
-    # 3. Server fires webhook on completion → callback handler resumes graph
-    # 4. Validate response, return typed result
-    # Idempotency key: thread_id + node_id from checkpoint
-    raise NotImplementedError("LangGraph adapter not yet implemented.")
+
+def _default_idempotency_key(task: str, payload: BaseModel) -> str:
+    """Deterministic key for a (task, payload) pair.
+
+    Mirrors the direct-mode SDK's hashing so a node that does
+    `await_human(task=..., payload=...)` produces the same key on
+    every replay AND the same key as a non-LangGraph call to the
+    same content.
+
+    NOTE: This default collides across graph threads with identical
+    content. For HITL across threads, pass an explicit
+    `idempotency_key=f"{_IDEMPOTENCY_PREFIX}:{thread_id}:{node_name}"`.
+    """
+    canonical = json.dumps(
+        {"task": task, "payload": payload.model_dump(mode="json")},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return f"{_IDEMPOTENCY_PREFIX}:{hashlib.sha256(canonical.encode()).hexdigest()[:32]}"
+
+
+def _serialize_assign_to(assign_to: object | None) -> dict[str, Any] | None:
+    """Match the wire shape the server's Pydantic schema expects.
+    Same logic as the Temporal adapter — kept inline rather than
+    importing because the Temporal adapter's helper is in a different
+    module path and cross-importing between adapters tangles the
+    optional-extra story."""
+    if assign_to is None:
+        return None
+    if isinstance(assign_to, str):
+        return {"email": assign_to}
+    if isinstance(assign_to, list):
+        return {"emails": assign_to}
+    if isinstance(assign_to, BaseModel):
+        return assign_to.model_dump(mode="json")
+    return {"value": str(assign_to)}
+
+
+# ─── Graph-side: await_human ────────────────────────────────────────
+
+
+async def await_human(
+    *,
+    task: str,
+    payload_schema: type[BaseModel],
+    payload: BaseModel,
+    response_schema: type[T],
+    timeout_seconds: int,
+    callback_url: str,
+    server_url: str,
+    api_key: str | None = None,
+    idempotency_key: str | None = None,
+    assign_to: object | None = None,
+    notify: list[str] | None = None,
+    verifier: VerifierConfig | None = None,
+    redact_payload: bool = False,
+) -> T:
+    """Pause a LangGraph node until a human completes a task.
+
+    Parameters mirror the direct-mode `awaithumans.await_human` plus
+    LangGraph-specific glue:
+
+      - `callback_url`: the URL on YOUR web server where you mounted
+        `dispatch_resume`. Encode the LangGraph `thread_id` in this
+        URL so the callback handler can resume the right graph
+        instance:
+          `https://my-app.com/awaithumans/cb?thread={thread_id}`
+      - `server_url`: the awaithumans server (the human-facing one
+        running `awaithumans dev` or your hosted deployment).
+      - `api_key`: bearer token for `server_url`.
+
+    `interrupt(...)` does double duty: on the FIRST invocation of
+    this node it throws `GraphInterrupt` (caller catches at the
+    `.ainvoke()` boundary, the checkpointer persists state); on the
+    SECOND invocation (resume) the same call returns the value
+    passed to `Command(resume=...)`. This function `await`s on that
+    return — so semantically it "blocks" until the human submits,
+    even though the underlying process may have died and been
+    restarted in between.
+
+    Raises `TaskTimeoutError` / `TaskCancelledError` /
+    `VerificationExhaustedError` / `SchemaValidationError` on the
+    matching server-side terminal status.
+    """
+    _require_langgraph()
+
+    # Imports deferred so this module is import-safe without
+    # langgraph installed — the gate above only fires when this is
+    # actually called from inside a graph node.
+    from langgraph.types import interrupt
+
+    idem = idempotency_key or _default_idempotency_key(task, payload)
+
+    # Create the task on the server FIRST. The server's per-key
+    # uniqueness (active-tasks-only) makes this idempotent across
+    # node replays — a checkpoint-restore that re-runs this node
+    # will hit the same task without spawning a duplicate ticket
+    # for the human.
+    #
+    # We do this BEFORE interrupt() so the human-facing surface
+    # (Slack DM, email, dashboard row) appears immediately. Putting
+    # interrupt first would create a "tree falls in the forest"
+    # window where the graph is paused but no human has been
+    # notified yet.
+    headers: dict[str, str] = {}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    body = {
+        "task": task,
+        "payload": payload.model_dump(mode="json"),
+        "payload_schema": payload_schema.model_json_schema(),
+        "response_schema": response_schema.model_json_schema(),
+        "form_definition": None,
+        "timeout_seconds": timeout_seconds,
+        "idempotency_key": idem,
+        "assign_to": _serialize_assign_to(assign_to),
+        "notify": notify,
+        "verifier_config": verifier.model_dump() if verifier else None,
+        "redact_payload": redact_payload,
+        "callback_url": callback_url,
+    }
+
+    async with httpx.AsyncClient(timeout=30) as client:
+        resp = await client.post(
+            f"{server_url.rstrip('/')}/api/tasks",
+            json=body,
+            headers=headers,
+        )
+        if resp.status_code not in (200, 201):
+            raise RuntimeError(
+                f"awaithumans server rejected task creation "
+                f"(HTTP {resp.status_code}): {resp.text[:500]}"
+            )
+        task_record = resp.json()
+
+    logger.info(
+        "LangGraph adapter created task task_id=%s idempotency_key=%s",
+        task_record.get("id"),
+        idem,
+    )
+
+    # First run: throws GraphInterrupt, graph pauses, caller returns.
+    # Resume: returns the dict the callback handler passed to
+    # Command(resume=...). We hand the FULL webhook body through (not
+    # just `response`) so this function can branch on `status` to
+    # surface the right typed error.
+    resume_value = interrupt(
+        {
+            "task_id": task_record.get("id"),
+            "idempotency_key": idem,
+            "task": task,
+            "payload": payload.model_dump(mode="json"),
+            "callback_url": callback_url,
+        }
+    )
+
+    if not isinstance(resume_value, dict):
+        raise RuntimeError(
+            f"LangGraph adapter expected a dict resume value, got "
+            f"{type(resume_value).__name__}. Did your callback handler "
+            f"forget to pass the webhook body to Command(resume=...)?"
+        )
+
+    status = resume_value.get("status")
+    if status == "completed":
+        try:
+            return response_schema.model_validate(resume_value.get("response"))
+        except Exception as exc:  # noqa: BLE001
+            raise SchemaValidationError("response", str(exc)) from exc
+    if status == "timed_out":
+        raise TaskTimeoutError(task=task, timeout_seconds=timeout_seconds)
+    if status == "cancelled":
+        raise TaskCancelledError(task)
+    if status == "verification_exhausted":
+        attempt = (
+            resume_value.get("verification_attempt", 0)
+            if isinstance(resume_value, dict)
+            else 0
+        )
+        raise VerificationExhaustedError(task, attempt)
+    raise RuntimeError(
+        f"LangGraph adapter saw unknown terminal status "
+        f"'{status}' for task '{task}'"
+    )
+
+
+# ─── User-web-server-side: dispatch_resume ──────────────────────────
+
+
+# Type alias for the bits of a compiled graph we touch. Kept
+# structural (a callable that takes Command + config) so users can
+# pass a real `CompiledStateGraph` OR a wrapper without us pulling
+# the heavy class.
+GraphInvokable = Callable[..., Awaitable[Any]]
+
+
+async def dispatch_resume(
+    *,
+    graph: Any,
+    thread_id: str,
+    body: bytes,
+    signature_header: str | None,
+) -> dict[str, Any]:
+    """Verify a webhook body and resume the matching graph thread.
+
+    The user's web server wraps this in a route handler. They:
+
+      1. Read the thread_id from the request URL (a query param they
+         baked into `callback_url=` when constructing the node's
+         call to `await_human`).
+      2. Pass the raw body bytes and the `X-Awaithumans-Signature`
+         header value to this function along with the compiled graph.
+      3. Return 200 on success, 401 on `PermissionError`, 400 on
+         `ValueError`, 500 on anything else.
+
+    See `examples/langgraph-py/server.py` for a ~10-line FastAPI
+    wrapper. The split is deliberate: the SDK doesn't know which web
+    framework you use, but it owns the security-critical bits
+    (signature verification, payload parsing, Command construction).
+
+    Returns the JSON-decoded webhook payload so the caller can log
+    or audit it after the resume completes.
+    """
+    _require_langgraph()
+    from langgraph.types import Command
+
+    # `verify_signature` lives in the server package because the
+    # canonical implementation (HKDF + HMAC over PAYLOAD_KEY) is
+    # already there. Importing here forces the user to have the
+    # [server] extra installed too, which they typically do in the
+    # web-server process — this is the same trade-off the Temporal
+    # adapter's `dispatch_signal` makes. A future refactor could
+    # move HMAC to a shared `awaithumans.utils.webhook_sig` module
+    # and let both the server and the adapters import it.
+    from awaithumans.server.services.webhook_dispatch import verify_signature
+
+    if not verify_signature(body=body, signature=signature_header):
+        raise PermissionError("Invalid awaithumans webhook signature.")
+
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Webhook body is not JSON: {exc}") from exc
+
+    config = {"configurable": {"thread_id": thread_id}}
+    await graph.ainvoke(Command(resume=payload), config=config)
+
+    logger.info(
+        "Resumed graph thread_id=%s task_id=%s status=%s",
+        thread_id,
+        payload.get("task_id") if isinstance(payload, dict) else None,
+        payload.get("status") if isinstance(payload, dict) else None,
+    )
+    return payload if isinstance(payload, dict) else {}


### PR DESCRIPTION
## Summary

Mirror of #62 on the Python side. The Python LangGraph adapter shipped in #57 was a stub. This wires up the real `await_human` and `dispatch_resume`, plus a runnable FastAPI example (`examples/langgraph-py/`) that mirrors `examples/langgraph-ts/` end-to-end.

```
[node]
await await_human()
  → POST /api/tasks            (creates task on awaithumans)
  → interrupt({task_id, ...})  (graph pauses; checkpointer saves state)
                                  ⏸
                                  human submits in dashboard
                                  awaithumans webhook fires (with retry queue from #61)
                                  ⏵
              POST /awaithumans/cb?thread=…
                → handler verifies HMAC
                → graph.ainvoke(Command(resume=<body>))
                → interrupt() returns the resume value
                → response validated against pydantic responseSchema
[node continues with typed decision]
```

## What's in the adapter
- **`await_human(...)`** — creates the task, calls `interrupt(...)`, validates the resume value, raises `TaskTimeoutError` / `TaskCancelledError` / `VerificationExhaustedError` / `SchemaValidationError` matching the Temporal adapter's surface.
- **`dispatch_resume(...)`** — framework-agnostic. Verifies HMAC, parses body, calls `graph.ainvoke(Command(resume=…))`. Wrap it in three lines of FastAPI (or any other framework).

## E2E verification
- [x] Auto-approve path (amount < $100): graph completes in one `.ainvoke()`, never touches awaithumans.
- [x] Human-review path (amount $250):
  - `check_policy` → routes to `human_review` → `await_human` → task created on server (id captured)
  - Graph reports `status: interrupted` with the task ID and callback URL
  - Admin completes task via `/api/tasks/{id}/complete`
  - App log: `LangGraph adapter created task ... `, `[node:human_review] decision approved=True notes=...`, `Resumed graph thread_id=... status=completed`
  - Final state via `GET /threads/{id}`: `{customer_id, amount_usd, auto_approved: false, approved: true, notes: "..."}`
- [x] Server unit tests: 505 passed (one pre-existing temporal failure unrelated)

## Risk notes
- Graph threads need a thread-scoped idempotency key. The SDK default (`hash(task+payload)`) collides across threads. The example passes `idempotency_key=f"langgraph:{thread_id}:human_review"` and the adapter docstring documents this. We may want a thread-aware default in a follow-up but the explicit-key path is correct today.
- `dispatch_resume` imports `verify_signature` from `awaithumans.server.services.webhook_dispatch`, so the user's web-server process needs `[server]` installed alongside `[langgraph]`. Same trade-off as the Temporal adapter; documented in the docstring. A future refactor can hoist the HMAC primitives to a shared non-server module.