### PR TITLE
Resumable direct mode: Stripe-strict idempotency + Option C roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,21 @@ into a versioned release when tagged.
 
 ## [Unreleased]
 
-Nothing queued. Next tag will be `0.1.0` (pre-launch).
+### Changed (BREAKING)
+
+- **Idempotency keys now follow strict Stripe semantics.** A task's
+  `idempotency_key` always returns the same task, regardless of
+  status. Previously a terminal task's key was released, allowing a
+  fresh task with the same key — convenient for "re-trigger a
+  review" but silently lost the human's response when an agent
+  restart raced with task completion in direct mode. To request a
+  fresh task for the same logical event, pass a distinct key (e.g.
+  suffix with `:retry-1`). Direct-mode `await_human()` is now
+  resumable across agent restarts: a re-invocation with the same
+  key returns the stored response (for `COMPLETED` tasks) or the
+  typed terminal error (for `TIMED_OUT` / `CANCELLED` /
+  `VERIFICATION_EXHAUSTED`). Aligns the implementation with the
+  Stripe model the docs already claimed.
 
 ---
 

--- a/docs/api/create-task.mdx
+++ b/docs/api/create-task.mdx
@@ -94,15 +94,17 @@ Content-Type: application/json
 
 ## Idempotency behavior
 
-If a non-terminal task with `idempotency_key` already exists:
+Strict Stripe-style: same key, same task, always.
 
-```http
-HTTP/1.1 200 OK
+If any task with `idempotency_key` already exists — terminal or not — the response is `200 OK` with the existing task. The client should treat this as success and proceed to poll. If the existing task is already terminal, the next poll returns immediately with the stored response (for `completed`) or the appropriate terminal status (for `timed_out`, `cancelled`, `verification_exhausted`), and the SDK translates those into typed errors.
+
+This is what makes direct-mode `await_human()` resumable across agent restarts: a re-invocation with the same key after the human completed during your downtime returns the stored decision instead of creating a duplicate ticket.
+
+To create a fresh task for the same logical event (e.g. a yesterday's task timed out and you want a new review today), pass a distinct key — convention is to suffix with a retry counter:
+
+```python
+idempotency_key=f"refund:{order_id}:retry-{attempt}"
 ```
-
-The response body is the existing task. Status is whatever it currently is (`notified`, `in_progress`, `submitted`, etc.). Your client should treat this as success and proceed to poll/wait.
-
-If a TERMINAL task with that key exists, a new task is created with the same key (the partial-unique index releases the key on terminal). The response is `201` again with a fresh task ID.
 
 ## Errors
 

--- a/docs/community/roadmap.mdx
+++ b/docs/community/roadmap.mdx
@@ -1,0 +1,24 @@
+---
+title: "Help wanted"
+description: "Substantial features we'd love community help shipping. Pick one up, drop a proposal in the linked issue, and we'll review."
+---
+
+`awaithumans` ships small surface area on purpose. A few things on the roadmap are big enough that they make better community projects than founder-built features — well-bounded, self-contained, and meaty enough to be a real systems-design exercise.
+
+If one of these resonates, comment on the linked issue with a short proposal (your read on the open questions, a rough split into PR-sized chunks). We'll iterate, agree on the shape, and merge in stages so a contributor isn't blocked on one giant PR review.
+
+## Local task book — durable resumption without an orchestrator
+
+**Status:** open · **Issue:** [#64](https://github.com/awaithumans/awaithumans/issues/64) · **Effort:** ~1–2 weeks
+
+Today direct-mode `await_human()` is resumable across agent restarts as long as your runtime re-invokes it (we ship the idempotent-recovery primitive on the server side — see [Idempotency](/concepts/idempotency)). Workflow engines like Temporal and LangGraph automate that re-invocation via their own state management; users not on either currently have to wire up a supervisor or queue themselves.
+
+This feature builds the smallest possible "client-side workflow state" into the SDK: a local SQLite task book that records each in-flight call, plus a decorator + boot-time recovery scan that re-invokes registered handlers automatically. End result: your `if decision.approved:` block runs after a crash without you having to think about retry loops.
+
+Picking this up means designing the persistence shape (where state lives, how handlers are identified, how args round-trip), the recovery semantics (auto vs. explicit, single-process vs. multi-process), and the cross-language story (Python first, TypeScript follow-up). [Full design space and open questions in the issue.](https://github.com/awaithumans/awaithumans/issues/64)
+
+This is exactly the kind of thing that's a good portfolio piece: real systems-design tradeoffs, a self-contained subsystem you don't have to refactor the server for, and direct user impact for the long tail of agent builders running on FastAPI / cron / serverless.
+
+---
+
+Other "help wanted" issues land here as they're scoped. If you have something in mind that isn't listed, open a [GitHub Discussion](https://github.com/awaithumans/awaithumans/discussions) — we'd rather talk shape than code review a surprise.

--- a/docs/concepts/idempotency.mdx
+++ b/docs/concepts/idempotency.mdx
@@ -7,34 +7,29 @@ description: "Safe-retry semantics for await_human(). What the key actually does
 
 ## The model
 
-awaithumans follows Stripe's idempotency model: **safe-retry-while-active, NOT eternal uniqueness.**
+awaithumans follows Stripe's idempotency model: **same key, same task, always.**
 
-A key is "active" while the task is in a non-terminal status (`CREATED`, `NOTIFIED`, `IN_PROGRESS`, `SUBMITTED`, `VERIFIED`, `REJECTED`). After the task reaches a terminal status (`COMPLETED`, `TIMED_OUT`, `CANCELLED`, `VERIFICATION_EXHAUSTED`), the key is released — a new task with the same key can be created.
+The first call with a given `idempotency_key` creates the task. Every subsequent call with that key — while the task is in flight, after it completes, after it times out, after it's cancelled, after the verifier exhausts — returns the same task. Different result, same row.
 
 This is what you want. It means:
 
-- ✅ Calling `await_human(...)` twice with the same key while a human is reviewing → returns the same task (safe retry)
-- ✅ Calling `await_human(...)` again the next day with the same key → creates a fresh task (you can re-trigger a review)
+- ✅ Calling `await_human(...)` twice with the same key while a human is reviewing → returns the same task (in-flight dedup)
 - ✅ Network blip during task creation → safe to retry without creating a duplicate
+- ✅ **Agent process crashes mid-`await_human()` and the human completes during the outage → re-invoking on restart returns the stored response and your `if decision.approved:` block runs**
+- ✅ The original timed out → re-invoking returns the timed-out task; your code gets a typed `TaskTimeoutError`, not a phantom new task
 
-It's NOT a permanent dedup gate. If you want "this task has been seen before, never run it again" semantics, that's your application's job — store the task's terminal outcome and check before calling.
+If you want "this is a fresh review for the same business event," pass a distinct key — see [Re-triggering a review](#re-triggering-a-review) below.
 
 ## What happens under the hood
 
-The `tasks.idempotency_key` column has a **partial unique index**:
-
-```sql
-CREATE UNIQUE INDEX ix_tasks_active_idempotency_key
-  ON tasks (idempotency_key)
-  WHERE status NOT IN ('COMPLETED', 'TIMED_OUT', 'CANCELLED', 'VERIFICATION_EXHAUSTED');
-```
-
 When you call `await_human(...)`:
 
-1. Server looks up active tasks with this key
-2. **Found?** Return the existing task. The SDK long-polls it.
-3. **Not found?** INSERT a fresh task. The partial index lets us race-safely insert even if a previous task with the same key is now terminal.
-4. **Race condition** (two concurrent INSERTs)? The unique constraint catches it; the loser re-fetches the winner.
+1. Server looks up tasks with this key — any status, terminal or not.
+2. **Found?** Return the existing task. The SDK long-polls it. If the status is already terminal the long-poll returns immediately with the stored response or the appropriate typed error.
+3. **Not found?** INSERT a fresh task.
+4. **Race condition** (two concurrent INSERTs with the same new key)? The unique constraint catches it; the loser re-fetches the winner.
+
+The `tasks.idempotency_key` column has a partial unique index gated on non-terminal status, kept from earlier versions for race safety on concurrent insertion. With the application-layer lookup now covering terminal rows, the index never gets exercised on the recovery path — the lookup returns the existing row before any INSERT is attempted.
 
 ## Default keys
 
@@ -66,29 +61,48 @@ Why: the `(task, payload)` default is content-addressed, so two refund requests 
 
 A natural-key approach (`refund:{order_id}`) makes intent explicit:
 
-- Same `order_id` while task is active → same task (intentional)
-- Same `order_id` after task closed → fresh task (intentional re-review)
-- Different `order_id` → different task (intentional)
+- Same `order_id` while task is active → same task (intentional dedup)
+- Same `order_id` after task closed → same task (intentional recovery — see [What about retries](#what-about-retries-from-the-agents-side))
+- Different `order_id` → different task
+
+## Re-triggering a review
+
+When you genuinely want to start a *fresh* review for the same logical event — for example, a refund timed out yesterday and you want to surface it again today — encode that intent in the key:
+
+```python
+attempt = 1
+decision = await_human_sync(
+    task=f"Approve refund for {order_id}?",
+    # ...
+    idempotency_key=f"refund:{order_id}:retry-{attempt}",
+)
+```
+
+The previous task (under `refund:{order_id}` or `refund:{order_id}:retry-0`) stays in the audit log; the new key creates a new task that the human can act on independently. Same approach Stripe recommends for retried payment intents.
 
 ## What about retries from the agent's side?
 
-If your agent crashes mid-`await_human()` and restarts, it'll call `await_human(...)` again with the same args. The default-keyed task gets dedup'd, you long-poll the same row, the human only sees one ticket. No duplicate work.
+Two cases. Both work; the second is the one that distinguishes awaithumans from a naive long-poll.
+
+**Crash *before* the human completes.** Agent re-invokes with the same key, the server returns the still-in-flight task, the SDK resumes the long-poll. The human only ever sees one ticket. No duplicate work.
+
+**Crash *during* human review, human completes during the outage, agent restarts.** Agent re-invokes with the same key, the server returns the now-`COMPLETED` task with the stored response, the SDK skips long-polling and returns the typed result immediately. Your `if decision.approved:` block runs as if the agent had been alive the whole time.
 
 This is the entire point. `await_human()` is the durable-but-with-humans equivalent of Temporal's `await activity()` — your retry loop just works.
 
 ## What about the verifier?
 
-When the verifier rejects an attempt, the task goes to `REJECTED` (non-terminal). The idempotency key is still active. If your agent calls `await_human(...)` again with the same key, it returns the same task — the human can still resubmit and run another verifier attempt.
+When the verifier rejects an attempt, the task goes to `REJECTED` (non-terminal). If your agent calls `await_human(...)` again with the same key, it returns the same task — the human can still resubmit and run another verifier attempt.
 
-If the verifier exhausts attempts → `VERIFICATION_EXHAUSTED` (terminal). Now the key is released. Next call creates a fresh task with attempt counter reset.
+If the verifier exhausts attempts → `VERIFICATION_EXHAUSTED` (terminal). Subsequent calls with the same key return the same exhausted task and the SDK raises `VerificationExhaustedError`. To retry the whole pipeline with a fresh attempt counter, pass a new key (see [Re-triggering a review](#re-triggering-a-review)).
 
 ## Example: a refund pipeline
 
 ```python
 async def process_refund(order):
     # First HITL: approval. If we ever retry this whole function,
-    # the same order_id maps to the same task (or a new one if the
-    # previous run's task already terminated).
+    # the same order_id maps to the same task — including the stored
+    # decision if the human completed it during a previous outage.
     decision = await_human_sync(
         task=f"Approve ${order.amount} refund for {order.customer_id}?",
         # ...

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -109,6 +109,12 @@
       "pages": [
         "troubleshooting"
       ]
+    },
+    {
+      "group": "Community",
+      "pages": [
+        "community/roadmap"
+      ]
     }
   ],
   "footerSocials": {

--- a/packages/python/awaithumans/adapters/temporal/__init__.py
+++ b/packages/python/awaithumans/adapters/temporal/__init__.py
@@ -169,8 +169,9 @@ def _default_idempotency_key(task: str, payload: BaseModel) -> str:
     Mirrors the direct-mode SDK's hashing so a workflow that does
     `await_human(task=..., payload=...)` ends up with the same key
     on every replay AND the same key as a non-Temporal call to the
-    same content. The server's idempotency-after-terminal semantics
-    handle re-runs cleanly."""
+    same content. Stripe-style idempotency on the server means
+    replays of a completed activity recover the stored response
+    instead of creating a duplicate task."""
     import hashlib
 
     canonical = json.dumps(
@@ -327,16 +328,10 @@ async def await_human(
         # The webhook payload doesn't carry max_attempts; the
         # server's verification_attempt counter at terminal state is
         # the closest signal of how many tries the human got.
-        attempt = (
-            received[0].get("verification_attempt", 0)
-            if isinstance(received[0], dict)
-            else 0
-        )
+        attempt = received[0].get("verification_attempt", 0) if isinstance(received[0], dict) else 0
         raise VerificationExhaustedError(task, attempt)
     # Unknown status — shouldn't happen, but fail loud rather than silent.
-    raise RuntimeError(
-        f"Temporal adapter saw unknown terminal status '{status}' for task '{task}'"
-    )
+    raise RuntimeError(f"Temporal adapter saw unknown terminal status '{status}' for task '{task}'")
 
 
 # ─── User-web-server-side: dispatch_signal ──────────────────────────

--- a/packages/python/awaithumans/server/services/task_service.py
+++ b/packages/python/awaithumans/server/services/task_service.py
@@ -55,11 +55,18 @@ async def create_task(
 ) -> Task:
     """Create a new task, or return the existing one if idempotency key matches.
 
-    If a non-terminal task with the same idempotency key exists, returns it
-    (dedup behavior). If the existing task is terminal, creates a new one.
+    Stripe-style idempotency: same key always returns the same task,
+    regardless of status. While the task is active this gives in-flight
+    dedup; after the task is terminal it gives recovery — a restarted
+    agent that re-invokes `await_human()` with the same key gets the
+    stored response (or terminal-status error) instead of creating a
+    duplicate. To re-trigger work for the same logical event, pass a
+    distinct key (e.g. `f"refund:{order_id}:retry-1"`).
     """
-    # Check for existing task with same idempotency key
-    existing = await _find_active_task_by_idempotency_key(session, idempotency_key)
+    # Check for existing task with same idempotency key. Looking up
+    # ANY status (including terminal) is what makes direct mode
+    # resumable across agent restarts.
+    existing = await _find_task_by_idempotency_key(session, idempotency_key)
     if existing is not None:
         return existing
 
@@ -120,10 +127,12 @@ async def create_task(
         # Race condition: another request inserted with the same idempotency key
         # between our SELECT and INSERT. Roll back and return the existing task.
         await session.rollback()
-        existing = await _find_active_task_by_idempotency_key(session, idempotency_key)
+        existing = await _find_task_by_idempotency_key(session, idempotency_key)
         if existing is not None:
             return existing
-        # The existing task went terminal between our attempts — re-raise
+        # No task found despite IntegrityError — should be unreachable
+        # now that the lookup covers all statuses. Re-raise to surface
+        # the genuine constraint violation if it ever happens.
         raise
 
     await session.refresh(new_task)
@@ -523,15 +532,16 @@ def _snapshot_task_for_verifier(task: Task) -> Task:
     )
 
 
-async def _find_active_task_by_idempotency_key(
-    session: AsyncSession, idempotency_key: str
-) -> Task | None:
-    """Find a non-terminal task with the given idempotency key."""
-    result = await session.execute(
-        select(Task)
-        .where(Task.idempotency_key == idempotency_key)
-        .where(Task.status.notin_(list(TERMINAL_STATUSES_SET)))
-    )
+async def _find_task_by_idempotency_key(session: AsyncSession, idempotency_key: str) -> Task | None:
+    """Find any task with the given idempotency key, regardless of status.
+
+    Returning terminal tasks here is what makes `await_human()` resumable
+    across agent restarts: an agent that crashes mid-call and re-invokes
+    with the same key gets the stored response (for COMPLETED) or the
+    typed terminal error (for TIMED_OUT / CANCELLED /
+    VERIFICATION_EXHAUSTED), instead of creating a duplicate.
+    """
+    result = await session.execute(select(Task).where(Task.idempotency_key == idempotency_key))
     return result.scalar_one_or_none()
 
 

--- a/packages/python/tests/tasks/test_idempotency_after_terminal.py
+++ b/packages/python/tests/tasks/test_idempotency_after_terminal.py
@@ -1,16 +1,15 @@
-"""Regression test: after a task reaches a terminal state, a new task
-can be created with the same idempotency key.
+"""Stripe-style idempotency: same key always returns the same task.
 
-The partial unique index on `tasks.idempotency_key` is conditional on
-`status NOT IN (...terminal...)`, so terminal rows shouldn't block a
-re-insert. Early on the WHERE clause used lowercase values
-(`'completed'`) while SQLAlchemy serialized the enum as uppercase
-names (`'COMPLETED'`), so the index never excluded anything and the
-retry-after-terminal story silently failed with a raw UNIQUE violation.
+While the task is active this gives in-flight dedup; after the task
+is terminal it gives recovery — a restarted agent that re-invokes
+`await_human()` with the same key gets the stored response (for
+COMPLETED) or the typed terminal error (for TIMED_OUT / CANCELLED /
+VERIFICATION_EXHAUSTED), instead of creating a duplicate.
 
-This test pins that behaviour: create a task, complete it, create
-another one with the same key — should succeed and return a distinct
-row."""
+Pre-Option-A this file pinned the opposite behavior — terminal keys
+allowed a fresh task. That deviation from the documented Stripe model
+is what made direct-mode `await_human()` lose the human's response on
+agent restart. The new tests pin the corrected contract."""
 
 from __future__ import annotations
 
@@ -27,10 +26,13 @@ from awaithumans.server.db.models import (  # noqa: F401 — register models
     EmailSenderIdentity,
     SlackInstallation,
     Task,
+    TaskStatus,
 )
 from awaithumans.server.services.task_service import (
+    cancel_task,
     complete_task,
     create_task,
+    timeout_task,
 )
 
 
@@ -45,22 +47,96 @@ async def session() -> AsyncGenerator[AsyncSession, None]:
     await engine.dispose()
 
 
-@pytest.mark.asyncio
-async def test_retry_after_terminal_with_same_idempotency_key(
-    session: AsyncSession,
-) -> None:
-    # Create #1.
-    first = await create_task(
+async def _make(session: AsyncSession, key: str) -> Task:
+    return await create_task(
         session,
         task="Approve refund",
         payload={"amount": 100},
         payload_schema={},
         response_schema={},
         timeout_seconds=900,
-        idempotency_key="shared-key-xyz",
+        idempotency_key=key,
     )
 
-    # Complete it — status moves to COMPLETED (terminal).
+
+@pytest.mark.asyncio
+async def test_duplicate_idempotency_key_while_active_returns_existing(
+    session: AsyncSession,
+) -> None:
+    """In-flight dedup: while the task is non-terminal, the same key
+    returns the same row. Pins the unchanged half of the contract."""
+    first = await _make(session, "shared-key-active")
+    second = await _make(session, "shared-key-active")
+    assert second.id == first.id
+    assert second.status == TaskStatus.CREATED
+
+
+@pytest.mark.asyncio
+async def test_recover_after_completed_returns_existing_with_response(
+    session: AsyncSession,
+) -> None:
+    """The recovery path. An agent that crashed mid-`await_human()`
+    while a human was reviewing comes back up, the human has already
+    submitted, and the agent re-calls with the same key. It MUST get
+    the stored response back, not a fresh blank task."""
+    first = await _make(session, "shared-key-completed")
+    completed = await complete_task(
+        session,
+        task_id=first.id,
+        response={"approved": True, "reason": "policy match"},
+        completed_via_channel="test",
+    )
+    assert completed.status == TaskStatus.COMPLETED
+
+    recovered = await _make(session, "shared-key-completed")
+    assert recovered.id == first.id
+    assert recovered.status == TaskStatus.COMPLETED
+    assert recovered.response == {"approved": True, "reason": "policy match"}
+
+
+@pytest.mark.asyncio
+async def test_recover_after_timed_out_returns_existing_terminal_task(
+    session: AsyncSession,
+) -> None:
+    """Recovery for TIMED_OUT: re-call returns the same terminal task,
+    SDK's poll-branch translates it into TaskTimeoutError. Critically,
+    we do NOT silently create a fresh task — that would mean the agent
+    starts a SECOND human ticket for an event the first cycle already
+    timed out on."""
+    first = await _make(session, "shared-key-timed-out")
+    await timeout_task(session, first.id)
+    await session.refresh(first)
+    assert first.status == TaskStatus.TIMED_OUT
+
+    recovered = await _make(session, "shared-key-timed-out")
+    assert recovered.id == first.id
+    assert recovered.status == TaskStatus.TIMED_OUT
+
+
+@pytest.mark.asyncio
+async def test_recover_after_cancelled_returns_existing_terminal_task(
+    session: AsyncSession,
+) -> None:
+    """Recovery for CANCELLED. SDK's poll-branch raises TaskCancelledError."""
+    first = await _make(session, "shared-key-cancelled")
+    await cancel_task(session, first.id)
+    await session.refresh(first)
+    assert first.status == TaskStatus.CANCELLED
+
+    recovered = await _make(session, "shared-key-cancelled")
+    assert recovered.id == first.id
+    assert recovered.status == TaskStatus.CANCELLED
+
+
+@pytest.mark.asyncio
+async def test_distinct_keys_create_distinct_tasks(
+    session: AsyncSession,
+) -> None:
+    """The escape hatch: callers who genuinely want a fresh task for
+    the same logical event use a distinct key (e.g. an explicit
+    retry-counter suffix). Pin that path so re-review workflows
+    documented in `docs/concepts/idempotency.mdx` keep working."""
+    first = await _make(session, "shared-key:original")
     await complete_task(
         session,
         task_id=first.id,
@@ -68,46 +144,6 @@ async def test_retry_after_terminal_with_same_idempotency_key(
         completed_via_channel="test",
     )
 
-    # Create #2 with the same idempotency key. Should succeed and
-    # return a DIFFERENT row from the terminal one.
-    second = await create_task(
-        session,
-        task="Approve refund",
-        payload={"amount": 100},
-        payload_schema={},
-        response_schema={},
-        timeout_seconds=900,
-        idempotency_key="shared-key-xyz",
-    )
-
+    second = await _make(session, "shared-key:retry-1")
     assert second.id != first.id
-    assert second.status.value == "created"
-
-
-@pytest.mark.asyncio
-async def test_duplicate_idempotency_key_while_active_returns_existing(
-    session: AsyncSession,
-) -> None:
-    """Dedup semantics: while the original task is still non-terminal,
-    creating with the same idempotency key returns the same row."""
-    first = await create_task(
-        session,
-        task="Approve refund",
-        payload={"amount": 100},
-        payload_schema={},
-        response_schema={},
-        timeout_seconds=900,
-        idempotency_key="shared-key-active",
-    )
-
-    second = await create_task(
-        session,
-        task="Approve refund",
-        payload={"amount": 100},
-        payload_schema={},
-        response_schema={},
-        timeout_seconds=900,
-        idempotency_key="shared-key-active",
-    )
-
-    assert second.id == first.id
+    assert second.status == TaskStatus.CREATED


### PR DESCRIPTION
## Summary

Ship **Option A** (the durability fix discussed in chat): a task's `idempotency_key` now always returns the same task, regardless of status. Direct-mode `await_human()` is finally resumable across agent restarts — the user's `if decision.approved:` block runs even when the human completed during the outage.

Also adds a community-facing **Help Wanted** doc page and a detailed GitHub issue ([#64](https://github.com/awaithumans/awaithumans/issues/64)) for **Option C** (the local task-book that automates re-invocation entirely), so external contributors can pick it up.

## What changes (BREAKING)

| Behavior | Before | After |
|---|---|---|
| Same key while task active | Returns existing | Returns existing (unchanged) |
| Same key after `COMPLETED` | Allowed a fresh task | **Returns existing with stored response** — SDK's poll branch returns the typed result immediately, the agent's `if` block runs |
| Same key after `TIMED_OUT` / `CANCELLED` / `VERIFICATION_EXHAUSTED` | Allowed a fresh task | **Returns the existing terminal task** — SDK raises the matching typed error |
| Want a fresh task for the same logical event | Same key worked | Pass a distinct key (e.g. suffix `:retry-1`) |

The docs page already claimed Stripe semantics (\"safe-retry-while-active, NOT eternal uniqueness\"). This change aligns the implementation with the claim. Pre-1.0 behavior change, called out in the CHANGELOG.

## What's in the diff

**Server-side fix**
- \`packages/python/awaithumans/server/services/task_service.py\` — \`_find_active_task_by_idempotency_key\` → \`_find_task_by_idempotency_key\`, drop the status filter; \`create_task\` docstring updated to reflect Stripe-strict semantics.
- \`packages/python/awaithumans/adapters/temporal/__init__.py\` — comment update so the Temporal adapter's note about idempotency stays accurate.

**Tests**
- \`packages/python/tests/tasks/test_idempotency_after_terminal.py\` — rewritten to pin the new contract. The previous \`test_retry_after_terminal_with_same_idempotency_key\` (which asserted that a terminal key allowed a *new* task) is replaced with \`test_recover_after_completed_returns_existing_with_response\`, plus dedicated tests for \`TIMED_OUT\` and \`CANCELLED\` recovery and a \`test_distinct_keys_create_distinct_tasks\` that pins the explicit-retry-with-suffixed-key escape hatch.
- All 5 new tests pass; full \`tests/tasks/\` suite (38 tests) green.

**Docs**
- \`docs/concepts/idempotency.mdx\` — rewritten \"The model\" section to lead with the recovery use-case; added a \"Re-triggering a review\" section that documents the suffixed-key pattern; updated the \"What about retries\" and \"What about the verifier\" sections to match.
- \`docs/api/create-task.mdx\` — \"Idempotency behavior\" section rewritten.
- \`CHANGELOG.md\` — breaking-change entry under Unreleased.

**Community**
- \`docs/community/roadmap.mdx\` — new Help Wanted page pointing at #64 (Option C).
- \`docs/mint.json\` — adds the new page under a \"Community\" nav group.

**Issue**
- [#64](https://github.com/awaithumans/awaithumans/issues/64) — \"Local task book: zero-orchestrator durable resumption for direct-mode \`await_human()\`\". Tagged \`enhancement\` + \`help wanted\`. Includes design space, open questions, acceptance criteria, code pointers, and out-of-scope guard rails.

## Why the partial-unique index stays

The \`tasks.idempotency_key\` partial unique index (gated on non-terminal status) still exists. With the application-layer lookup now covering terminal rows the index isn't exercised on the recovery path, but it's still load-bearing for race safety on concurrent INSERTs of *new* keys. Dropping it would require a migration and tightens the constraint slightly in unhelpful ways. Leaving it.

## Test plan

- [x] \`pytest tests/tasks/\` — 38 passed
- [x] \`pytest tests/tasks/ tests/core/ tests/forms/\` — 122 passed
- [x] \`ruff check\` + \`ruff format\` — clean
- [ ] Manual: run the verifier example from PR #53, kill the agent before submitting in the dashboard, complete the task in the dashboard during the outage, restart the agent — \`if decision.approved:\` should now run with the stored decision (this is the fix the whole PR exists for)
- [ ] Manual: verify the suffixed-retry-key path — submit a task that times out, then re-invoke with the same base key (should raise \`TaskTimeoutError\` from the existing terminal task) and again with \`:retry-1\` (should create a fresh task)

## Pre-existing failing tests, NOT touched by this PR

\`tests/adapters/test_temporal_adapter.py::test_await_human_returns_response_after_signal\` and \`...::test_await_human_raises_typed_error_on_cancelled_status\` fail on \`origin/main\` already — \`@activity.defn\` decorator-binding issue in the test fixture, unrelated to this change. Verified by stashing this PR's changes and running against bare main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)