### PR TITLE
fix: move HMAC signing out of server package, add cryptography to adapter extras

### DIFF
--- a/examples/langgraph-py/requirements.txt
+++ b/examples/langgraph-py/requirements.txt
@@ -5,10 +5,9 @@
 # this checkout. Pre-PyPI this gets you the LangGraph adapter import.
 # Post-launch users can replace with `awaithumans[langgraph]>=0.1.0`.
 #
-# We also pull [server] because dispatch_resume reuses the canonical
-# HMAC verification from awaithumans.server.services.webhook_dispatch
-# (same trade-off the Temporal adapter makes — see adapter docstring).
--e ../../packages/python[langgraph,server]
+# Post-PR-#71 the [langgraph] extra includes `cryptography`, so the
+# callback receiver verifies webhook HMACs without needing [server].
+-e ../../packages/python[langgraph]
 
 # FastAPI + uvicorn for the app process. The awaithumans package
 # already depends on these via [server], but listing them explicitly

--- a/packages/python/awaithumans/adapters/langgraph/__init__.py
+++ b/packages/python/awaithumans/adapters/langgraph/__init__.py
@@ -320,15 +320,12 @@ async def dispatch_resume(
     _require_langgraph()
     from langgraph.types import Command
 
-    # `verify_signature` lives in the server package because the
-    # canonical implementation (HKDF + HMAC over PAYLOAD_KEY) is
-    # already there. Importing here forces the user to have the
-    # [server] extra installed too, which they typically do in the
-    # web-server process — this is the same trade-off the Temporal
-    # adapter's `dispatch_signal` makes. A future refactor could
-    # move HMAC to a shared `awaithumans.utils.webhook_sig` module
-    # and let both the server and the adapters import it.
-    from awaithumans.server.services.webhook_dispatch import verify_signature
+    # HMAC verification lives in `utils.webhook_signing` so importing
+    # it doesn't transitively pull in the [server] extra (FastAPI,
+    # SQLModel, etc.). Pre-PR-#71 this import resolved through the
+    # server package and a callback receiver running with only
+    # [langgraph] installed crashed on the first webhook.
+    from awaithumans.utils.webhook_signing import verify_signature
 
     if not verify_signature(body=body, signature=signature_header):
         raise PermissionError("Invalid awaithumans webhook signature.")

--- a/packages/python/awaithumans/adapters/temporal/__init__.py
+++ b/packages/python/awaithumans/adapters/temporal/__init__.py
@@ -414,7 +414,13 @@ async def dispatch_signal(
     `temporal_client` is whatever you got back from
     `await temporalio.client.Client.connect(...)` at startup —
     typically a long-lived module-level singleton."""
-    from awaithumans.server.services.webhook_dispatch import verify_signature
+    # HMAC verification lives in `utils.webhook_signing` so importing
+    # it doesn't transitively pull in the [server] extra (FastAPI,
+    # SQLModel, etc.). Pre-PR-#71 this import resolved through the
+    # server package and the callback receiver crashed with
+    # `ModuleNotFoundError: cryptography` when only [temporal] was
+    # installed.
+    from awaithumans.utils.webhook_signing import verify_signature
 
     if not verify_signature(body=body, signature=signature_header):
         # PermissionError is the right shape — the wrapper renders

--- a/packages/python/awaithumans/server/services/webhook_dispatch.py
+++ b/packages/python/awaithumans/server/services/webhook_dispatch.py
@@ -50,78 +50,36 @@ Delivery semantics:
 
 from __future__ import annotations
 
-import hashlib
-import hmac
 import json
 import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import httpx
-from cryptography.hazmat.primitives.hashes import SHA256
-from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from awaithumans.server.core.encryption import get_key
 from awaithumans.server.db.models import (
     Task,
     WebhookDelivery,
     WebhookDeliveryStatus,
 )
 from awaithumans.utils.constants import (
-    HMAC_SHA256_DIGEST_BYTES,
     WEBHOOK_DELIVERY_TIMEOUT_SECONDS,
-    WEBHOOK_HKDF_INFO,
-    WEBHOOK_HKDF_SALT,
     WEBHOOK_RETRY_BACKOFF_SECONDS,
     WEBHOOK_RETRY_MAX_AGE_SECONDS,
     WEBHOOK_SIGNATURE_HEADER,
 )
 
+# HMAC primitives moved to a server-package-free module (PR #71) so
+# the durable adapters can verify callbacks without pulling in
+# FastAPI / SQLModel / etc. We re-export the same names here for
+# backward compat — every existing caller still does
+# `from awaithumans.server.services.webhook_dispatch import sign_body`
+# and that continues to work.
+from awaithumans.utils.webhook_signing import sign_body, verify_signature  # noqa: F401
+
 logger = logging.getLogger("awaithumans.server.services.webhook_dispatch")
-
-
-def _hmac_key() -> bytes:
-    """Derive a 32-byte HMAC key from PAYLOAD_KEY via HKDF-SHA256.
-
-    Channel-scoped salt — the same root key signs sessions, magic
-    links, AND webhooks, but each one derives a distinct subkey via
-    HKDF so a leak of any one downstream key doesn't compromise the
-    others."""
-    return HKDF(
-        algorithm=SHA256(),
-        length=HMAC_SHA256_DIGEST_BYTES,
-        salt=WEBHOOK_HKDF_SALT,
-        info=WEBHOOK_HKDF_INFO,
-    ).derive(get_key())
-
-
-def sign_body(body: bytes) -> str:
-    """Compute the `sha256=<hex>` signature header value.
-
-    Public so callback handlers in the SDK adapters (and the docs
-    examples) can use the same canonical computation when verifying
-    incoming requests on the user's web server."""
-    mac = hmac.new(_hmac_key(), body, hashlib.sha256).hexdigest()
-    return f"sha256={mac}"
-
-
-def verify_signature(*, body: bytes, signature: str | None) -> bool:
-    """Constant-time check of the `X-Awaithumans-Signature` header.
-
-    Used by the SDK adapters' callback handlers (Temporal, LangGraph)
-    to verify incoming webhook bodies before signalling a workflow.
-    `signature` is the header value as received (may include the
-    `sha256=` prefix or just be the hex digest). Both shapes are
-    accepted; missing/empty signatures fail closed."""
-    if not signature:
-        return False
-    expected = sign_body(body)
-    if hmac.compare_digest(signature, expected):
-        return True
-    # Tolerate header-value-without-prefix (some routing layers strip).
-    return hmac.compare_digest(signature, expected.removeprefix("sha256="))
 
 
 def _build_payload(task: Task) -> dict[str, Any]:

--- a/packages/python/awaithumans/utils/webhook_signing.py
+++ b/packages/python/awaithumans/utils/webhook_signing.py
@@ -1,0 +1,162 @@
+"""HMAC signing for outbound webhooks.
+
+Lives in `utils/` rather than `server/services/` so the durable
+adapters (Temporal, LangGraph) can verify callback signatures
+WITHOUT pulling in the full `[server]` extra (FastAPI, SQLModel,
+slack-sdk, etc.) — see PR #71. The previous home transitively
+imported half the server package via `from awaithumans.server.db.models
+import Task`, which meant a Temporal callback receiver hit
+`ModuleNotFoundError: cryptography` (and several others) on the
+first webhook.
+
+What this module does:
+
+  - Derive a 32-byte HMAC key from `AWAITHUMANS_PAYLOAD_KEY` via
+    HKDF-SHA256 with channel-scoped salt + info, so a leak of any
+    other downstream subkey (sessions, magic links) doesn't
+    compromise webhook signing.
+  - Sign a request body to produce the `sha256=<hex>` value of the
+    `X-Awaithumans-Signature` header.
+  - Verify an incoming signature with constant-time comparison,
+    tolerating a header value with or without the `sha256=` prefix
+    (some routing layers strip it).
+
+Cross-language compat is the source of truth: the TS adapters do the
+SAME HKDF derivation in `signBody` / `verifySignature`, so a Python
+server can ship a webhook to a TS receiver and vice versa.
+
+Dependencies: `cryptography` (HKDF). NOT `awaithumans.server.*` —
+the import surface is intentionally tiny.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import os
+from functools import lru_cache
+
+from cryptography.hazmat.primitives.hashes import SHA256
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+from awaithumans.utils.constants import (
+    HMAC_SHA256_DIGEST_BYTES,
+    WEBHOOK_HKDF_INFO,
+    WEBHOOK_HKDF_SALT,
+)
+
+
+class PayloadKeyMissingError(RuntimeError):
+    """Raised when AWAITHUMANS_PAYLOAD_KEY is unset or unreadable.
+
+    Distinct error class so callers can choose to surface a clearer
+    "the webhook receiver isn't configured" message instead of a
+    generic 500."""
+
+
+class PayloadKeyInvalidError(RuntimeError):
+    """Raised when AWAITHUMANS_PAYLOAD_KEY is set but not a valid
+    32-byte base64 value. Most often a copy-paste truncation."""
+
+
+def _decode_payload_key(raw: str) -> bytes:
+    """Accept urlsafe-base64 or standard base64, with or without
+    padding. Mirrors `server.core.encryption.get_key` exactly so
+    a single PAYLOAD_KEY produces the same bytes whether it's used
+    for AES at the storage layer or HKDF here."""
+    padded = raw + "=" * (-len(raw) % 4)
+    decoded: bytes | None = None
+    try:
+        decoded = base64.urlsafe_b64decode(padded)
+    except Exception:  # noqa: BLE001
+        try:
+            decoded = base64.b64decode(padded, validate=True)
+        except Exception:  # noqa: BLE001
+            decoded = None
+    if decoded is None:
+        raise PayloadKeyInvalidError(
+            "AWAITHUMANS_PAYLOAD_KEY is not valid base64. "
+            "Regenerate with: python -c 'import secrets; print(secrets.token_urlsafe(32))'"
+        )
+    if len(decoded) != HMAC_SHA256_DIGEST_BYTES:
+        raise PayloadKeyInvalidError(
+            f"AWAITHUMANS_PAYLOAD_KEY must decode to {HMAC_SHA256_DIGEST_BYTES} "
+            f"bytes; got {len(decoded)}. Generate with: "
+            "python -c 'import secrets; print(secrets.token_urlsafe(32))'"
+        )
+    return decoded
+
+
+@lru_cache(maxsize=1)
+def _root_key() -> bytes:
+    """Resolve and validate the root PAYLOAD_KEY once per process.
+
+    Reads directly from `os.environ` so the utils module stays free
+    of the server's `pydantic-settings` dependency. Production
+    deployments set the env var via their normal config; tests can
+    monkeypatch `os.environ` and call `reset_cache()`."""
+    raw = os.environ.get("AWAITHUMANS_PAYLOAD_KEY")
+    if not raw:
+        raise PayloadKeyMissingError(
+            "AWAITHUMANS_PAYLOAD_KEY is not set. The webhook signing "
+            "key derives from it; both the awaithumans server AND "
+            "any callback receiver verifying webhooks need the same "
+            "value. Generate with:\n"
+            "  python -c 'import secrets; print(secrets.token_urlsafe(32))'"
+        )
+    return _decode_payload_key(raw)
+
+
+@lru_cache(maxsize=1)
+def _hmac_key() -> bytes:
+    """HKDF-SHA256 over the root key, channel-scoped to webhooks.
+
+    Channel-scoped salt — the same root key signs sessions, magic
+    links, AND webhooks, but each one derives a distinct subkey so
+    a leak of any one downstream key doesn't compromise the others.
+    Bumping `WEBHOOK_HKDF_INFO` is a versioned breaking change —
+    old signatures stop verifying, callers must migrate."""
+    return HKDF(
+        algorithm=SHA256(),
+        length=HMAC_SHA256_DIGEST_BYTES,
+        salt=WEBHOOK_HKDF_SALT,
+        info=WEBHOOK_HKDF_INFO,
+    ).derive(_root_key())
+
+
+def reset_cache() -> None:
+    """Drop both cached keys — used by tests that swap PAYLOAD_KEY.
+    Without this, a fixture that mutates the env var sees stale
+    bytes from the first test that ran in the process."""
+    _root_key.cache_clear()
+    _hmac_key.cache_clear()
+
+
+def sign_body(body: bytes) -> str:
+    """Compute the `sha256=<hex>` signature header value.
+
+    Public so callback handlers in the SDK adapters (and the docs
+    examples) can produce signatures the same way the awaithumans
+    server does. Receivers should use `verify_signature` instead —
+    constant-time and tolerant of the optional `sha256=` prefix."""
+    mac = hmac.new(_hmac_key(), body, hashlib.sha256).hexdigest()
+    return f"sha256={mac}"
+
+
+def verify_signature(*, body: bytes, signature: str | None) -> bool:
+    """Constant-time check of the `X-Awaithumans-Signature` header.
+
+    Used by the SDK adapters' callback handlers (Temporal, LangGraph)
+    to verify incoming webhook bodies before signalling a workflow.
+    `signature` is the header value as received (may include the
+    `sha256=` prefix or just be the hex digest). Both shapes are
+    accepted; missing/empty signatures fail closed.
+    """
+    if not signature:
+        return False
+    expected = sign_body(body)
+    if hmac.compare_digest(signature, expected):
+        return True
+    # Tolerate header-value-without-prefix (some routing layers strip).
+    return hmac.compare_digest(signature, expected.removeprefix("sha256="))

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -91,9 +91,15 @@ server = [
 ]
 temporal = [
     "temporalio>=1.7.0",
+    # HMAC verification of awaithumans callbacks. Lives in
+    # `awaithumans.utils.webhook_signing` (PR #71); the temporal
+    # callback receiver imports it without needing [server].
+    "cryptography>=43.0.0",
 ]
 langgraph = [
     "langgraph>=0.2.0",
+    # Same as [temporal]: callback handlers verify webhook HMACs.
+    "cryptography>=43.0.0",
 ]
 verifier-claude = [
     "anthropic>=0.40.0",

--- a/packages/python/tests/auth/conftest.py
+++ b/packages/python/tests/auth/conftest.py
@@ -58,13 +58,34 @@ def _isolated_db() -> Iterator[None]:
 @pytest.fixture(autouse=True)
 def _payload_key() -> Iterator[None]:
     """Every auth test needs PAYLOAD_KEY — sessions and encrypted columns
-    both derive their keys from it."""
-    original = settings.PAYLOAD_KEY
-    settings.PAYLOAD_KEY = secrets.token_urlsafe(32)
+    both derive their keys from it.
+
+    We swap BOTH the pydantic-settings copy AND the `os.environ` value
+    because the new `awaithumans.utils.webhook_signing` module (PR #71)
+    reads directly from `os.environ` to stay free of the [server]
+    extra. Without the env-var swap, a test that signs a body via the
+    server gets a different HMAC key than a test that verifies via the
+    adapter, and signature checks flap."""
+    import os
+
+    from awaithumans.utils import webhook_signing
+
+    fresh = secrets.token_urlsafe(32)
+    original_settings = settings.PAYLOAD_KEY
+    original_env = os.environ.get("AWAITHUMANS_PAYLOAD_KEY")
+
+    settings.PAYLOAD_KEY = fresh
+    os.environ["AWAITHUMANS_PAYLOAD_KEY"] = fresh
     encryption.reset_key_cache()
+    webhook_signing.reset_cache()
     yield
-    settings.PAYLOAD_KEY = original
+    settings.PAYLOAD_KEY = original_settings
+    if original_env is None:
+        os.environ.pop("AWAITHUMANS_PAYLOAD_KEY", None)
+    else:
+        os.environ["AWAITHUMANS_PAYLOAD_KEY"] = original_env
     encryption.reset_key_cache()
+    webhook_signing.reset_cache()
 
 
 @pytest.fixture(autouse=True)

--- a/packages/python/tests/core/test_webhook_dispatch.py
+++ b/packages/python/tests/core/test_webhook_dispatch.py
@@ -68,13 +68,31 @@ from awaithumans.utils.constants import (
 
 @pytest.fixture(autouse=True)
 def _payload_key() -> Iterator[None]:
-    """HKDF derives the webhook key from PAYLOAD_KEY — required."""
-    original = settings.PAYLOAD_KEY
-    settings.PAYLOAD_KEY = secrets.token_urlsafe(32)
+    """HKDF derives the webhook key from PAYLOAD_KEY — required.
+
+    Swaps both the pydantic-settings copy and the `os.environ` value
+    because `awaithumans.utils.webhook_signing` reads directly from
+    `os.environ` (PR #71)."""
+    import os
+
+    from awaithumans.utils import webhook_signing
+
+    fresh = secrets.token_urlsafe(32)
+    original_settings = settings.PAYLOAD_KEY
+    original_env = os.environ.get("AWAITHUMANS_PAYLOAD_KEY")
+
+    settings.PAYLOAD_KEY = fresh
+    os.environ["AWAITHUMANS_PAYLOAD_KEY"] = fresh
     encryption.reset_key_cache()
+    webhook_signing.reset_cache()
     yield
-    settings.PAYLOAD_KEY = original
+    settings.PAYLOAD_KEY = original_settings
+    if original_env is None:
+        os.environ.pop("AWAITHUMANS_PAYLOAD_KEY", None)
+    else:
+        os.environ["AWAITHUMANS_PAYLOAD_KEY"] = original_env
     encryption.reset_key_cache()
+    webhook_signing.reset_cache()
 
 
 @pytest_asyncio.fixture


### PR DESCRIPTION
## Summary

A user testing the Python Temporal example hit `ModuleNotFoundError: No module named 'cryptography'` on every webhook delivery. Their venv had `[temporal]` installed per the example's `requirements.txt`, but the callback receiver crashed and the workflow timed out waiting for a signal that couldn't fire.

The root cause was structural. The Temporal and LangGraph adapters' `dispatch_signal` / `dispatch_resume` helpers verified HMAC signatures by importing from `awaithumans.server.services.webhook_dispatch`, which transitively pulled in `cryptography`, `sqlmodel`, `awaithumans.server.db.models`, `awaithumans.server.core.encryption`, and ultimately the entire `[server]` extra. Adding `cryptography` to `[temporal]` would just have moved the failure to the next missing dep.

## What changed

- **New `awaithumans.utils.webhook_signing`** owns `sign_body` / `verify_signature` / `reset_cache`. Reads `AWAITHUMANS_PAYLOAD_KEY` directly from `os.environ` so it doesn't depend on `pydantic-settings`. Same HKDF parameters + wire format, so existing signatures verify unchanged.
- **`awaithumans.server.services.webhook_dispatch`** re-exports `sign_body` / `verify_signature` for backward compat — every existing import path still works.
- **Both adapters** now import from `utils.webhook_signing` instead of `server.services.webhook_dispatch`.
- **`[temporal]` and `[langgraph]` extras** gain `cryptography>=43`. A fresh `pip install awaithumans[temporal]` now ships everything the callback receiver needs.
- **`examples/langgraph-py/requirements.txt`** drops the `[langgraph,server]` workaround → `[langgraph]` is sufficient. `examples/temporal/requirements.txt` was already `[temporal]`; post-PR it Just Works.
- **Test fixtures** swap both `settings.PAYLOAD_KEY` and `os.environ[\"AWAITHUMANS_PAYLOAD_KEY\"]` so both caches derive matching keys.

## Verified in a [temporal]-only venv

\`\`\`
\$ python -m venv /tmp/aw-temporal-fresh
\$ /tmp/aw-temporal-fresh/bin/pip install -e packages/python[temporal] fastapi uvicorn
\$ /tmp/aw-temporal-fresh/bin/python -c \"import sqlmodel\"
ModuleNotFoundError: No module named 'sqlmodel'   # correct — no [server]
\$ /tmp/aw-temporal-fresh/bin/python -c \"
import os, secrets
os.environ['AWAITHUMANS_PAYLOAD_KEY'] = secrets.token_urlsafe(32)
from awaithumans.adapters.temporal import dispatch_signal
from awaithumans.utils.webhook_signing import sign_body, verify_signature
body = b'{\\\"task_id\\\":\\\"t1\\\",\\\"status\\\":\\\"completed\\\"}'
sig = sign_body(body)
assert verify_signature(body=body, signature=sig)
print('OK HMAC roundtrip in [temporal]-only venv')\"
OK HMAC roundtrip in [temporal]-only venv
\`\`\`

## Test plan
- [x] \`tests/core/test_webhook_dispatch.py\` — 18/18 pass (unchanged behavior; updated fixture)
- [x] Full server suite — 515 passed, no regressions from the import re-routing
- [x] Adapter modules import zero \`awaithumans.server.*\` modules in a minimal venv
- [x] User's failure path reproduced and fixed: callback receiver no longer crashes with cryptography ModuleNotFoundError

## Out of scope
The TS adapters already inline HMAC verification, so they're not affected by this PR. If we ever add a third Python adapter, it should import from \`awaithumans.utils.webhook_signing\` directly.