### PR TITLE
feat(dashboard): tasks page filter bar + pagination

### DIFF
--- a/packages/dashboard/app/(dashboard)/page.tsx
+++ b/packages/dashboard/app/(dashboard)/page.tsx
@@ -1,12 +1,20 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
-import { fetchTasks, type Task, type TaskStatus } from "@/lib/server";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+	fetchMe,
+	fetchTasks,
+	type MeResponse,
+	type Task,
+	type TaskStatus,
+} from "@/lib/server";
 import { assigneeLabel, cn, formatRelativeTime } from "@/lib/utils";
 import {
 	SECONDS_PER_MINUTE,
 	TASK_ID_TRUNCATE_LENGTH,
+	TASK_LIST_DEFAULT_PAGE_SIZE,
+	TASK_LIST_PAGE_SIZES,
 	TASK_LIST_POLL_INTERVAL_MS,
 } from "@/lib/constants";
 import { ErrorBanner } from "@/components/error-banner";
@@ -14,26 +22,136 @@ import { ShellEmptyState } from "@/components/shell-empty-state";
 import { StatusBadge } from "@/components/status-badge";
 import { TerminalSpinner } from "@/components/terminal-spinner";
 
-const STATUS_FILTERS: { label: string; value: TaskStatus | "all" }[] = [
+const STATUS_OPTIONS: { label: string; value: TaskStatus | "all" }[] = [
 	{ label: "All", value: "all" },
-	{ label: "Pending", value: "created" },
+	{ label: "Created", value: "created" },
+	{ label: "Notified", value: "notified" },
 	{ label: "Assigned", value: "assigned" },
+	{ label: "In progress", value: "in_progress" },
+	{ label: "Submitted", value: "submitted" },
+	{ label: "Verified", value: "verified" },
 	{ label: "Completed", value: "completed" },
-	{ label: "Timed Out", value: "timed_out" },
+	{ label: "Rejected", value: "rejected" },
+	{ label: "Timed out", value: "timed_out" },
 	{ label: "Cancelled", value: "cancelled" },
+	{ label: "Verification exhausted", value: "verification_exhausted" },
 ];
 
+interface FilterState {
+	status: TaskStatus | "all";
+	assignedTo: string;
+	unassigned: boolean;
+	mine: boolean;
+	pageSize: number;
+	offset: number;
+}
+
+const DEFAULT_FILTERS: FilterState = {
+	status: "all",
+	assignedTo: "",
+	unassigned: false,
+	mine: false,
+	pageSize: TASK_LIST_DEFAULT_PAGE_SIZE,
+	offset: 0,
+};
+
+/**
+ * URL-synced state. Each filter knob writes through to the query
+ * string so refresh-and-share-a-link works. Reading the URL on every
+ * render keeps the component a single source of truth — the URL.
+ */
+function readFiltersFromSearchParams(
+	params: URLSearchParams,
+): FilterState {
+	const rawStatus = params.get("status") ?? "all";
+	const status = STATUS_OPTIONS.some((o) => o.value === rawStatus)
+		? (rawStatus as TaskStatus | "all")
+		: "all";
+	const rawSize = Number(params.get("pageSize") ?? TASK_LIST_DEFAULT_PAGE_SIZE);
+	const pageSize = TASK_LIST_PAGE_SIZES.includes(rawSize)
+		? rawSize
+		: TASK_LIST_DEFAULT_PAGE_SIZE;
+	const offset = Math.max(0, Number(params.get("offset") ?? "0") || 0);
+	return {
+		status,
+		assignedTo: params.get("assignedTo") ?? "",
+		unassigned: params.get("unassigned") === "true",
+		mine: params.get("mine") === "true",
+		pageSize,
+		offset,
+	};
+}
+
+function filtersToSearchParams(state: FilterState): URLSearchParams {
+	const sp = new URLSearchParams();
+	if (state.status !== "all") sp.set("status", state.status);
+	if (state.assignedTo) sp.set("assignedTo", state.assignedTo);
+	if (state.unassigned) sp.set("unassigned", "true");
+	if (state.mine) sp.set("mine", "true");
+	if (state.pageSize !== TASK_LIST_DEFAULT_PAGE_SIZE)
+		sp.set("pageSize", String(state.pageSize));
+	if (state.offset > 0) sp.set("offset", String(state.offset));
+	return sp;
+}
+
 export default function TaskQueuePage() {
+	// Suspense boundary required for `useSearchParams` under the
+	// dashboard's static export build (matches the task detail page).
+	return (
+		<Suspense fallback={<TerminalSpinner label="awaiting tasks" size="md" />}>
+			<TaskQueuePageInner />
+		</Suspense>
+	);
+}
+
+function TaskQueuePageInner() {
 	const router = useRouter();
+	const searchParams = useSearchParams();
+	const filters = useMemo(
+		() => readFiltersFromSearchParams(searchParams),
+		[searchParams],
+	);
+
 	const [tasks, setTasks] = useState<Task[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
-	const [statusFilter, setStatusFilter] = useState<TaskStatus | "all">("all");
+	const [me, setMe] = useState<MeResponse | null>(null);
 
-	const loadTasks = async () => {
+	const updateFilters = useCallback(
+		(patch: Partial<FilterState>) => {
+			// Mutating filters (status / mine / etc.) snaps offset back
+			// to 0 — staying on page 5 of a different filter is rarely
+			// what the user wants and breaks "Next is empty" detection.
+			const offsetBumped = "offset" in patch && patch.offset !== undefined;
+			const next: FilterState = {
+				...filters,
+				...patch,
+				offset: offsetBumped ? (patch.offset as number) : 0,
+			};
+			const sp = filtersToSearchParams(next);
+			const query = sp.toString();
+			// `replace` so the browser's back button doesn't accumulate
+			// a per-filter-tweak history entry.
+			router.replace(query ? `/?${query}` : "/", { scroll: false });
+		},
+		[filters, router],
+	);
+
+	const loadTasks = useCallback(async () => {
 		try {
 			setError(null);
-			const params = statusFilter === "all" ? {} : { status: statusFilter };
+			const params: Parameters<typeof fetchTasks>[0] = {
+				limit: filters.pageSize,
+				offset: filters.offset,
+			};
+			if (filters.status !== "all") params.status = filters.status;
+			if (filters.unassigned) {
+				params.unassigned = true;
+			} else if (filters.mine && me?.email) {
+				params.assigned_to = me.email;
+			} else if (filters.assignedTo) {
+				params.assigned_to = filters.assignedTo;
+			}
 			const data = await fetchTasks(params);
 			setTasks(data);
 		} catch (err) {
@@ -41,41 +159,133 @@ export default function TaskQueuePage() {
 		} finally {
 			setLoading(false);
 		}
-	};
+	}, [filters, me?.email]);
+
+	// Fetch /me once; needed for "Mine only" → assigned_to=me.email.
+	useEffect(() => {
+		fetchMe()
+			.then(setMe)
+			.catch(() => setMe(null));
+	}, []);
 
 	useEffect(() => {
 		loadTasks();
-		// Poll every 5 seconds for updates
 		const interval = setInterval(loadTasks, TASK_LIST_POLL_INTERVAL_MS);
 		return () => clearInterval(interval);
-	}, [statusFilter]);
+	}, [loadTasks]);
+
+	const currentPage = Math.floor(filters.offset / filters.pageSize) + 1;
+	// We don't know the total — Next is disabled when fewer than a
+	// full page came back (the server can't possibly have more rows
+	// after this offset under the same filters).
+	const hasNextPage = tasks.length === filters.pageSize;
+
+	const filtersActive =
+		filters.status !== "all" ||
+		filters.assignedTo !== "" ||
+		filters.unassigned ||
+		filters.mine;
 
 	return (
 		<div>
-			<div className="flex items-center justify-between mb-6">
+			<div className="flex items-center justify-between mb-4">
 				<div>
 					<h1 className="text-2xl font-bold">Tasks</h1>
 					<p className="text-white/40 text-sm mt-1">
-						{tasks.length} task{tasks.length !== 1 ? "s" : ""}
+						{loading
+							? "loading…"
+							: `${tasks.length} on this page` +
+								(filtersActive ? " (filtered)" : "")}
 					</p>
 				</div>
-				<div className="flex gap-2">
-					{STATUS_FILTERS.map((f) => (
-						<button
-							key={f.value}
-							type="button"
-							onClick={() => setStatusFilter(f.value)}
-							className={cn(
-								"px-3 py-1.5 text-sm rounded-md border transition-colors",
-								statusFilter === f.value
-									? "bg-brand/10 text-brand border-brand/30"
-									: "bg-white/5 text-white/50 border-white/10 hover:text-white/80",
-							)}
-						>
-							{f.label}
-						</button>
-					))}
-				</div>
+			</div>
+
+			{/* Filter bar */}
+			<div className="border border-white/10 rounded-lg p-4 mb-6 flex flex-wrap items-center gap-3">
+				{/* Status dropdown */}
+				<label className="flex items-center gap-2 text-sm text-white/60">
+					<span>Status</span>
+					<select
+						value={filters.status}
+						onChange={(e) =>
+							updateFilters({
+								status: e.target.value as TaskStatus | "all",
+							})
+						}
+						className="bg-white/5 border border-white/10 rounded-md px-2 py-1 text-sm text-white focus:outline-none focus:border-brand/40"
+					>
+						{STATUS_OPTIONS.map((o) => (
+							<option key={o.value} value={o.value}>
+								{o.label}
+							</option>
+						))}
+					</select>
+				</label>
+
+				{/* Assignee email */}
+				<label className="flex items-center gap-2 text-sm text-white/60">
+					<span>Assignee</span>
+					<input
+						type="text"
+						placeholder="email"
+						value={filters.assignedTo}
+						disabled={filters.unassigned || filters.mine}
+						onChange={(e) =>
+							updateFilters({ assignedTo: e.target.value })
+						}
+						className="bg-white/5 border border-white/10 rounded-md px-2 py-1 text-sm text-white placeholder:text-white/30 focus:outline-none focus:border-brand/40 disabled:opacity-40 disabled:cursor-not-allowed"
+					/>
+				</label>
+
+				{/* Toggles */}
+				<label className="flex items-center gap-2 text-sm text-white/60 cursor-pointer">
+					<input
+						type="checkbox"
+						checked={filters.unassigned}
+						onChange={(e) =>
+							updateFilters({
+								unassigned: e.target.checked,
+								// Mutually-exclusive with Mine.
+								mine: e.target.checked ? false : filters.mine,
+							})
+						}
+						className="accent-brand"
+					/>
+					<span>Unassigned only</span>
+				</label>
+				{me?.is_operator && (
+					<label className="flex items-center gap-2 text-sm text-white/60 cursor-pointer">
+						<input
+							type="checkbox"
+							checked={filters.mine}
+							onChange={(e) =>
+								updateFilters({
+									mine: e.target.checked,
+									unassigned: e.target.checked ? false : filters.unassigned,
+								})
+							}
+							className="accent-brand"
+						/>
+						<span>Mine only</span>
+					</label>
+				)}
+
+				{filtersActive && (
+					<button
+						type="button"
+						onClick={() =>
+							updateFilters({
+								status: "all",
+								assignedTo: "",
+								unassigned: false,
+								mine: false,
+							})
+						}
+						className="ml-auto text-xs text-white/40 hover:text-white/70 transition-colors underline"
+					>
+						Clear filters
+					</button>
+				)}
 			</div>
 
 			{error && <ErrorBanner message={error} />}
@@ -197,6 +407,58 @@ main();`,
 							))}
 						</tbody>
 					</table>
+				</div>
+			)}
+
+			{/* Pagination footer — rendered whenever we have rows OR we
+			    are on a non-first page (so an over-shot offset can page
+			    back). Hidden on the empty-state, which has its own
+			    onboarding snippet. */}
+			{(tasks.length > 0 || filters.offset > 0) && !loading && (
+				<div className="mt-6 flex flex-wrap items-center gap-4">
+					<label className="flex items-center gap-2 text-sm text-white/60">
+						<span>Page size</span>
+						<select
+							value={filters.pageSize}
+							onChange={(e) =>
+								updateFilters({ pageSize: Number(e.target.value) })
+							}
+							className="bg-white/5 border border-white/10 rounded-md px-2 py-1 text-sm text-white focus:outline-none focus:border-brand/40"
+						>
+							{TASK_LIST_PAGE_SIZES.map((s) => (
+								<option key={s} value={s}>
+									{s}
+								</option>
+							))}
+						</select>
+					</label>
+					<div className="ml-auto flex items-center gap-2 text-sm text-white/60">
+						<span>Page {currentPage}</span>
+						<button
+							type="button"
+							onClick={() =>
+								updateFilters({
+									offset: Math.max(0, filters.offset - filters.pageSize),
+								})
+							}
+							disabled={filters.offset === 0}
+							className="px-3 py-1.5 text-sm rounded-md border border-white/10 text-white/70 hover:bg-white/5 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+						>
+							← Prev
+						</button>
+						<button
+							type="button"
+							onClick={() =>
+								updateFilters({
+									offset: filters.offset + filters.pageSize,
+								})
+							}
+							disabled={!hasNextPage}
+							className="px-3 py-1.5 text-sm rounded-md border border-white/10 text-white/70 hover:bg-white/5 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+						>
+							Next →
+						</button>
+					</div>
 				</div>
 			)}
 		</div>

--- a/packages/dashboard/lib/constants.ts
+++ b/packages/dashboard/lib/constants.ts
@@ -7,6 +7,10 @@ import type { TaskStatus } from "./types";
 /** Polling interval for task list auto-refresh (milliseconds). */
 export const TASK_LIST_POLL_INTERVAL_MS = 5000;
 
+/** Page size options for the tasks list. The server caps at 200. */
+export const TASK_LIST_PAGE_SIZES: readonly number[] = [25, 50, 100] as const;
+export const TASK_LIST_DEFAULT_PAGE_SIZE = 25;
+
 /** Default limit for the audit page task fetch. */
 export const AUDIT_PAGE_DEFAULT_LIMIT = 100;
 

--- a/packages/dashboard/lib/server/tasks.ts
+++ b/packages/dashboard/lib/server/tasks.ts
@@ -8,14 +8,16 @@ import { apiFetch } from "./client";
 export async function fetchTasks(params?: {
 	status?: TaskStatus;
 	assigned_to?: string;
+	unassigned?: boolean;
 	limit?: number;
 	offset?: number;
 }): Promise<Task[]> {
 	const searchParams = new URLSearchParams();
 	if (params?.status) searchParams.set("status", params.status);
 	if (params?.assigned_to) searchParams.set("assigned_to", params.assigned_to);
+	if (params?.unassigned) searchParams.set("unassigned", "true");
 	if (params?.limit) searchParams.set("limit", String(params.limit));
-	if (params?.offset) searchParams.set("offset", String(params.offset));
+	if (params?.offset !== undefined) searchParams.set("offset", String(params.offset));
 
 	const query = searchParams.toString();
 	return apiFetch<Task[]>(`/api/tasks${query ? `?${query}` : ""}`);

--- a/packages/python/awaithumans/server/routes/tasks.py
+++ b/packages/python/awaithumans/server/routes/tasks.py
@@ -204,6 +204,14 @@ async def list_tasks_route(
     request: Request,
     status: TaskStatus | None = Query(None, description="Filter by status"),
     assigned_to: str | None = Query(None, description="Filter by assigned email"),
+    unassigned: bool = Query(
+        False,
+        description=(
+            "If true, return only tasks where no assignee has been pinned "
+            "(both user_id and email are null). Used by the dashboard to "
+            "surface broadcast tasks needing Claim. Overrides assigned_to."
+        ),
+    ),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     session: AsyncSession = Depends(get_session),
@@ -225,19 +233,23 @@ async def list_tasks_route(
         # Non-operator session — force scope to the caller's own tasks
         # regardless of the `assigned_to` query param. Honouring the
         # client-supplied filter would let a non-operator pass any
-        # email and read those tasks.
+        # email and read those tasks. Same goes for `unassigned=true`:
+        # a reviewer asking to see "all unassigned" would expand their
+        # visibility past their own queue.
         user_id = caller_user_id(request)
         if user_id is None:
             # Should be unreachable — middleware would have 401'd.
             return []
         scoped_assigned_user_id = user_id
         assigned_to = None
+        unassigned = False
 
     tasks = await list_tasks(
         session,
         status=status,
         assigned_to_email=assigned_to,
         assigned_to_user_id=scoped_assigned_user_id,
+        unassigned=unassigned,
         limit=limit,
         offset=offset,
     )

--- a/packages/python/awaithumans/server/services/task_service.py
+++ b/packages/python/awaithumans/server/services/task_service.py
@@ -154,6 +154,7 @@ async def list_tasks(
     status: TaskStatus | None = None,
     assigned_to_email: str | None = None,
     assigned_to_user_id: str | None = None,
+    unassigned: bool = False,
     limit: int = 50,
     offset: int = 0,
 ) -> list[Task]:
@@ -162,14 +163,26 @@ async def list_tasks(
     `assigned_to_user_id` is the authoritative scope for non-operator
     callers — it filters on the resolved directory user ID stamped at
     routing time, which is stable across email changes and works for
-    Slack-only users (where `assigned_to_email` is null)."""
+    Slack-only users (where `assigned_to_email` is null).
+
+    `unassigned=True` surfaces only broadcast tasks that no human has
+    claimed yet (BOTH user_id AND email columns null). Useful for the
+    dashboard's "Unassigned" filter so operators can spot tasks that
+    need a Claim. Wins over `assigned_to_email` / `assigned_to_user_id`
+    if both are passed — those filters are nonsensical alongside
+    "show only unassigned."
+    """
     query = select(Task).order_by(Task.created_at.desc()).limit(limit).offset(offset)
     if status is not None:
         query = query.where(Task.status == status)
-    if assigned_to_email is not None:
-        query = query.where(Task.assigned_to_email == assigned_to_email)
-    if assigned_to_user_id is not None:
-        query = query.where(Task.assigned_to_user_id == assigned_to_user_id)
+    if unassigned:
+        query = query.where(Task.assigned_to_user_id.is_(None))
+        query = query.where(Task.assigned_to_email.is_(None))
+    else:
+        if assigned_to_email is not None:
+            query = query.where(Task.assigned_to_email == assigned_to_email)
+        if assigned_to_user_id is not None:
+            query = query.where(Task.assigned_to_user_id == assigned_to_user_id)
     result = await session.execute(query)
     return list(result.scalars().all())
 

--- a/packages/python/tests/tasks/test_route_authorization.py
+++ b/packages/python/tests/tasks/test_route_authorization.py
@@ -375,3 +375,52 @@ def test_claim_terminal_task_returns_409(
     _login(client, OPERATOR_EMAIL, OPERATOR_PASSWORD)
     resp = client.post(f"/api/tasks/{task_id}/claim")
     assert resp.status_code == 409
+
+
+# ─── List filter: ?unassigned=true ─────────────────────────────────────
+
+
+def test_list_unassigned_true_returns_only_unassigned(
+    client: TestClient, operator_user: User
+) -> None:
+    """Operator's "Unassigned" filter on the dashboard must surface
+    ONLY tasks where no human owns the row yet. Mixed-state lists hide
+    the broadcast queue under regular routed tasks."""
+    unassigned_id = _make_task(client, idempotency_key="filter-1")
+    assigned_id = _make_task(
+        client,
+        assigned_to_email=OPERATOR_EMAIL,
+        idempotency_key="filter-2",
+    )
+
+    resp = client.get(
+        "/api/tasks?unassigned=true", headers=_admin_headers()
+    )
+    assert resp.status_code == 200
+    rows = resp.json()
+    ids = {r["id"] for r in rows}
+    assert unassigned_id in ids
+    assert assigned_id not in ids
+
+
+def test_list_unassigned_ignored_for_non_operator(
+    client: TestClient, reviewer_user: User
+) -> None:
+    """A non-operator passing `?unassigned=true` would otherwise widen
+    their visibility past their own assigned tasks. The route must
+    drop the flag for non-operators (server-side scoping wins)."""
+    _make_task(client, idempotency_key="filter-3")  # unassigned
+    own = _make_task(
+        client,
+        assigned_to_email=REVIEWER_EMAIL,
+        idempotency_key="filter-4",
+    )
+    _login(client, REVIEWER_EMAIL, REVIEWER_PASSWORD)
+
+    resp = client.get("/api/tasks?unassigned=true")
+    assert resp.status_code == 200
+    rows = resp.json()
+    ids = {r["id"] for r in rows}
+    # The reviewer should see only their own task — the unassigned
+    # broadcast does not leak into their queue.
+    assert ids == {own}


### PR DESCRIPTION
## Summary

Tasks page had a row of 5 status pills and fetched up to 50 rows with no offset. Once a workspace has a real backlog, you can't find a specific task and can't tell what's sitting unassigned. This adds a proper filter bar + prev/next paging.

## Filter bar

| Control | Behavior |
|---|---|
| **Status** | Dropdown of all 11 task statuses (was 5 pills). |
| **Assignee** | Email text input → `?assigned_to=`. Disables when Unassigned/Mine is on. |
| **Unassigned only** | Toggle → new server `?unassigned=true`. Surfaces broadcast tasks that need a Claim. |
| **Mine only** | Operator-only toggle → `?assigned_to=me.email`. Non-operators are already scoped server-side. |
| **Clear filters** | Link, appears when any filter is set. |

Unassigned and Mine are mutually exclusive — flipping one clears the other.

## Pagination

- Page size: 25 / 50 / 100 (server caps at 200).
- Prev / Next. Next disables when fewer than `pageSize` rows came back — cheap heuristic that doesn't lie.
- Page N indicator. No total-count: would need a separate count query against the same filters; deferred to a follow-up.

## URL-synced state

Every filter writes through to `?status=...&assignedTo=...&unassigned=true&pageSize=50&offset=25` via `router.replace`. Refresh persists state, links are shareable, the back button doesn't accumulate one history entry per filter tweak. State snaps `offset` back to 0 whenever a filter mutates (otherwise "page 5 of a different filter" is a confusing UX hole).

## Server change

`GET /api/tasks` gains `?unassigned: bool = False`. When true, scopes to `WHERE assigned_to_user_id IS NULL AND assigned_to_email IS NULL`. Non-operators have it dropped (same way `?assigned_to=` is already dropped for them) so reviewers can't widen past their own queue.

## Test plan
- [x] 2 new server tests cover the unassigned filter (operator sees only unassigned; non-operator scoping wins).
- [x] Server suite: 515 passed.
- [x] Dashboard: `tsc --noEmit` clean, `npm run build` succeeds.
- [x] Manual e2e against live dev server with 35 seeded tasks (25 unassigned, 10 assigned-to-alice):
  - `?unassigned=true&limit=25` → 25 rows, Next disabled.
  - `?unassigned=true&offset=25` → empty page, Prev still works to back out.
  - `?assigned_to=alice@test.dev&limit=25` → 10 rows.
  - `?status=created&offset=25` → 10 rows (35 total minus first page).

## Out of scope (named for the inevitable follow-ups)
- Free-text search across `task` / payload — needs server-side LIKE / FTS.
- Created-at range picker — also a server change.
- Sortable columns — API only orders by `created_at desc` today.
- Total-count badge — needs a `?include_count=true` server flag.