### PR TITLE
fix: idempotency-collision DX across all 4 adapters

### DIFF
--- a/packages/python/awaithumans/adapters/langgraph/__init__.py
+++ b/packages/python/awaithumans/adapters/langgraph/__init__.py
@@ -235,6 +235,33 @@ async def await_human(
         idem,
     )
 
+    # Idempotency-collision short-circuit. If the server returned an
+    # already-terminal task — e.g. the dev re-ran the example with
+    # the same idempotency_key after a previous completion — there's
+    # no webhook coming and `Command(resume=...)` would never fire.
+    # Pre-#72 this hung the graph on `interrupt()` until the
+    # checkpointer's timeout (or forever, if there isn't one). Treat
+    # this as the Stripe-style retry-returns-cached-response contract:
+    # log loudly, then resolve from `task_record["response"]` and
+    # skip `interrupt()` entirely. Subsequent nodes run normally.
+    existing_status = task_record.get("status")
+    if existing_status in _TERMINAL_STATUS_VALUES:
+        logger.warning(
+            "LangGraph adapter: idempotency_key=%s already exists, status=%s, "
+            "completed_at=%s. Returning cached response without calling "
+            "interrupt(). Pass a fresh idempotency_key= for a new attempt.",
+            idem,
+            existing_status,
+            task_record.get("completed_at") or task_record.get("timed_out_at"),
+        )
+        return _resolve_terminal(
+            existing_status,
+            task_record,
+            response_schema,
+            task=task,
+            timeout_seconds=timeout_seconds,
+        )
+
     # First run: throws GraphInterrupt, graph pauses, caller returns.
     # Resume: returns the dict the callback handler passed to
     # Command(resume=...). We hand the FULL webhook body through (not
@@ -277,6 +304,46 @@ async def await_human(
     raise RuntimeError(
         f"LangGraph adapter saw unknown terminal status "
         f"'{status}' for task '{task}'"
+    )
+
+
+# Terminal status values as wire strings (server returns them as
+# strings on the task JSON; no need to import the TaskStatus enum
+# just for this set).
+_TERMINAL_STATUS_VALUES = frozenset(
+    {"completed", "timed_out", "cancelled", "verification_exhausted"}
+)
+
+
+def _resolve_terminal(
+    status: str,
+    task_record: dict[str, Any],
+    response_schema: type[T],
+    *,
+    task: str,
+    timeout_seconds: int,
+) -> T:
+    """Map a server-returned terminal task to the right return value.
+
+    Used by the idempotency-collision short-circuit. Mirrors the
+    post-resume branches in `await_human` but takes the full task
+    dict from the server instead of the webhook resume payload —
+    only difference is where the `response` field lives."""
+    if status == "completed":
+        try:
+            return response_schema.model_validate(task_record.get("response"))
+        except Exception as exc:  # noqa: BLE001
+            raise SchemaValidationError("response", str(exc)) from exc
+    if status == "timed_out":
+        raise TaskTimeoutError(task=task, timeout_seconds=timeout_seconds)
+    if status == "cancelled":
+        raise TaskCancelledError(task)
+    if status == "verification_exhausted":
+        raise VerificationExhaustedError(
+            task, task_record.get("verification_attempt", 0)
+        )
+    raise RuntimeError(
+        f"LangGraph adapter saw unknown terminal status '{status}' for task '{task}'"
     )
 
 

--- a/packages/python/awaithumans/adapters/temporal/__init__.py
+++ b/packages/python/awaithumans/adapters/temporal/__init__.py
@@ -200,25 +200,6 @@ def _signal_name(idempotency_key: str) -> str:
     return f"{_SIGNAL_PREFIX}:{idempotency_key}"
 
 
-def _default_idempotency_key(task: str, payload: BaseModel) -> str:
-    """Deterministic key for a (task, payload) pair.
-
-    Mirrors the direct-mode SDK's hashing so a workflow that does
-    `await_human(task=..., payload=...)` ends up with the same key
-    on every replay AND the same key as a non-Temporal call to the
-    same content. Stripe-style idempotency on the server means
-    replays of a completed activity recover the stored response
-    instead of creating a duplicate task."""
-    import hashlib
-
-    canonical = json.dumps(
-        {"task": task, "payload": payload.model_dump(mode="json")},
-        sort_keys=True,
-        separators=(",", ":"),
-    )
-    return f"temporal:{hashlib.sha256(canonical.encode()).hexdigest()[:32]}"
-
-
 async def await_human(
     *,
     task: str,
@@ -268,7 +249,15 @@ async def await_human(
     from temporalio import workflow
 
     info = workflow.info()
-    idem = idempotency_key or _default_idempotency_key(task, payload)
+    # Default key = workflow_id (matches the TS adapter, PR #60).
+    # Stable across replays of the same run AND unique per kickoff
+    # because the kickoff generates `refund-{uuid.uuid4()}`. Content-
+    # hash dedup is still available — pass `idempotency_key=` if you
+    # want it (e.g. `f"refund:{order_id}"`). The pre-#72 default was
+    # `temporal:{hash(task,payload)}` which collided across runs with
+    # identical content and made the example unrunnable on retry —
+    # see #72 for the failure mode.
+    idem = idempotency_key or f"temporal:{info.workflow_id}"
     signal = _signal_name(idem)
 
     # Captured by the signal handler closure. We can't use a plain
@@ -346,11 +335,37 @@ async def await_human(
         redact_payload=redact_payload,
     )
 
-    await workflow.execute_activity(
+    task_record = await workflow.execute_activity(
         awaithumans_create_task,
         create_input,
         start_to_close_timeout=timedelta(seconds=create_activity_timeout_seconds),
     )
+
+    # Idempotency-collision short-circuit. If the server returned an
+    # already-terminal task — e.g. the dev re-ran the example with the
+    # same idempotency_key after a previous completion — there's no
+    # signal coming. Pre-#72 the workflow parked on wait_condition for
+    # the full `timeout_seconds` and then raised TaskTimeoutError, a
+    # 15-minute wait for what should be an immediate cached return.
+    # Treat this as the Stripe-style retry-returns-cached-response
+    # contract: log loudly, then resolve from `task_record["response"]`.
+    existing_status = task_record.get("status") if isinstance(task_record, dict) else None
+    if existing_status in _TERMINAL_STATUS_VALUES:
+        logger.warning(
+            "Temporal adapter: idempotency_key=%s already exists, status=%s, "
+            "completed_at=%s. Returning cached response without waiting for "
+            "a new signal. Pass a fresh idempotency_key= for a new attempt.",
+            idem,
+            existing_status,
+            task_record.get("completed_at") or task_record.get("timed_out_at"),
+        )
+        return _resolve_terminal(
+            existing_status,
+            task_record,
+            response_schema,
+            task=task,
+            timeout_seconds=timeout_seconds,
+        )
 
     # Wait for the signal OR the timeout — Temporal parks the
     # workflow under both, no compute consumed while idle. asyncio's
@@ -382,6 +397,46 @@ async def await_human(
         raise VerificationExhaustedError(task, attempt)
     # Unknown status — shouldn't happen, but fail loud rather than silent.
     raise RuntimeError(f"Temporal adapter saw unknown terminal status '{status}' for task '{task}'")
+
+
+# Terminal status values as wire strings (the server sends `task["status"]`
+# as a string; we don't need to import the TaskStatus enum for this set).
+_TERMINAL_STATUS_VALUES = frozenset(
+    {"completed", "timed_out", "cancelled", "verification_exhausted"}
+)
+
+
+def _resolve_terminal(
+    status: str,
+    task_record: dict[str, Any],
+    response_schema: type[T],
+    *,
+    task: str,
+    timeout_seconds: int,
+) -> T:
+    """Map a server-returned terminal task to the right return value.
+
+    Used by the idempotency-collision short-circuit AND by the
+    LangGraph adapter (PR #72). Mirrors the post-signal branches at
+    the bottom of `await_human` but takes the full task dict from
+    the server instead of the webhook payload — only difference is
+    where the `response` field lives."""
+    if status == "completed":
+        try:
+            return response_schema.model_validate(task_record.get("response"))
+        except Exception as exc:  # noqa: BLE001
+            raise SchemaValidationError("response", str(exc)) from exc
+    if status == "timed_out":
+        raise TaskTimeoutError(task=task, timeout_seconds=timeout_seconds)
+    if status == "cancelled":
+        raise TaskCancelledError(task)
+    if status == "verification_exhausted":
+        raise VerificationExhaustedError(
+            task, task_record.get("verification_attempt", 0)
+        )
+    raise RuntimeError(
+        f"Temporal adapter saw unknown terminal status '{status}' for task '{task}'"
+    )
 
 
 # ─── User-web-server-side: dispatch_signal ──────────────────────────

--- a/packages/python/tests/adapters/test_idempotency_collision.py
+++ b/packages/python/tests/adapters/test_idempotency_collision.py
@@ -1,0 +1,203 @@
+"""Idempotency-collision short-circuit (PR #72) — both Python adapters.
+
+Pins the Stripe-style retry-returns-cached-response contract: when
+`create_task` returns an existing terminal task (e.g. the dev re-ran
+the example with the same idempotency key after a previous
+completion), the adapter should:
+
+  - For status=completed: validate the cached response and return it.
+  - For status=timed_out / cancelled / verification_exhausted: raise
+    the matching typed error.
+  - NOT register a signal handler / NOT call interrupt() for a state
+    transition that already happened — the webhook fired ages ago,
+    so waiting for it would just timeout.
+
+Without this, a developer testing the temporal example and running it
+twice with the same payload would park their workflow on
+`wait_condition` for the full `timeout_seconds` (15 min by default)
+before getting a misleading `TaskTimeoutError`. Same shape exists in
+the LangGraph adapter where `interrupt()` would never fire its
+matching `Command(resume=...)`.
+
+We test `_resolve_terminal` directly because the full surface of
+`await_human` requires a live Temporal worker (covered in slower
+integration tests) — but `_resolve_terminal` is what makes the
+short-circuit work, and pinning its branches ensures every terminal
+status maps to the right return / error.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+from awaithumans.adapters.langgraph import _resolve_terminal as _resolve_terminal_lg
+from awaithumans.adapters.temporal import _resolve_terminal as _resolve_terminal_t
+from awaithumans.errors import (
+    SchemaValidationError,
+    TaskCancelledError,
+    TaskTimeoutError,
+    VerificationExhaustedError,
+)
+
+
+class RefundDecision(BaseModel):
+    approved: bool
+    notes: str | None = None
+
+
+# ─── Temporal adapter ─────────────────────────────────────────────────
+
+
+def test_temporal_resolve_completed_returns_validated_response() -> None:
+    """Happy path: an already-completed task returns its cached
+    response, validated against the schema."""
+    task_record = {
+        "status": "completed",
+        "response": {"approved": True, "notes": "approved on a previous run"},
+    }
+    result = _resolve_terminal_t(
+        "completed",
+        task_record,
+        RefundDecision,
+        task="Approve refund",
+        timeout_seconds=900,
+    )
+    assert isinstance(result, RefundDecision)
+    assert result.approved is True
+    assert result.notes == "approved on a previous run"
+
+
+def test_temporal_resolve_completed_with_invalid_response_raises_schema_error() -> (
+    None
+):
+    """If the cached response doesn't match the schema, surface a
+    SchemaValidationError instead of returning a malformed object —
+    same shape as the post-signal path."""
+    task_record = {"status": "completed", "response": {"wrong_field": "bad"}}
+    with pytest.raises(SchemaValidationError):
+        _resolve_terminal_t(
+            "completed",
+            task_record,
+            RefundDecision,
+            task="Approve refund",
+            timeout_seconds=900,
+        )
+
+
+def test_temporal_resolve_timed_out_raises_typed_error() -> None:
+    with pytest.raises(TaskTimeoutError):
+        _resolve_terminal_t(
+            "timed_out",
+            {"status": "timed_out", "response": None},
+            RefundDecision,
+            task="Approve refund",
+            timeout_seconds=900,
+        )
+
+
+def test_temporal_resolve_cancelled_raises_typed_error() -> None:
+    with pytest.raises(TaskCancelledError):
+        _resolve_terminal_t(
+            "cancelled",
+            {"status": "cancelled", "response": None},
+            RefundDecision,
+            task="Approve refund",
+            timeout_seconds=900,
+        )
+
+
+def test_temporal_resolve_verification_exhausted_carries_attempt_count() -> None:
+    """The attempt counter helps the caller log how far the verifier
+    got before giving up — pin that it survives the cached path."""
+    task_record = {
+        "status": "verification_exhausted",
+        "response": None,
+        "verification_attempt": 3,
+    }
+    with pytest.raises(VerificationExhaustedError) as exc_info:
+        _resolve_terminal_t(
+            "verification_exhausted",
+            task_record,
+            RefundDecision,
+            task="Approve refund",
+            timeout_seconds=900,
+        )
+    # Error stores the attempt number — assert it's the one we sent.
+    assert "3" in str(exc_info.value)
+
+
+def test_temporal_resolve_unknown_status_raises_runtime_error() -> None:
+    """A novel terminal status (the server adds one we don't know
+    about yet) should fail loud, not silently return None."""
+    with pytest.raises(RuntimeError):
+        _resolve_terminal_t(
+            "made_up_status",
+            {"status": "made_up_status"},
+            RefundDecision,
+            task="Approve refund",
+            timeout_seconds=900,
+        )
+
+
+# ─── LangGraph adapter ────────────────────────────────────────────────
+#
+# Same shape as Temporal — the helper differs only in its module home,
+# so we re-run the same matrix to pin both. Duplication here is
+# cheaper than abstracting; if a regression slips in for one adapter
+# only, the matrix still catches it.
+
+
+def test_langgraph_resolve_completed_returns_validated_response() -> None:
+    task_record = {
+        "status": "completed",
+        "response": {"approved": False, "notes": "fraud signal"},
+    }
+    result = _resolve_terminal_lg(
+        "completed",
+        task_record,
+        RefundDecision,
+        task="Approve refund",
+        timeout_seconds=900,
+    )
+    assert result.approved is False
+    assert result.notes == "fraud signal"
+
+
+def test_langgraph_resolve_timed_out_raises_typed_error() -> None:
+    with pytest.raises(TaskTimeoutError):
+        _resolve_terminal_lg(
+            "timed_out",
+            {"status": "timed_out", "response": None},
+            RefundDecision,
+            task="Approve refund",
+            timeout_seconds=900,
+        )
+
+
+def test_langgraph_resolve_cancelled_raises_typed_error() -> None:
+    with pytest.raises(TaskCancelledError):
+        _resolve_terminal_lg(
+            "cancelled",
+            {"status": "cancelled", "response": None},
+            RefundDecision,
+            task="Approve refund",
+            timeout_seconds=900,
+        )
+
+
+def test_langgraph_resolve_verification_exhausted_carries_attempt_count() -> None:
+    task_record = {
+        "status": "verification_exhausted",
+        "response": None,
+        "verification_attempt": 5,
+    }
+    with pytest.raises(VerificationExhaustedError) as exc_info:
+        _resolve_terminal_lg(
+            "verification_exhausted",
+            task_record,
+            RefundDecision,
+            task="Approve refund",
+            timeout_seconds=900,
+        )
+    assert "5" in str(exc_info.value)

--- a/packages/typescript-sdk/src/adapters/langgraph/index.ts
+++ b/packages/typescript-sdk/src/adapters/langgraph/index.ts
@@ -215,6 +215,28 @@ export async function awaitHuman<TPayload, TResponse>(
 		body,
 	});
 
+	// Idempotency-collision short-circuit. If the server returned an
+	// already-terminal task — e.g. a dev re-ran with the same key
+	// after a previous completion — there's no webhook coming and
+	// `Command({resume})` would never fire. Pre-#72 the graph hung on
+	// `interrupt()` until the checkpointer's timeout. Treat this as
+	// the Stripe-style retry-returns-cached-response contract.
+	if (task.status && TERMINAL_STATUS_VALUES.has(task.status)) {
+		console.warn(
+			`[awaithumans/langgraph] idempotency_key=${idempotencyKey} already exists, ` +
+				`status=${task.status}, completed_at=${task.completedAt ?? task.timedOutAt}. ` +
+				`Returning cached response without calling interrupt(). ` +
+				`Pass a fresh idempotencyKey for a new attempt.`,
+		);
+		return resolveTerminal(
+			task.status,
+			{ response: task.response, verification_attempt: task.verificationAttempt },
+			options.responseSchema,
+			options.task,
+			options.timeoutMs,
+		);
+	}
+
 	// `interrupt()` does double duty: on first run it throws a
 	// GraphInterrupt (caller catches at the .invoke boundary, graph
 	// pauses, checkpointer persists state); on resume the same line
@@ -229,28 +251,55 @@ export async function awaitHuman<TPayload, TResponse>(
 		callbackUrl: options.callbackUrl,
 	});
 
-	const status = resumeValue.status;
+	return resolveTerminal(
+		resumeValue.status ?? "<missing>",
+		resumeValue,
+		options.responseSchema,
+		options.task,
+		options.timeoutMs,
+	);
+}
+
+const TERMINAL_STATUS_VALUES = new Set<string>([
+	"completed",
+	"timed_out",
+	"cancelled",
+	"verification_exhausted",
+]);
+
+/**
+ * Map a server-returned terminal status to the right return value.
+ * Used both by the post-resume branches (when the webhook delivers a
+ * terminal payload) and the idempotency-collision short-circuit.
+ */
+function resolveTerminal<TResponse>(
+	status: string,
+	source: { response?: unknown; verification_attempt?: number },
+	responseSchema: import("zod").ZodType<TResponse>,
+	taskName: string,
+	timeoutMs: number,
+): TResponse {
 	if (status === "completed") {
-		const validated = options.responseSchema.safeParse(resumeValue.response);
+		const validated = responseSchema.safeParse(source.response);
 		if (!validated.success) {
 			throw new SchemaValidationError("response", validated.error.message);
 		}
 		return validated.data;
 	}
 	if (status === "timed_out") {
-		throw new TaskTimeoutError(options.task, options.timeoutMs);
+		throw new TaskTimeoutError(taskName, timeoutMs);
 	}
 	if (status === "cancelled") {
-		throw new TaskCancelledError(options.task);
+		throw new TaskCancelledError(taskName);
 	}
 	if (status === "verification_exhausted") {
 		throw new VerificationExhaustedError(
-			options.task,
-			resumeValue.verification_attempt ?? 0,
+			taskName,
+			source.verification_attempt ?? 0,
 		);
 	}
 	throw new Error(
-		`LangGraph adapter saw unknown terminal status '${status ?? "<missing>"}' for task '${options.task}'`,
+		`LangGraph adapter saw unknown terminal status '${status}' for task '${taskName}'`,
 	);
 }
 
@@ -263,6 +312,14 @@ interface CreateTaskInput {
 interface CreateTaskResult {
 	id: string;
 	idempotencyKey: string;
+	// Terminal-state echo so `awaitHuman` can short-circuit on
+	// idempotency collisions (PR #72). Null/empty when the task is
+	// freshly created and no human has acted yet.
+	status: string;
+	response: unknown | null;
+	completedAt: string | null;
+	timedOutAt: string | null;
+	verificationAttempt: number;
 }
 
 async function createTaskOnServer(input: CreateTaskInput): Promise<CreateTaskResult> {
@@ -284,8 +341,24 @@ async function createTaskOnServer(input: CreateTaskInput): Promise<CreateTaskRes
 		const text = await resp.text();
 		throw new TaskCreateError(resp.status, text);
 	}
-	const data = (await resp.json()) as { id: string; idempotency_key: string };
-	return { id: data.id, idempotencyKey: data.idempotency_key };
+	const data = (await resp.json()) as {
+		id: string;
+		idempotency_key: string;
+		status: string;
+		response: unknown | null;
+		completed_at: string | null;
+		timed_out_at: string | null;
+		verification_attempt: number;
+	};
+	return {
+		id: data.id,
+		idempotencyKey: data.idempotency_key,
+		status: data.status,
+		response: data.response,
+		completedAt: data.completed_at,
+		timedOutAt: data.timed_out_at,
+		verificationAttempt: data.verification_attempt,
+	};
 }
 
 // ─── User-web-server-side: createLangGraphCallbackHandler ────────────

--- a/packages/typescript-sdk/src/adapters/temporal/index.ts
+++ b/packages/typescript-sdk/src/adapters/temporal/index.ts
@@ -84,7 +84,10 @@ import {
 	serializeAssignTo,
 	serializeVerifierConfig,
 } from "../../internal/wire.js";
-import type { AssignTo, AwaitHumanOptions, VerifierConfig } from "../../types/index.js";
+import type { AssignTo, AwaitHumanOptions, TaskStatus, VerifierConfig } from "../../types/index.js";
+import { TERMINAL_STATUSES } from "../../types/index.js";
+
+import type { ZodType as ZodTypeRef } from "zod";
 
 // Static import of @temporalio/workflow.
 //
@@ -148,6 +151,15 @@ interface CreateTaskActivityInput {
 interface CreateTaskActivityResult {
 	id: string;
 	idempotencyKey: string;
+	// Echoed from the server so `awaitHuman` can short-circuit when an
+	// idempotency-key collision returns an already-terminal task. PR
+	// #72 — without this, a re-run with the same key would park the
+	// workflow on `wf.condition` until timeout.
+	status: string;
+	response: unknown | null;
+	completedAt: string | null;
+	timedOutAt: string | null;
+	verificationAttempt: number;
 }
 
 // The signal payload the user's web server delivers — mirrors the
@@ -162,6 +174,45 @@ interface CompletionSignal {
 	completed_by_email?: string | null;
 	completed_via_channel?: string | null;
 	verification_attempt?: number;
+}
+
+/**
+ * Map a server-returned terminal task to the right return value.
+ * Used by both the idempotency-collision short-circuit (PR #72) and
+ * the post-signal branches at the bottom of `awaitHuman` — only
+ * difference is where the `response` field lives.
+ *
+ * Kept as a non-async function (no Temporal API touched) so it's
+ * callable from the workflow sandbox without ceremony.
+ */
+function resolveTerminal<TResponse>(
+	status: string,
+	source: { response?: unknown; verificationAttempt?: number; verification_attempt?: number },
+	responseSchema: ZodTypeRef<TResponse>,
+	taskName: string,
+	timeoutMs: number,
+): TResponse {
+	if (status === "completed") {
+		const validated = responseSchema.safeParse(source.response);
+		if (!validated.success) {
+			throw new SchemaValidationError("response", validated.error.message);
+		}
+		return validated.data;
+	}
+	if (status === "timed_out") {
+		throw new TaskTimeoutError(taskName, timeoutMs);
+	}
+	if (status === "cancelled") {
+		throw new TaskCancelledError(taskName);
+	}
+	if (status === "verification_exhausted") {
+		const attempt =
+			source.verificationAttempt ?? source.verification_attempt ?? 0;
+		throw new VerificationExhaustedError(taskName, attempt);
+	}
+	throw new Error(
+		`Temporal adapter saw unknown terminal status '${status}' for task '${taskName}'`,
+	);
 }
 
 function signalName(idempotencyKey: string): string {
@@ -250,11 +301,34 @@ export async function awaitHuman<TPayload, TResponse>(
 			options.createActivityTimeoutMs ?? DEFAULT_CREATE_ACTIVITY_TIMEOUT_MS,
 	});
 
-	await awaithumansCreateTask({
+	const taskRecord = await awaithumansCreateTask({
 		serverUrl: options.serverUrl,
 		apiKey: options.apiKey,
 		body,
 	});
+
+	// Idempotency-collision short-circuit. If the server returned an
+	// already-terminal task — e.g. a dev re-ran the example with the
+	// same idempotency_key after a previous completion — there's no
+	// signal coming. Pre-#72 the workflow parked on `wf.condition`
+	// for the full `timeoutMs` and then threw `TaskTimeoutError`,
+	// which made the example look broken on retry. Treat this as the
+	// Stripe-style retry-returns-cached-response contract.
+	if (TERMINAL_STATUSES.includes(taskRecord.status as TaskStatus)) {
+		console.warn(
+			`[awaithumans/temporal] idempotency_key=${idempotencyKey} already exists, ` +
+				`status=${taskRecord.status}, completed_at=${taskRecord.completedAt ?? taskRecord.timedOutAt}. ` +
+				`Returning cached response without waiting for a new signal. ` +
+				`Pass a fresh idempotencyKey for a new attempt.`,
+		);
+		return resolveTerminal(
+			taskRecord.status,
+			taskRecord,
+			options.responseSchema,
+			options.task,
+			options.timeoutMs,
+		);
+	}
 
 	// Race: signal received OR timeout. `wf.condition` returns true
 	// when the predicate fires, false when it timed out.
@@ -339,8 +413,28 @@ export async function awaithumansCreateTask(
 		);
 	}
 
-	const data = (await resp.json()) as { id: string; idempotency_key: string };
-	return { id: data.id, idempotencyKey: data.idempotency_key };
+	// We need more than `id` + `idempotency_key` so the workflow can
+	// short-circuit when an idempotency-key collision returns an
+	// already-terminal task (PR #72). Fields that aren't yet set are
+	// null on the wire.
+	const data = (await resp.json()) as {
+		id: string;
+		idempotency_key: string;
+		status: string;
+		response: unknown | null;
+		completed_at: string | null;
+		timed_out_at: string | null;
+		verification_attempt: number;
+	};
+	return {
+		id: data.id,
+		idempotencyKey: data.idempotency_key,
+		status: data.status,
+		response: data.response,
+		completedAt: data.completed_at,
+		timedOutAt: data.timed_out_at,
+		verificationAttempt: data.verification_attempt,
+	};
 }
 
 // ─── User-web-server-side: dispatchSignal ───────────────────────────


### PR DESCRIPTION
## Summary

Re-running `python refund_workflow.py start 250` parked the workflow on `wait_condition` for 15 minutes before timing out with a misleading TaskTimeoutError. Same trap exists across all four adapters. Three layered fixes — each independently valuable — close it.

## What broke

The Python Temporal adapter's default idempotency key was `temporal:hash(task, payload)`. Run the example twice with the same payload → same key → the server returned the EXISTING completed task → the adapter happily registered a signal handler → waited 15 min for a signal that fired hours earlier → TaskTimeoutError.

Same shape in the LangGraph adapters: `interrupt()` would never fire its `Command(resume=...)` because the webhook had already arrived in a previous run.

## The fix (3 layers)

**1. Adapter short-circuit on terminal collision (correctness).** When `create_task` returns an already-terminal task, resolve immediately from the cached `task["response"]` instead of waiting. Maps to typed errors for non-completed terminal statuses. This is the Stripe-style retry-returns-cached-response contract.

**2. Default key for Python Temporal = `workflow_id`.** Matches the TS adapter (PR #60). `workflow.info().workflow_id` is sandbox-safe, stable across replays of one run, and unique per kickoff. Devs who want content-hash dedup still pass `idempotency_key=` explicitly.

**3. Loud WARNING log on every existing-task hit.** Even when the short-circuit handles things cleanly, the WARN log makes the WHY visible: idempotency_key + status + completed_at + the hint "Pass a fresh idempotency_key for a new attempt."

## Wire shape changes

Both `awaithumans_create_task` (Python) and `awaithumansCreateTask` (TS) Temporal activities now return the full `{id, idempotency_key, status, response, completed_at, timed_out_at, verification_attempt}` instead of just `{id, idempotency_key}`. Server already returned all of these — adapters just discarded them.

## Test plan
- [x] 10 new unit tests in `tests/adapters/test_idempotency_collision.py` cover every terminal-status branch through both Python adapters' `_resolve_terminal`: completed (validated response), schema-mismatch, timed_out, cancelled, verification_exhausted (with attempt count), unknown status.
- [x] Full server suite: 525 passed (was 515 + 10 new).
- [x] TS unit suite: 66 / 66 (no behavior change at that layer; new fields wired through the activity result).
- [ ] Manual e2e against `awaithumans dev` + Temporal: dev re-runs `start 250` immediately after a completion, gets a fresh task (workflow_id-based default key) and the WARNING log when explicitly passing a colliding key.

## Out of scope for this PR
LangGraph TS default is still content hash; the example overrides with `langgraph:{threadId}:humanReview`. That's correct for cross-thread setups, so no change. The TS Temporal default is already `temporal:{workflowId}` (PR #60).