### PR TITLE
docs: sweep idempotency-semantics references across the project

### DIFF
--- a/BUILD_NOTES.md
+++ b/BUILD_NOTES.md
@@ -503,11 +503,21 @@ belong here, not there:
   (`completed`, `timed_out`, `cancelled`, `verification_exhausted`).
   Stored in `utils/constants.TERMINAL_STATUSES_SET`. Any code that
   branches on terminality should use that set, not a hand-rolled list.
-- **Partial unique index on idempotency_key.** Active tasks (non-terminal)
-  must have unique keys. Terminal ones can repeat. Implemented in
+- **Idempotency: same key = same task, always (Stripe-strict).**
+  Direct-mode `await_human()` is resumable across agent restarts —
+  re-invoking with the same key returns the stored response (for
+  COMPLETED tasks) or the typed terminal error (for TIMED_OUT /
+  CANCELLED / VERIFICATION_EXHAUSTED), never a duplicate. The
+  application-layer lookup (`_find_task_by_idempotency_key`) returns
+  any task regardless of status. To start a fresh task for the same
+  event, callers pass a distinct key (suffix convention: `:retry-N`).
+  The partial unique index on `idempotency_key` (gated on
+  non-terminal status) is kept for race safety on concurrent INSERTs
+  of new keys; with the application-layer lookup covering terminal
+  rows, it's never exercised on the recovery path. Implemented in
   `db/models/task.py` via `sqlite_where` / `postgresql_where` on
-  `Index`. Lets a developer retry a failed task with the same content
-  without hitting a constraint error.
+  `Index`. See `docs/concepts/idempotency.mdx` for the user-facing
+  contract.
 - **First-writer-wins completion.** `complete_task` does an atomic
   `UPDATE ... WHERE status NOT IN (terminal)` and checks `rowcount`.
   Raises `TaskAlreadyTerminalError` on loss — which can happen if the

--- a/docs/concepts/task-lifecycle.mdx
+++ b/docs/concepts/task-lifecycle.mdx
@@ -102,4 +102,4 @@ If the verifier rejects an attempt and we marked the task terminal, the human co
 - `max_attempts` is exhausted → `VERIFICATION_EXHAUSTED` (terminal)
 - Timeout fires → `TIMED_OUT` (terminal)
 
-This matches Stripe's idempotency-with-retry model: safe to retry, eventually settles.
+The lifecycle is shaped to settle exactly once. Once a task hits any terminal status, that status is the canonical answer for that idempotency key — re-invoking `await_human()` with the same key returns the same outcome rather than starting over. See [Idempotency](/concepts/idempotency).

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -79,7 +79,7 @@ def main():
         ),
         response_schema=RefundDecision,
         timeout_seconds=900,
-        idempotency_key=f"refund:{order_id}",  # safe to retry
+        idempotency_key=f"refund:{order_id}",  # same key = same task, even after restart
     )
 
     if decision.approved:
@@ -228,7 +228,7 @@ See [Verifier](/adapters/verifier) for the full provider list and NL-parsing tri
     The state machine your task moves through.
   </Card>
   <Card title="Idempotency" icon="rotate" href="/concepts/idempotency">
-    Why retries are safe and what `idempotency_key` actually does.
+    How the same key recovers the same task across crashes.
   </Card>
   <Card title="Temporal" icon="repeat" href="/adapters/temporal">
     Park a workflow for hours/days while waiting. Zero compute idle.

--- a/examples/quickstart-ts/refund.ts
+++ b/examples/quickstart-ts/refund.ts
@@ -52,12 +52,16 @@ async function main(): Promise<void> {
 		},
 		responseSchema: Decision,
 		timeoutMs: 900_000, // 15 minutes — plenty of time to walk to the kitchen
-		// Ties retries of the same order to the same task. If the agent
-		// crashes after creating the task and the orchestrator retries,
-		// the server returns the existing task instead of stacking
-		// duplicates. Without an explicit key the SDK auto-hashes
-		// (task, payload) — fine for dev, but tie to your real business
-		// event (orderId, transferId, requestId) in production.
+		// Ties this call to the order. Same key, same task — forever.
+		// If the agent crashes mid-call and the human approves during
+		// the outage, re-running with the same key returns the stored
+		// decision (the `if (decision.approved)` block runs as if
+		// nothing happened). Without an explicit key the SDK
+		// auto-hashes (task, payload) — fine for dev, but tie to your
+		// real business event (orderId, transferId, requestId) in
+		// production. To start a fresh review for the same event
+		// (e.g. yesterday's task timed out), use a distinct key like
+		// `refund:${orderId}:retry-1`.
 		idempotencyKey: `refund:${orderId}`,
 	});
 

--- a/examples/quickstart/refund.py
+++ b/examples/quickstart/refund.py
@@ -61,12 +61,16 @@ def main() -> None:
         ),
         response_schema=Decision,
         timeout_seconds=900,  # 15 minutes — plenty of time to walk to the kitchen
-        # Ties retries of the same order to the same task. If the agent
-        # crashes after creating the task and the orchestrator retries,
-        # the server returns the existing task instead of stacking
-        # duplicates. Without an explicit key the SDK auto-hashes
-        # (task, payload) — fine for dev, but tie to your real business
-        # event (order_id, transfer_id, request_id) in production.
+        # Ties this call to the order. Same key, same task — forever.
+        # If the agent crashes mid-call and the human approves during
+        # the outage, re-running with the same key returns the stored
+        # decision (this `if decision.approved:` block runs as if
+        # nothing happened). Without an explicit key the SDK
+        # auto-hashes (task, payload) — fine for dev, but tie to your
+        # real business event (order_id, transfer_id, request_id) in
+        # production. To start a fresh review for the same event
+        # (e.g. yesterday's task timed out), use a distinct key like
+        # f"refund:{order_id}:retry-1".
         idempotency_key=f"refund:{order_id}",
     )
 

--- a/packages/python/awaithumans/client.py
+++ b/packages/python/awaithumans/client.py
@@ -109,6 +109,14 @@ async def await_human(
     Direct mode: creates a task on the server, then long-polls until the
     human completes it or the timeout expires.
 
+    Resumable: same `idempotency_key` returns the same task forever. If
+    the agent crashes mid-await and the human completes during the
+    outage, re-invoking with the same key returns the stored response
+    (your `if decision.approved:` block runs as if nothing happened).
+    To start a fresh task for the same event after a previous one
+    timed out / was cancelled / was completed, use a distinct key
+    (e.g. f"{base}:retry-1"). See docs/concepts/idempotency.
+
     For durable mode, use awaithumans.temporal or awaithumans.langgraph instead.
     """
     # ── Validate timeout range ───────────────────────────────────────

--- a/packages/python/awaithumans/server/db/models/task.py
+++ b/packages/python/awaithumans/server/db/models/task.py
@@ -13,15 +13,20 @@ from awaithumans.types import TaskStatus
 from awaithumans.utils.constants import TERMINAL_STATUSES_SET
 
 # Partial unique index — only ACTIVE tasks have unique idempotency keys.
-# After a task reaches a terminal state, another task with the same key
-# can be created. This lets developers retry failed/timed-out tasks
-# with the same content without hitting a duplicate-key error.
+# Terminal rows are excluded from the index so the application-layer
+# lookup (`_find_task_by_idempotency_key`) can return ANY task with a
+# given key — including terminal ones — for the resumable-direct-mode
+# recovery path: an agent that crashes during a human review and
+# re-invokes `await_human()` with the same key gets back the stored
+# response instead of creating a duplicate. The partial index is kept
+# purely for race safety on concurrent INSERTs of *new* keys; in
+# practice it never fires on the recovery path because the lookup
+# returns the existing row before any INSERT is attempted.
 #
 # SQLAlchemy stores enum columns as the enum's NAME (uppercase),
 # not .value (lowercase). The WHERE clause has to match, or the
-# partial index never filters anything and the "retry after terminal"
-# story silently fails with a raw UNIQUE violation. Derive the names
-# from TERMINAL_STATUSES_SET so this can't drift.
+# partial index never filters anything. Derive the names from
+# TERMINAL_STATUSES_SET so this can't drift.
 _TERMINAL_STATUS_VALUES = (
     "(" + ", ".join(f"'{s.name}'" for s in sorted(TERMINAL_STATUSES_SET, key=lambda s: s.name)) + ")"
 )

--- a/packages/python/awaithumans/types/task.py
+++ b/packages/python/awaithumans/types/task.py
@@ -44,7 +44,15 @@ class AwaitHumanOptions(BaseModel):
         description='E.g., ["slack:#ops", "email:a@b.com"]',
     )
     verifier: VerifierConfig | None = Field(default=None, description="AI verification config.")
-    idempotency_key: str | None = Field(default=None, description="Explicit idempotency key.")
+    idempotency_key: str | None = Field(
+        default=None,
+        description=(
+            "Explicit idempotency key. Same key = same task, even after restart "
+            "or terminal status — re-invocation returns the stored response "
+            "(or terminal-status error) instead of creating a duplicate. To "
+            'start a fresh task for the same event, use a distinct key (e.g. ":retry-1").'
+        ),
+    )
     redact_payload: bool = Field(default=False, description="If true, audit log hides payload.")
 
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/packages/typescript-sdk/src/types/task.ts
+++ b/packages/typescript-sdk/src/types/task.ts
@@ -42,7 +42,15 @@ export interface AwaitHumanOptions<TPayload, TResponse> {
 	/** AI verifier config — sent to the server for execution. Optional — no verifier = human answer trusted. */
 	verifier?: VerifierConfig;
 
-	/** Explicit idempotency key. Defaults to content hash (direct mode) or engine identity (durable adapters). */
+	/**
+	 * Explicit idempotency key. Defaults to content hash (direct mode)
+	 * or engine identity (durable adapters).
+	 *
+	 * Same key = same task, even after restart or terminal status —
+	 * re-invocation returns the stored response (or terminal-status
+	 * error) instead of creating a duplicate. To start a fresh task
+	 * for the same event, use a distinct key (e.g. `:retry-1` suffix).
+	 */
 	idempotencyKey?: string;
 
 	/** If true, audit log hides the payload body. */


### PR DESCRIPTION
Audits every surface that explained or alluded to the old "retry-after-terminal releases the key" semantics and updates each to match the Stripe-strict contract introduced in the previous commit. No code behavior changes — purely docs, comments, and docstrings catching up to the new contract so users (human and AI) get one consistent story.

Surfaces touched:
  - docs/concepts/task-lifecycle.mdx — replace the Stripe-with-retry framing at the bottom with the "settles exactly once" framing
  - docs/quickstart.mdx — inline `# safe to retry` comment and the "Why retries are safe" card link description
  - examples/quickstart/refund.py + quickstart-ts/refund.ts — the long inline idempotency-key explanation now describes resumption across restarts and the suffixed-key escape hatch
  - packages/python/awaithumans/client.py — `await_human()` docstring now leads with the resumability guarantee
  - packages/python/awaithumans/types/task.py — `idempotency_key` field description rewritten
  - packages/typescript-sdk/src/types/task.ts — same for the TS SDK `idempotencyKey` JSDoc
  - packages/python/awaithumans/server/db/models/task.py — partial unique index comment now explains the index is kept for race safety on new-key INSERTs; the application-layer lookup is what handles recovery
  - BUILD_NOTES.md — the database-architecture note about the partial unique index now matches the new contract

Tests untouched (all 122 passing). docs/concepts/idempotency.mdx and docs/api/create-task.mdx were already updated in the prior commit.