### PR TITLE
fix(temporal-py): make adapter actually run a real Temporal workflow

### DIFF
--- a/examples/temporal/refund_workflow.py
+++ b/examples/temporal/refund_workflow.py
@@ -48,7 +48,7 @@ from temporalio.worker import Worker
 # Sandbox-safe import: anything that triggers the Temporal sandbox
 # guard (e.g. heavy modules) goes inside `unsafe.imports_passed_through`.
 with workflow.unsafe.imports_passed_through():
-    from awaithumans.adapters.temporal import await_human
+    from awaithumans.adapters.temporal import await_human, awaithumans_create_task
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("examples.temporal.refund_workflow")
@@ -72,6 +72,25 @@ class RefundDecision(BaseModel):
 
     approved: bool
     notes: str | None = None
+
+
+# ─── Workflow input ──────────────────────────────────────────────────
+
+
+@dataclass
+class RefundWorkflowInput:
+    """Everything the workflow needs that we read from the environment.
+
+    Temporal's workflow sandbox forbids `os.environ` access (and most
+    stdlib I/O) — env vars have to be read OUTSIDE the workflow and
+    passed in as input args. Same pattern as the temporal-ts example.
+    """
+
+    amount: int
+    customer_id: str
+    server_url: str
+    api_key: str | None
+    callback_base: str
 
 
 # ─── Downstream activity (fires after the human decides) ─────────────
@@ -106,21 +125,28 @@ async def process_refund(req: ProcessRefundInput) -> str:
 @workflow.defn
 class RefundWorkflow:
     @workflow.run
-    async def run(self, amount: int, customer_id: str = "cus_demo") -> dict:
+    async def run(self, args: RefundWorkflowInput) -> dict:
+        # `_callback_url_for_workflow` is sandbox-safe — no env reads,
+        # just string-formatting the workflow ID into the base URL the
+        # caller passed in.
+        callback_url = _callback_url_for_workflow(
+            args.callback_base, workflow.info().workflow_id
+        )
+
         # Block for up to 15 minutes waiting for the human.
         decision = await await_human(
-            task=f"Approve ${amount} refund for {customer_id}?",
+            task=f"Approve ${args.amount} refund for {args.customer_id}?",
             payload_schema=RefundPayload,
             payload=RefundPayload(
-                amount_usd=amount,
-                customer_id=customer_id,
+                amount_usd=args.amount,
+                customer_id=args.customer_id,
                 reason="Customer reports duplicate charge.",
             ),
             response_schema=RefundDecision,
             timeout_seconds=15 * 60,
-            callback_url=_callback_url_for_workflow(workflow.info().workflow_id),
-            server_url=os.environ.get("AWAITHUMANS_URL", "http://localhost:3001"),
-            api_key=os.environ.get("AWAITHUMANS_ADMIN_API_TOKEN"),
+            callback_url=callback_url,
+            server_url=args.server_url,
+            api_key=args.api_key,
         )
 
         if not decision.approved:
@@ -129,8 +155,8 @@ class RefundWorkflow:
         refund_id = await workflow.execute_activity(
             process_refund,
             ProcessRefundInput(
-                customer_id=customer_id,
-                amount_usd=amount,
+                customer_id=args.customer_id,
+                amount_usd=args.amount,
                 decision_notes=decision.notes,
             ),
             start_to_close_timeout=timedelta(seconds=30),
@@ -138,14 +164,13 @@ class RefundWorkflow:
         return {"refund_id": refund_id, "outcome": "approved", "notes": decision.notes}
 
 
-def _callback_url_for_workflow(workflow_id: str) -> str:
+def _callback_url_for_workflow(base: str, workflow_id: str) -> str:
     """Build the webhook URL for THIS workflow.
 
     `callback_server.py` reads the `wf` query param to know which
     workflow to signal. The full URL must be reachable from wherever
     the awaithumans server is running — for local dev with ngrok
-    tunnel, override AWAITHUMANS_CALLBACK_BASE."""
-    base = os.environ.get("AWAITHUMANS_CALLBACK_BASE", "http://localhost:8765")
+    tunnel, override AWAITHUMANS_CALLBACK_BASE in the kickoff env."""
     return f"{base.rstrip('/')}/awaithumans/callback?wf={workflow_id}"
 
 
@@ -158,7 +183,7 @@ async def run_worker() -> None:
         client,
         task_queue=TASK_QUEUE,
         workflows=[RefundWorkflow],
-        activities=[process_refund],
+        activities=[process_refund, awaithumans_create_task],
     ):
         logger.info("Worker started — task queue=%s", TASK_QUEUE)
         # Block forever; ctrl-C exits.
@@ -166,11 +191,28 @@ async def run_worker() -> None:
 
 
 async def kickoff(amount: int) -> None:
+    # Read all env-derived config OUT HERE (sandbox-free), then pass it
+    # as a single workflow arg. The discovery file written by
+    # `awaithumans dev` is the dev-mode default for the admin token.
+    from awaithumans.utils.discovery import resolve_admin_token, resolve_server_url
+
+    server_url = resolve_server_url()
+    api_key = resolve_admin_token()
+    callback_base = os.environ.get(
+        "AWAITHUMANS_CALLBACK_BASE", "http://localhost:8765"
+    )
+
     client = await Client.connect("localhost:7233")
     workflow_id = f"refund-{uuid.uuid4()}"
     handle = await client.start_workflow(
         RefundWorkflow.run,
-        amount,
+        RefundWorkflowInput(
+            amount=amount,
+            customer_id="cus_demo",
+            server_url=server_url,
+            api_key=api_key,
+            callback_base=callback_base,
+        ),
         id=workflow_id,
         task_queue=TASK_QUEUE,
     )

--- a/packages/python/awaithumans/adapters/temporal/__init__.py
+++ b/packages/python/awaithumans/adapters/temporal/__init__.py
@@ -115,8 +115,45 @@ class _CreateTaskInput:
     redact_payload: bool
 
 
-async def _create_task_activity(req: _CreateTaskInput) -> dict[str, Any]:
+def _activity_defn() -> Any:
+    """Lazy-bind `@activity.defn` so this module imports cleanly even
+    when temporalio isn't installed. The decorator is applied on the
+    `awaithumans_create_task` function below; without it, the worker
+    rejects the activity at registration time with "missing attributes,
+    was it decorated with @activity.defn?". A naked import-time
+    `from temporalio import activity` would force every consumer of
+    this module — including the direct-mode SDK — to install the
+    [temporal] extra, which we explicitly avoid."""
+    try:
+        from temporalio import activity
+
+        return activity.defn
+    except ImportError:
+        # If temporalio isn't installed we never reach this code from
+        # a worker (the import gate in `_require_temporal` fires
+        # first), but the decorator still has to be importable at
+        # module load. A no-op stand-in keeps the module loadable;
+        # the worker registration would fail later with the same
+        # "missing attributes" error if anyone tried to use it
+        # without installing the extra.
+        return lambda fn: fn
+
+
+@_activity_defn()
+async def awaithumans_create_task(req: _CreateTaskInput) -> dict[str, Any]:
     """Activity: POST the task to the awaithumans server.
+
+    Register on your Temporal worker alongside your own activities:
+
+        from awaithumans.adapters.temporal import awaithumans_create_task
+
+        async with Worker(
+            client,
+            task_queue=TASK_QUEUE,
+            workflows=[YourWorkflow],
+            activities=[your_activity, awaithumans_create_task],
+        ):
+            ...
 
     Lives in the user's worker process, NOT inside the workflow
     sandbox — HTTP and most stdlib I/O is forbidden in workflow code.
@@ -296,7 +333,7 @@ async def await_human(
     )
 
     await workflow.execute_activity(
-        _create_task_activity,
+        awaithumans_create_task,
         create_input,
         start_to_close_timeout=timedelta(seconds=create_activity_timeout_seconds),
     )


### PR DESCRIPTION
## Summary

Discovered while regression-testing all four engine adapters end-to-end. The Python Temporal adapter had the same kind of mock-vs-reality bugs that #60 fixed in the TS one — its 12 unit tests mock the workflow API top-to-bottom, so two real-world bugs slipped through.

Both surface immediately when you run `examples/temporal/refund_workflow.py` against a live Temporal cluster.

## What was broken

1. **Activity not decorated with `@activity.defn`.** `_create_task_activity` was a plain async function. The workflow called `workflow.execute_activity(_create_task_activity, ...)`, but Temporal's worker rejects undecorated activities at registration time:
   ```
   TypeError: Activity _create_task_activity missing attributes,
              was it decorated with @activity.defn?
   ```

2. **Workflow body reads `os.environ` inside the sandbox.** The example's workflow read `AWAITHUMANS_URL`, `AWAITHUMANS_ADMIN_API_TOKEN`, and `AWAITHUMANS_CALLBACK_BASE` directly. Temporal's sandbox forbids env access:
   ```
   RestrictedWorkflowAccessError: Cannot access os.environ.get
                                  from inside a workflow.
   ```

## What changed

- **Adapter:** decorate the activity with `@activity.defn` (lazy-bound so the module still imports without temporalio), rename to public `awaithumans_create_task` for parity with the TS adapter's `awaithumansCreateTask`, and document that workers must register it alongside their own activities.
- **Example:** introduce `RefundWorkflowInput` dataclass; the kickoff reads env vars OUTSIDE the workflow and passes them in as a single arg. Mirrors `examples/temporal-ts/kickoff.ts`.

## E2E verification

Run with `awaithumans dev` + `temporal server start-dev`:
- [x] Worker boots and registers both activities cleanly.
- [x] Kickoff starts a workflow, adapter POSTs the task, workflow parks on `wait_condition`.
- [x] Admin completes task via `/api/tasks/{id}/complete`.
- [x] Webhook delivery `succeeded` (HTTP 200, attempt 1) via queue from #61.
- [x] Callback server signals the workflow.
- [x] `await_human` returns validated `RefundDecision`; `process_refund` activity runs; kickoff prints `{refund_id, outcome: "approved", notes: "..."}` matching the human's input.
- [x] Server test suite: 505 passed (one pre-existing temporal mock failure unrelated).

## Risk note

The pyproject's `[temporal]` extra now requires consumers to register `awaithumans_create_task` on their worker. This is a contract change — operators with existing pipelines that import the old `_create_task_activity` symbol will see ImportErrors after upgrade. Pre-launch (May 12) so we accept this; post-launch we'd need to keep the old name as an alias.