### PR TITLE
feat(langgraph-examples): AWAITHUMANS_DEMO_ASSIGN_TO env var

### DIFF
--- a/examples/langgraph-py/README.md
+++ b/examples/langgraph-py/README.md
@@ -60,6 +60,10 @@ cd examples/langgraph-py
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 export AWAITHUMANS_PAYLOAD_KEY=$(cat /tmp/<your-dev-cwd>/.awaithumans/payload.key)
+# Demo-only: pre-assign every human-review task to your dashboard
+# login so the Approve / Reject form renders immediately. Leave
+# unset in production — operators claim tasks from the dashboard.
+export AWAITHUMANS_DEMO_ASSIGN_TO="you@example.com"
 uvicorn app:app --host 0.0.0.0 --port 8765
 
 # Terminal 3 — kick off a run

--- a/examples/langgraph-py/app.py
+++ b/examples/langgraph-py/app.py
@@ -85,11 +85,22 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
         awaithumans_api_key=api_key,
         callback_base=CALLBACK_BASE,
         auto_approve_threshold_usd=100.0,
+        # Demo convenience: pre-assign tasks to the operator who'll
+        # approve them in the dashboard, so the response form
+        # renders without needing a Claim flow. Leave unset in
+        # production; operators claim from the dashboard once that
+        # button ships.
+        assign_to_email=os.environ.get("AWAITHUMANS_DEMO_ASSIGN_TO") or None,
     )
     _graph = build_refund_graph(cfg, _thread_id_ref)
     logger.info("[app] graph + callback at http://localhost:%s", PORT)
     logger.info("[app] awaithumans server: %s", server_url)
     logger.info("[app] callback base: %s", CALLBACK_BASE)
+    if cfg.assign_to_email:
+        logger.info(
+            "[app] tasks will be assigned to %s (AWAITHUMANS_DEMO_ASSIGN_TO)",
+            cfg.assign_to_email,
+        )
     yield
 
 

--- a/examples/langgraph-py/graph.py
+++ b/examples/langgraph-py/graph.py
@@ -80,6 +80,16 @@ class GraphConfig(BaseModel):
     callback_base: str          # e.g. "http://localhost:8765"
     auto_approve_threshold_usd: float
 
+    # Optional: assign every human-review task to this email on
+    # creation. Leaving this unset creates unassigned tasks, which is
+    # fine in production (operators claim from the dashboard) but
+    # awkward in the demo because the dashboard has no Claim button
+    # YET — see https://github.com/awaithumans/awaithumans/issues/...
+    # The cleanest demo-time fix is to assign tasks to whichever
+    # operator email is logged into the dashboard so the response form
+    # renders immediately.
+    assign_to_email: str | None = None
+
 
 # ─── Nodes ─────────────────────────────────────────────────────────
 
@@ -142,6 +152,8 @@ def _make_human_review(cfg: GraphConfig, thread_id_ref: list[str]):
             server_url=cfg.awaithumans_server_url,
             api_key=cfg.awaithumans_api_key,
             idempotency_key=f"langgraph:{thread_id}:human_review",
+            # See `GraphConfig.assign_to_email` — None in production.
+            assign_to=cfg.assign_to_email,
         )
 
         logger.info(

--- a/examples/langgraph-ts/README.md
+++ b/examples/langgraph-ts/README.md
@@ -59,6 +59,10 @@ awaithumans dev
 cd examples/langgraph-ts
 npm install
 export AWAITHUMANS_PAYLOAD_KEY=$(cat /tmp/<your-dev-cwd>/.awaithumans/payload.key)
+# Demo-only: pre-assign every human-review task to your dashboard
+# login so the Approve / Reject form renders immediately. Leave
+# unset in production — operators claim tasks from the dashboard.
+export AWAITHUMANS_DEMO_ASSIGN_TO="you@example.com"
 npm run app
 
 # Terminal 3 — kick off a run

--- a/examples/langgraph-ts/app.ts
+++ b/examples/langgraph-ts/app.ts
@@ -72,17 +72,29 @@ async function main(): Promise<void> {
 	// call so the node knows which thread its callback URL should
 	// encode. A more idiomatic approach would thread `RunnableConfig`
 	// through node signatures — keeping this simple for the example.
+	// Demo convenience: pre-assign tasks to the operator who'll
+	// approve them in the dashboard, so the response form renders
+	// without needing a Claim flow. Leave unset in production;
+	// operators claim from the dashboard once that button ships.
+	const assignToEmail = process.env.AWAITHUMANS_DEMO_ASSIGN_TO || undefined;
+
 	const threadIdRef = { value: "<unset>" };
 	const graph = buildRefundGraph(
 		{
 			awaithumans: { serverUrl, apiKey, callbackBase: CALLBACK_BASE },
 			autoApproveThresholdUsd: 100,
+			assignToEmail,
 		},
 		threadIdRef,
 	) as unknown as CompiledStateGraph<
 		RefundStateType,
 		Partial<RefundStateType>
 	>;
+	if (assignToEmail) {
+		console.log(
+			`[app] tasks will be assigned to ${assignToEmail} (AWAITHUMANS_DEMO_ASSIGN_TO)`,
+		);
+	}
 
 	const handleCallback = createLangGraphCallbackHandler({
 		graph,

--- a/examples/langgraph-ts/graph.ts
+++ b/examples/langgraph-ts/graph.ts
@@ -70,6 +70,14 @@ export interface BuildGraphOptions {
 		callbackBase: string; // e.g. "http://localhost:8765"
 	};
 	autoApproveThresholdUsd: number;
+	// Optional: assign every human-review task to this email on
+	// creation. Leaving this unset creates unassigned tasks, which
+	// is fine in production (operators claim from the dashboard) but
+	// awkward in the demo because the dashboard's Claim button isn't
+	// shipped yet. The cleanest demo-time fix is to assign tasks to
+	// whichever operator email is logged into the dashboard so the
+	// response form renders immediately.
+	assignToEmail?: string;
 }
 
 // ─── Nodes ──────────────────────────────────────────────────────────
@@ -130,6 +138,8 @@ function makeHumanReview(opts: BuildGraphOptions, threadId: () => string) {
 			serverUrl: opts.awaithumans.serverUrl,
 			apiKey: opts.awaithumans.apiKey,
 			idempotencyKey: `langgraph:${threadId()}:humanReview`,
+			// See `BuildGraphOptions.assignToEmail` — undefined in production.
+			assignTo: opts.assignToEmail,
 		});
 
 		console.log(


### PR DESCRIPTION
## Summary

Quick demo unblock. The dashboard's response form (Approve / Reject) only renders when the viewer is the assignee — that's the auth model from #82. Both langgraph examples create tasks unassigned, so operators see "Task Payload + Timeline + Cancel/Delete" and no way to actually approve.

This adds an optional env var `AWAITHUMANS_DEMO_ASSIGN_TO` that pre-assigns every human-review task to that email. Set it once before starting the example app and tasks become actionable immediately:

```bash
export AWAITHUMANS_DEMO_ASSIGN_TO="you@example.com"
uvicorn app:app ...      # or: npm run app
```

Threaded through both:
- `examples/langgraph-py/app.py` → `GraphConfig.assign_to_email` → `await_human(assign_to=...)`
- `examples/langgraph-ts/app.ts` → `BuildGraphOptions.assignToEmail` → `awaitHuman({assignTo})`

Both READMEs document it as demo-only. Production users leave it unset and either pass `assign_to=` in their own code or use the upcoming dashboard Claim button (separate PR — see follow-up `feat/task-claim-flow`).

## Test plan
- [x] Existing E2E flow still works with the env var unset (no behavior change for the default path)
- [x] With `AWAITHUMANS_DEMO_ASSIGN_TO` set: task is created with `assigned_to_email` populated and the dashboard shows the response form
- [x] TypeScript example typechecks; Python example imports cleanly