### PR TITLE
feat: dashboard Claim flow + adapters derive form_definition

### DIFF
--- a/packages/dashboard/app/(dashboard)/task/page.tsx
+++ b/packages/dashboard/app/(dashboard)/task/page.tsx
@@ -9,6 +9,7 @@ import {
 	fetchMe,
 	completeTask,
 	cancelTask,
+	claimTask,
 	deleteTask,
 	type MeResponse,
 	type Task,
@@ -133,6 +134,19 @@ function TaskDetailPageInner() {
 		}
 	};
 
+	const handleClaim = async () => {
+		if (!task) return;
+		try {
+			await claimTask(task.id);
+			// Reload — the task now has assigned_to_user_id == me.user_id,
+			// so the response form starts rendering and the Claim button
+			// hides itself.
+			await loadTask();
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Failed to claim task");
+		}
+	};
+
 	const handleDelete = async () => {
 		if (!task) return;
 		const confirmed = window.confirm(
@@ -165,6 +179,33 @@ function TaskDetailPageInner() {
 			task.assigned_to_email !== me.email) ||
 			(task.assigned_to_user_id !== null &&
 				task.assigned_to_user_id !== me.user_id));
+
+	// Claim is available when (a) the task is non-terminal, (b) no one
+	// is assigned yet, and (c) the viewer is an operator (the only role
+	// the server's /claim route accepts). The button hides itself once
+	// a claim succeeds since `assigned_to_user_id` flips non-null on the
+	// next loadTask() refresh.
+	const canClaim =
+		!!task &&
+		!!me?.is_operator &&
+		!isTerminal &&
+		task.assigned_to_user_id === null &&
+		task.assigned_to_email === null;
+
+	// Whether to render the response form. Submitting requires the
+	// viewer to be the assignee OR an operator (per `/complete` auth).
+	// Without the `is_operator` branch, every operator who navigated to
+	// an unassigned task — even one they JUST claimed — would see the
+	// form disappear momentarily. With it, claimed-by-me tasks render
+	// the form right away.
+	const canSubmitResponse =
+		!!task &&
+		!isTerminal &&
+		!!task.form_definition &&
+		!!me &&
+		(me.is_operator ||
+			task.assigned_to_user_id === me.user_id ||
+			task.assigned_to_email === me.email);
 
 	if (loading) {
 		return <TerminalSpinner label="awaiting task" size="md" />;
@@ -206,6 +247,15 @@ function TaskDetailPageInner() {
 					</div>
 				</div>
 				<div className="flex items-center gap-2">
+					{canClaim && (
+						<button
+							type="button"
+							onClick={handleClaim}
+							className="px-3 py-1.5 text-sm rounded-md bg-brand text-black font-semibold hover:bg-brand/90 transition-colors"
+						>
+							Claim task
+						</button>
+					)}
 					{!isTerminal && (
 						<button
 							type="button"
@@ -266,8 +316,26 @@ function TaskDetailPageInner() {
 						)}
 					</div>
 
-					{/* Response Form (if not terminal) */}
-					{!isTerminal && task.form_definition && (
+					{/* Unassigned hint — only rendered for operators with claim eligibility,
+					    so the viewer knows they need to claim before they can respond. */}
+					{canClaim && (
+						<div className="border border-amber-400/20 rounded-lg p-5 bg-amber-400/5">
+							<div className="text-sm text-amber-200/90">
+								This task is unassigned.{" "}
+								<button
+									type="button"
+									onClick={handleClaim}
+									className="underline hover:text-amber-100 transition-colors"
+								>
+									Claim it
+								</button>{" "}
+								to submit a response.
+							</div>
+						</div>
+					)}
+
+					{/* Response Form (only when the viewer is allowed to submit) */}
+					{canSubmitResponse && (
 						<div className="border border-brand/20 rounded-lg p-5 bg-brand/5">
 							<Eyebrow as="h2" size="md" tone="brand" weight="semibold" className="block mb-4">
 								Your Response
@@ -287,7 +355,10 @@ function TaskDetailPageInner() {
 								</div>
 							)}
 							<FormRenderer
-								form={task.form_definition}
+								// `canSubmitResponse` already gates on form_definition
+								// being non-null; the type system doesn't carry that
+								// across the boolean, hence the `!`.
+								form={task.form_definition!}
 								value={formData}
 								onChange={setFormData}
 								disabled={submitting}

--- a/packages/dashboard/lib/server/index.ts
+++ b/packages/dashboard/lib/server/index.ts
@@ -48,7 +48,7 @@ export {
 	type TaskStatsByDay,
 } from "./stats";
 export { fetchSystemStatus, type SystemStatus } from "./status";
-export { cancelTask, completeTask, deleteTask, fetchTask, fetchTasks } from "./tasks";
+export { cancelTask, claimTask, completeTask, deleteTask, fetchTask, fetchTasks } from "./tasks";
 export {
 	clearUserPassword,
 	createUser,

--- a/packages/dashboard/lib/server/tasks.ts
+++ b/packages/dashboard/lib/server/tasks.ts
@@ -41,6 +41,15 @@ export async function cancelTask(taskId: string): Promise<Task> {
 	});
 }
 
+export async function claimTask(taskId: string): Promise<Task> {
+	// First-writer-wins on the server (UPDATE…WHERE assignee IS NULL).
+	// 409 surfaces as a thrown error from `apiFetch`; the caller's
+	// loadTask() will then refresh and show the assignee that won.
+	return apiFetch<Task>(`/api/tasks/${taskId}/claim`, {
+		method: "POST",
+	});
+}
+
 export async function deleteTask(taskId: string): Promise<void> {
 	await apiFetch<void>(`/api/tasks/${encodeURIComponent(taskId)}`, {
 		method: "DELETE",

--- a/packages/python/awaithumans/adapters/langgraph/__init__.py
+++ b/packages/python/awaithumans/adapters/langgraph/__init__.py
@@ -193,12 +193,20 @@ async def await_human(
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
 
+    # Derive form_definition from response_schema so the dashboard
+    # can render the Approve / Reject form. Direct-mode SDK does the
+    # same in `client.py:159`. Without this, an operator opening the
+    # task page sees the payload but no form to submit.
+    from awaithumans.forms import extract_form
+
+    form_definition = extract_form(response_schema).model_dump(mode="json")
+
     body = {
         "task": task,
         "payload": payload.model_dump(mode="json"),
         "payload_schema": payload_schema.model_json_schema(),
         "response_schema": response_schema.model_json_schema(),
-        "form_definition": None,
+        "form_definition": form_definition,
         "timeout_seconds": timeout_seconds,
         "idempotency_key": idem,
         "assign_to": _serialize_assign_to(assign_to),

--- a/packages/python/awaithumans/adapters/temporal/__init__.py
+++ b/packages/python/awaithumans/adapters/temporal/__init__.py
@@ -316,6 +316,19 @@ async def await_human(
     else:
         assign_to_dict = {"value": str(assign_to)}
 
+    # Derive form_definition from response_schema so the dashboard can
+    # render the Approve / Reject form when an operator claims the
+    # task. Direct-mode SDK does the same in `client.py:159`. Without
+    # this, dashboard-driven approval has nothing to render.
+    #
+    # Imported INSIDE the workflow function (with the lazy
+    # `imports_passed_through` already in effect) so the heavy
+    # `awaithumans.forms` module isn't loaded at every workflow
+    # replay's first activation — only the once-per-await-human path.
+    from awaithumans.forms import extract_form
+
+    form_definition = extract_form(response_schema).model_dump(mode="json")
+
     create_input = _CreateTaskInput(
         server_url=server_url,
         api_key=api_key,
@@ -323,7 +336,7 @@ async def await_human(
         payload=payload_dict,
         payload_schema=payload_schema.model_json_schema(),
         response_schema=response_schema.model_json_schema(),
-        form_definition=None,  # form-rendering is direct-mode only for v1
+        form_definition=form_definition,
         timeout_seconds=timeout_seconds,
         idempotency_key=idem,
         callback_url=callback_url,

--- a/packages/python/awaithumans/server/routes/tasks.py
+++ b/packages/python/awaithumans/server/routes/tasks.py
@@ -44,6 +44,7 @@ from awaithumans.server.schemas import (
 from awaithumans.server.services.exceptions import TaskNotFoundError
 from awaithumans.server.services.task_service import (
     cancel_task,
+    claim_task,
     complete_task,
     create_task,
     delete_task,
@@ -338,6 +339,53 @@ async def _session_user_email(request: Request, session: AsyncSession) -> str | 
         return None
     user = await get_user(session, claims.user_id)
     return user.email if user else None
+
+
+@router.post("/{task_id}/claim", response_model=TaskResponse)
+async def claim_task_route(
+    task_id: str,
+    request: Request,
+    session: AsyncSession = Depends(get_session),
+) -> TaskResponse:
+    """Claim an unassigned task for the logged-in operator.
+
+    Mirrors the Slack "Claim" button and the email-handoff auto-claim
+    in shape — first-writer-wins via the `claim_task` service. Used
+    by the dashboard so an operator can become the assignee on a
+    broadcast (`notify=`) task or a task created without `assign_to=`.
+    Once assigned, the task page renders the response form so the
+    operator can submit Approve / Reject.
+
+    Caller MUST have a cookie session (operator-or-admin in our
+    role model). Pure admin-bearer is rejected — that token belongs
+    to the AI agent, not a human operator, so there's no user_id to
+    pin as the assignee. If you find yourself wanting to "admin-claim"
+    a task, log in to the dashboard with your operator account first.
+    """
+    require_operator_or_admin(request)
+
+    user_id = caller_user_id(request)
+    if user_id is None:
+        # Admin bearer with no session → no human identity to claim as.
+        from fastapi import HTTPException
+
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Claim requires a logged-in operator session. "
+                "Admin bearer tokens have no user identity to assign."
+            ),
+        )
+
+    claimer_email = await _session_user_email(request, session)
+    task = await claim_task(
+        session,
+        task_id=task_id,
+        user_id=user_id,
+        user_email=claimer_email,
+        claimed_via_channel="dashboard",
+    )
+    return await _task_to_response_with_lookup(session, task)
 
 
 @router.post("/{task_id}/cancel", response_model=TaskResponse)

--- a/packages/python/tests/tasks/test_route_authorization.py
+++ b/packages/python/tests/tasks/test_route_authorization.py
@@ -28,7 +28,7 @@ from awaithumans.server.app import create_app
 from awaithumans.server.core.config import settings
 from awaithumans.server.db.models import User
 
-from tests.auth.conftest import OPERATOR_PASSWORD
+from tests.auth.conftest import OPERATOR_EMAIL, OPERATOR_PASSWORD
 
 REVIEWER_EMAIL = "reviewer@example.com"
 REVIEWER_PASSWORD = "reviewer-correct-horse-battery"
@@ -296,3 +296,82 @@ def test_complete_own_task_succeeds_for_assignee(
     )
     assert resp.status_code == 200
     assert resp.json()["status"] == "completed"
+
+
+# ─── /claim ─────────────────────────────────────────────────────────────
+
+
+def test_claim_assigns_unassigned_task_to_caller(
+    client: TestClient, operator_user: User
+) -> None:
+    """The dashboard happy path: an operator opens an unassigned task
+    and clicks Claim. The route should pin them as the assignee so the
+    response form renders on the next page load."""
+    task_id = _make_task(client, idempotency_key="claim-1")  # no assign_to
+    _login(client, OPERATOR_EMAIL, OPERATOR_PASSWORD)
+    resp = client.post(f"/api/tasks/{task_id}/claim")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["assigned_to_email"] == OPERATOR_EMAIL
+    assert body["assigned_to_user_id"] == operator_user.id
+
+
+def test_claim_blocked_for_non_operator(
+    client: TestClient, reviewer_user: User
+) -> None:
+    """Claim is operator-or-admin (mirror of cancel/audit). A
+    non-operator reviewer must not be able to claim broadcast tasks
+    out from under operators — claim is an operator action."""
+    task_id = _make_task(client, idempotency_key="claim-2")
+    _login(client, REVIEWER_EMAIL, REVIEWER_PASSWORD)
+    resp = client.post(f"/api/tasks/{task_id}/claim")
+    assert resp.status_code == 403
+
+
+def test_claim_with_admin_bearer_400(client: TestClient) -> None:
+    """Admin bearer is the AI agent's identity — there's no human
+    user_id to pin as assignee. The route fails fast with 400 so the
+    caller gets a clear "log in as an operator first" message instead
+    of a misleading 200 with a null assignee."""
+    task_id = _make_task(client, idempotency_key="claim-3")
+    resp = client.post(f"/api/tasks/{task_id}/claim", headers=_admin_headers())
+    assert resp.status_code == 400
+    assert "operator" in resp.json()["detail"].lower()
+
+
+def test_claim_already_assigned_returns_409(
+    client: TestClient, operator_user: User, other_user: User
+) -> None:
+    """Claim is first-writer-wins via the existing service. Trying to
+    claim a task that already has an assignee surfaces
+    `TaskAlreadyClaimedError` → 409, so the dashboard can render
+    "claimed by Other"."""
+    task_id = _make_task(
+        client, assigned_to_email=OTHER_USER_EMAIL, idempotency_key="claim-4"
+    )
+    _login(client, OPERATOR_EMAIL, OPERATOR_PASSWORD)
+    resp = client.post(f"/api/tasks/{task_id}/claim")
+    assert resp.status_code == 409
+
+
+def test_claim_terminal_task_returns_409(
+    client: TestClient, operator_user: User
+) -> None:
+    """Claim on a completed/cancelled/timed-out task is meaningless.
+    The service raises `TaskAlreadyTerminalError` which the central
+    handler maps to 409."""
+    task_id = _make_task(
+        client,
+        assigned_to_email=OPERATOR_EMAIL,
+        idempotency_key="claim-5",
+    )
+    # Operator completes it via admin (so we don't tangle the test
+    # with an extra login round-trip).
+    client.post(
+        f"/api/tasks/{task_id}/complete",
+        json={"response": {"approved": True}},
+        headers=_admin_headers(),
+    )
+    _login(client, OPERATOR_EMAIL, OPERATOR_PASSWORD)
+    resp = client.post(f"/api/tasks/{task_id}/claim")
+    assert resp.status_code == 409

--- a/packages/typescript-sdk/src/adapters/langgraph/index.ts
+++ b/packages/typescript-sdk/src/adapters/langgraph/index.ts
@@ -82,6 +82,7 @@ import {
 	TaskTimeoutError,
 	VerificationExhaustedError,
 } from "../../errors.js";
+import { extractForm } from "../../forms/index.js";
 import { generateIdempotencyKey } from "../../internal/idempotency.js";
 import {
 	serializeAssignTo,
@@ -184,13 +185,19 @@ export async function awaitHuman<TPayload, TResponse>(
 	const payloadJsonSchema = zodToJsonSchema(options.payloadSchema);
 	const responseJsonSchema = zodToJsonSchema(options.responseSchema);
 	const timeoutSeconds = Math.round(options.timeoutMs / 1000);
+	// Derive form_definition from responseSchema so the dashboard can
+	// render the Approve / Reject form when an operator opens or
+	// claims the task. Direct-mode SDK does the same in
+	// `await-human.ts`. Without this, dashboard-driven approval has
+	// nothing to render.
+	const formDefinition = extractForm(options.responseSchema);
 
 	const body = {
 		task: options.task,
 		payload: options.payload,
 		payload_schema: payloadJsonSchema,
 		response_schema: responseJsonSchema,
-		form_definition: null,
+		form_definition: formDefinition,
 		timeout_seconds: timeoutSeconds,
 		idempotency_key: idempotencyKey,
 		assign_to: serializeAssignTo(options.assignTo as AssignTo | undefined),

--- a/packages/typescript-sdk/src/adapters/temporal/index.ts
+++ b/packages/typescript-sdk/src/adapters/temporal/index.ts
@@ -79,6 +79,7 @@ import {
 	TaskTimeoutError,
 	VerificationExhaustedError,
 } from "../../errors.js";
+import { extractForm } from "../../forms/index.js";
 import {
 	serializeAssignTo,
 	serializeVerifierConfig,
@@ -209,6 +210,12 @@ export async function awaitHuman<TPayload, TResponse>(
 	const payloadJsonSchema = zodToJsonSchema(options.payloadSchema);
 	const responseJsonSchema = zodToJsonSchema(options.responseSchema);
 	const timeoutSeconds = Math.round(options.timeoutMs / 1000);
+	// Derive form_definition from responseSchema so the dashboard can
+	// render the Approve / Reject form when an operator opens or
+	// claims the task. Direct-mode SDK does the same in
+	// `await-human.ts`. Without this, dashboard-driven approval has
+	// nothing to render.
+	const formDefinition = extractForm(options.responseSchema);
 
 	// Serialize the create-task wire body in the workflow (deterministic),
 	// then ship it through an activity (where HTTP is allowed).
@@ -217,7 +224,7 @@ export async function awaitHuman<TPayload, TResponse>(
 		payload: options.payload,
 		payload_schema: payloadJsonSchema,
 		response_schema: responseJsonSchema,
-		form_definition: null,
+		form_definition: formDefinition,
 		timeout_seconds: timeoutSeconds,
 		idempotency_key: idempotencyKey,
 		assign_to: serializeAssignTo(options.assignTo as AssignTo | undefined),


### PR DESCRIPTION
## Summary

Closes the two gaps that surfaced when the user tried to approve an adapter-created task from the dashboard:

1. **No response form rendered** — the four adapters (TS + Py × Temporal + LangGraph) passed `form_definition: null` to the server, so the dashboard had nothing to render. Direct-mode SDK derives it from `response_schema` via `extract_form`; this PR makes the adapters do the same.
2. **No way to become the assignee** — `/complete` requires the viewer to be the assignee, but there was no Claim button. Operators were stuck at "Cancel / Delete" with no path to approve.

## What changed

**Server (`packages/python`):**
- New `POST /api/tasks/{id}/claim`, operator-or-admin gated, reuses the existing `claim_task` service (first-writer-wins via `UPDATE…WHERE assignee IS NULL`).
- Admin-bearer returns 400 (no `user_id` to assign — admin tokens are the AI agent's identity, not a human's).
- 5 new tests covering success / 403 / 400 / 409-already-claimed / 409-terminal. Server suite: 513 passed.

**Adapters (Py + TS, Temporal + LangGraph):**
- All four now call `extract_form(response_schema)` and send the result as `form_definition`. SDK unit tests still pass (66 / 66).

**Dashboard (`packages/dashboard`):**
- New `claimTask()` API helper.
- "Claim task" button + inline amber callout when status is non-terminal, task is unassigned, and viewer is an operator.
- `canSubmitResponse` check replaces the old "render form whenever non-terminal" gate, so a non-operator viewing an unassigned task sees no orphaned form.

## E2E verification

Run with `awaithumans dev` + `langgraph-py` example, no `AWAITHUMANS_DEMO_ASSIGN_TO`:

- [x] Start unassigned task → returns interrupted with `form_definition: object` (was `null`).
- [x] Operator session POSTs `/claim` → assignee becomes operator.
- [x] Cookie session POSTs `/complete` → task `completed`; `completed_by_email = operator@test.dev`.
- [x] Webhook delivery `succeeded` first try (HTTP 200).
- [x] Graph resumes; final state has `approved: true, notes: "claim flow e2e ✓"`.
- [x] Re-claim of the completed task returns 409 `TASK_ALREADY_TERMINAL`.

## Relationship to #68

#68 adds an opt-in `AWAITHUMANS_DEMO_ASSIGN_TO` env var to the langgraph examples for the same reason. With this PR merged, that workaround becomes unnecessary — operators just claim from the dashboard. Both can land independently; we'd remove the env var from #68's examples in a small cleanup PR after.