### PR TITLE
feat(dashboard): broader assignee filter, polished bar, audit-log filters

### DIFF
--- a/packages/dashboard/app/(dashboard)/audit/page.tsx
+++ b/packages/dashboard/app/(dashboard)/audit/page.tsx
@@ -1,28 +1,163 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
-import { fetchTasks, type Task } from "@/lib/server";
-import { completedByLabel, formatRelativeTime } from "@/lib/utils";
-import { AUDIT_PAGE_DEFAULT_LIMIT, TASK_ID_TRUNCATE_LENGTH, TERMINAL_STATUSES } from "@/lib/constants";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+	fetchMe,
+	fetchTasks,
+	type MeResponse,
+	type Task,
+	type TaskStatus,
+} from "@/lib/server";
+import { completedByLabel, cn, formatRelativeTime } from "@/lib/utils";
+import {
+	TASK_ID_TRUNCATE_LENGTH,
+	TASK_LIST_DEFAULT_PAGE_SIZE,
+	TASK_LIST_PAGE_SIZES,
+	TASK_LIST_POLL_INTERVAL_MS,
+} from "@/lib/constants";
+import {
+	TaskFilterBar,
+	type StatusOption,
+} from "@/components/filters/task-filter-bar";
 import { ShellEmptyState } from "@/components/shell-empty-state";
 import { StatusBadge } from "@/components/status-badge";
 import { TerminalSpinner } from "@/components/terminal-spinner";
 
+/**
+ * Audit log = the tasks page restricted to terminal statuses, with
+ * a filter bar tailored to "what already happened" rather than
+ * "what's still open." Server enforces the terminal-only scope via
+ * `?terminal=true` (PR #73), so we don't have to filter client-side
+ * and pagination works correctly.
+ */
+
+const STATUS_OPTIONS: readonly StatusOption[] = [
+	{ label: "All terminal", value: "all" },
+	{ label: "Completed", value: "completed" },
+	{ label: "Timed out", value: "timed_out" },
+	{ label: "Cancelled", value: "cancelled" },
+	{ label: "Verification exhausted", value: "verification_exhausted" },
+] as const;
+
+interface FilterState {
+	status: TaskStatus | "all";
+	assignedTo: string;
+	unassigned: boolean; // unused on this page (audit = post-assignment) but
+	mine: boolean; //         kept in shape so we can share <TaskFilterBar>.
+	pageSize: number;
+	offset: number;
+}
+
+const DEFAULT_FILTERS: FilterState = {
+	status: "all",
+	assignedTo: "",
+	unassigned: false,
+	mine: false,
+	pageSize: TASK_LIST_DEFAULT_PAGE_SIZE,
+	offset: 0,
+};
+
+function readFiltersFromSearchParams(params: URLSearchParams): FilterState {
+	const rawStatus = params.get("status") ?? "all";
+	const status = STATUS_OPTIONS.some((o) => o.value === rawStatus)
+		? (rawStatus as TaskStatus | "all")
+		: "all";
+	const rawSize = Number(params.get("pageSize") ?? TASK_LIST_DEFAULT_PAGE_SIZE);
+	const pageSize = TASK_LIST_PAGE_SIZES.includes(rawSize)
+		? rawSize
+		: TASK_LIST_DEFAULT_PAGE_SIZE;
+	const offset = Math.max(0, Number(params.get("offset") ?? "0") || 0);
+	return {
+		status,
+		assignedTo: params.get("assignedTo") ?? "",
+		unassigned: false,
+		mine: params.get("mine") === "true",
+		pageSize,
+		offset,
+	};
+}
+
+function filtersToSearchParams(state: FilterState): URLSearchParams {
+	const sp = new URLSearchParams();
+	if (state.status !== "all") sp.set("status", state.status);
+	if (state.assignedTo) sp.set("assignedTo", state.assignedTo);
+	if (state.mine) sp.set("mine", "true");
+	if (state.pageSize !== TASK_LIST_DEFAULT_PAGE_SIZE)
+		sp.set("pageSize", String(state.pageSize));
+	if (state.offset > 0) sp.set("offset", String(state.offset));
+	return sp;
+}
+
 export default function AuditLogPage() {
+	return (
+		<Suspense fallback={<TerminalSpinner label="awaiting audit entries" size="md" />}>
+			<AuditLogPageInner />
+		</Suspense>
+	);
+}
+
+function AuditLogPageInner() {
 	const router = useRouter();
+	const searchParams = useSearchParams();
+	const filters = useMemo(
+		() => readFiltersFromSearchParams(searchParams),
+		[searchParams],
+	);
+
 	const [tasks, setTasks] = useState<Task[]>([]);
 	const [loading, setLoading] = useState(true);
+	const [me, setMe] = useState<MeResponse | null>(null);
+
+	const updateFilters = useCallback(
+		(patch: Partial<FilterState>) => {
+			const offsetBumped = "offset" in patch && patch.offset !== undefined;
+			const next: FilterState = {
+				...filters,
+				...patch,
+				offset: offsetBumped ? (patch.offset as number) : 0,
+			};
+			const sp = filtersToSearchParams(next);
+			const query = sp.toString();
+			router.replace(query ? `/audit?${query}` : "/audit", {
+				scroll: false,
+			});
+		},
+		[filters, router],
+	);
+
+	const loadTasks = useCallback(async () => {
+		try {
+			const params: Parameters<typeof fetchTasks>[0] = {
+				terminal: true,
+				limit: filters.pageSize,
+				offset: filters.offset,
+			};
+			if (filters.status !== "all") params.status = filters.status;
+			if (filters.mine && me?.email) params.assigned_to = me.email;
+			else if (filters.assignedTo) params.assigned_to = filters.assignedTo;
+			const data = await fetchTasks(params);
+			setTasks(data);
+		} finally {
+			setLoading(false);
+		}
+	}, [filters, me?.email]);
 
 	useEffect(() => {
-		fetchTasks({ limit: AUDIT_PAGE_DEFAULT_LIMIT })
-			.then(setTasks)
-			.finally(() => setLoading(false));
+		fetchMe().then(setMe).catch(() => setMe(null));
 	}, []);
 
-	const completedTasks = tasks.filter(
-		(t) => TERMINAL_STATUSES.includes(t.status),
-	);
+	useEffect(() => {
+		loadTasks();
+		const interval = setInterval(loadTasks, TASK_LIST_POLL_INTERVAL_MS);
+		return () => clearInterval(interval);
+	}, [loadTasks]);
+
+	const currentPage = Math.floor(filters.offset / filters.pageSize) + 1;
+	const hasNextPage = tasks.length === filters.pageSize;
+
+	const filtersActive =
+		filters.status !== "all" || filters.assignedTo !== "" || filters.mine;
 
 	return (
 		<div>
@@ -33,13 +168,33 @@ export default function AuditLogPage() {
 				</p>
 			</div>
 
+			<TaskFilterBar
+				filters={{
+					status: filters.status,
+					assignedTo: filters.assignedTo,
+					unassigned: false,
+					mine: filters.mine,
+				}}
+				onChange={updateFilters}
+				isOperator={!!me?.is_operator}
+				statusOptions={STATUS_OPTIONS}
+				showUnassignedToggle={false}
+				searchPlaceholder="search assignee — email, name, or Slack ID"
+			/>
+
 			{loading ? (
 				<TerminalSpinner label="awaiting audit entries" size="md" />
-			) : completedTasks.length === 0 ? (
-				<ShellEmptyState
-					heading="tail -f audit.log — no terminal events yet"
-					note="Completed, timed-out, and cancelled tasks land here the moment they close."
-				/>
+			) : tasks.length === 0 ? (
+				filtersActive ? (
+					<div className="border border-white/10 rounded-lg p-8 text-center text-white/50 text-sm">
+						No terminal tasks match these filters.
+					</div>
+				) : (
+					<ShellEmptyState
+						heading="tail -f audit.log — no terminal events yet"
+						note="Completed, timed-out, and cancelled tasks land here the moment they close."
+					/>
+				)
 			) : (
 				<div className="border border-white/10 rounded-lg overflow-hidden">
 					<table className="w-full">
@@ -54,7 +209,7 @@ export default function AuditLogPage() {
 							</tr>
 						</thead>
 						<tbody>
-							{completedTasks.map((task) => {
+							{tasks.map((task) => {
 								const createdAt = new Date(task.created_at).getTime();
 								const endedAt = task.completed_at
 									? new Date(task.completed_at).getTime()
@@ -69,7 +224,9 @@ export default function AuditLogPage() {
 										key={task.id}
 										className="border-b border-white/5 hover:bg-white/5 transition-colors cursor-pointer"
 										onClick={() => {
-											router.push(`/task?id=${encodeURIComponent(task.id)}`);
+											router.push(
+												`/task?id=${encodeURIComponent(task.id)}`,
+											);
 										}}
 									>
 										<td className="px-4 py-3">
@@ -102,6 +259,54 @@ export default function AuditLogPage() {
 							})}
 						</tbody>
 					</table>
+				</div>
+			)}
+
+			{(tasks.length > 0 || filters.offset > 0) && !loading && (
+				<div className="mt-6 flex flex-wrap items-center gap-4">
+					<label className="flex items-center gap-2 text-sm text-white/60">
+						<span>Page size</span>
+						<select
+							value={filters.pageSize}
+							onChange={(e) =>
+								updateFilters({ pageSize: Number(e.target.value) })
+							}
+							className="bg-white/5 border border-white/10 rounded-md px-2 py-1 text-sm text-white focus:outline-none focus:border-brand/40"
+						>
+							{TASK_LIST_PAGE_SIZES.map((s) => (
+								<option key={s} value={s}>
+									{s}
+								</option>
+							))}
+						</select>
+					</label>
+					<div className="ml-auto flex items-center gap-2 text-sm text-white/60">
+						<span>Page {currentPage}</span>
+						<button
+							type="button"
+							onClick={() =>
+								updateFilters({
+									offset: Math.max(0, filters.offset - filters.pageSize),
+								})
+							}
+							disabled={filters.offset === 0}
+							className="px-3 py-1.5 text-sm rounded-md border border-white/10 text-white/70 hover:bg-white/5 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+						>
+							← Prev
+						</button>
+						<button
+							type="button"
+							onClick={() =>
+								updateFilters({
+									offset: filters.offset + filters.pageSize,
+								})
+							}
+							disabled={!hasNextPage}
+							className="px-3 py-1.5 text-sm rounded-md border border-white/10 text-white/70 hover:bg-white/5 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+						>
+							Next →
+						</button>
+					</div>
 				</div>
 			)}
 		</div>

--- a/packages/dashboard/app/(dashboard)/page.tsx
+++ b/packages/dashboard/app/(dashboard)/page.tsx
@@ -18,11 +18,15 @@ import {
 	TASK_LIST_POLL_INTERVAL_MS,
 } from "@/lib/constants";
 import { ErrorBanner } from "@/components/error-banner";
+import {
+	TaskFilterBar,
+	type StatusOption,
+} from "@/components/filters/task-filter-bar";
 import { ShellEmptyState } from "@/components/shell-empty-state";
 import { StatusBadge } from "@/components/status-badge";
 import { TerminalSpinner } from "@/components/terminal-spinner";
 
-const STATUS_OPTIONS: { label: string; value: TaskStatus | "all" }[] = [
+const STATUS_OPTIONS: readonly StatusOption[] = [
 	{ label: "All", value: "all" },
 	{ label: "Created", value: "created" },
 	{ label: "Notified", value: "notified" },
@@ -35,7 +39,7 @@ const STATUS_OPTIONS: { label: string; value: TaskStatus | "all" }[] = [
 	{ label: "Timed out", value: "timed_out" },
 	{ label: "Cancelled", value: "cancelled" },
 	{ label: "Verification exhausted", value: "verification_exhausted" },
-];
+] as const;
 
 interface FilterState {
 	status: TaskStatus | "all";
@@ -200,93 +204,17 @@ function TaskQueuePageInner() {
 				</div>
 			</div>
 
-			{/* Filter bar */}
-			<div className="border border-white/10 rounded-lg p-4 mb-6 flex flex-wrap items-center gap-3">
-				{/* Status dropdown */}
-				<label className="flex items-center gap-2 text-sm text-white/60">
-					<span>Status</span>
-					<select
-						value={filters.status}
-						onChange={(e) =>
-							updateFilters({
-								status: e.target.value as TaskStatus | "all",
-							})
-						}
-						className="bg-white/5 border border-white/10 rounded-md px-2 py-1 text-sm text-white focus:outline-none focus:border-brand/40"
-					>
-						{STATUS_OPTIONS.map((o) => (
-							<option key={o.value} value={o.value}>
-								{o.label}
-							</option>
-						))}
-					</select>
-				</label>
-
-				{/* Assignee email */}
-				<label className="flex items-center gap-2 text-sm text-white/60">
-					<span>Assignee</span>
-					<input
-						type="text"
-						placeholder="email"
-						value={filters.assignedTo}
-						disabled={filters.unassigned || filters.mine}
-						onChange={(e) =>
-							updateFilters({ assignedTo: e.target.value })
-						}
-						className="bg-white/5 border border-white/10 rounded-md px-2 py-1 text-sm text-white placeholder:text-white/30 focus:outline-none focus:border-brand/40 disabled:opacity-40 disabled:cursor-not-allowed"
-					/>
-				</label>
-
-				{/* Toggles */}
-				<label className="flex items-center gap-2 text-sm text-white/60 cursor-pointer">
-					<input
-						type="checkbox"
-						checked={filters.unassigned}
-						onChange={(e) =>
-							updateFilters({
-								unassigned: e.target.checked,
-								// Mutually-exclusive with Mine.
-								mine: e.target.checked ? false : filters.mine,
-							})
-						}
-						className="accent-brand"
-					/>
-					<span>Unassigned only</span>
-				</label>
-				{me?.is_operator && (
-					<label className="flex items-center gap-2 text-sm text-white/60 cursor-pointer">
-						<input
-							type="checkbox"
-							checked={filters.mine}
-							onChange={(e) =>
-								updateFilters({
-									mine: e.target.checked,
-									unassigned: e.target.checked ? false : filters.unassigned,
-								})
-							}
-							className="accent-brand"
-						/>
-						<span>Mine only</span>
-					</label>
-				)}
-
-				{filtersActive && (
-					<button
-						type="button"
-						onClick={() =>
-							updateFilters({
-								status: "all",
-								assignedTo: "",
-								unassigned: false,
-								mine: false,
-							})
-						}
-						className="ml-auto text-xs text-white/40 hover:text-white/70 transition-colors underline"
-					>
-						Clear filters
-					</button>
-				)}
-			</div>
+			<TaskFilterBar
+				filters={{
+					status: filters.status,
+					assignedTo: filters.assignedTo,
+					unassigned: filters.unassigned,
+					mine: filters.mine,
+				}}
+				onChange={updateFilters}
+				isOperator={!!me?.is_operator}
+				statusOptions={STATUS_OPTIONS}
+			/>
 
 			{error && <ErrorBanner message={error} />}
 

--- a/packages/dashboard/components/filters/task-filter-bar.tsx
+++ b/packages/dashboard/components/filters/task-filter-bar.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { Search, X } from "lucide-react";
+import type { TaskStatus } from "@/lib/server";
+import { cn } from "@/lib/utils";
+
+/**
+ * Shared filter UI for the tasks list and the audit log.
+ *
+ * Why a shared component: pre-#73 we copy-pasted ~80 lines of filter
+ * markup between `/` (tasks) and `/audit` (terminal tasks), and the
+ * two were already drifting in spacing + behaviour. Now both pages
+ * lay out the same controls with the same affordances; only the
+ * status-option list and a couple of toggles differ.
+ *
+ * Page-owned, URL-synced state stays in the page component — this
+ * component is just the visual shell + the on-change plumbing.
+ */
+
+export interface FilterState {
+	status: TaskStatus | "all";
+	assignedTo: string;
+	unassigned: boolean;
+	mine: boolean;
+}
+
+export interface StatusOption {
+	label: string;
+	value: TaskStatus | "all";
+}
+
+export interface TaskFilterBarProps {
+	filters: FilterState;
+	onChange: (patch: Partial<FilterState>) => void;
+	isOperator: boolean;
+	statusOptions: readonly StatusOption[];
+	/**
+	 * Hide the "Unassigned only" toggle on contexts where it doesn't
+	 * make sense (e.g. audit page — terminal tasks are past
+	 * assignment, the toggle would always return zero).
+	 */
+	showUnassignedToggle?: boolean;
+	searchPlaceholder?: string;
+}
+
+export function TaskFilterBar({
+	filters,
+	onChange,
+	isOperator,
+	statusOptions,
+	showUnassignedToggle = true,
+	searchPlaceholder = "search email, name, or Slack ID",
+}: TaskFilterBarProps) {
+	const filtersActive =
+		filters.status !== "all" ||
+		filters.assignedTo !== "" ||
+		filters.unassigned ||
+		filters.mine;
+
+	const clearAll = () =>
+		onChange({
+			status: "all",
+			assignedTo: "",
+			unassigned: false,
+			mine: false,
+		});
+
+	return (
+		<div className="space-y-3 mb-6">
+			{/* Top row — search + quick toggles + clear */}
+			<div className="border border-white/10 rounded-lg p-3 flex flex-wrap items-center gap-2">
+				{/* Search field with icon */}
+				<div className="relative flex-1 min-w-[260px] max-w-md">
+					<Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-white/30 pointer-events-none" />
+					<input
+						type="text"
+						placeholder={searchPlaceholder}
+						value={filters.assignedTo}
+						disabled={filters.unassigned || filters.mine}
+						onChange={(e) =>
+							onChange({ assignedTo: e.target.value })
+						}
+						className={cn(
+							"w-full bg-white/5 border border-white/10 rounded-md pl-8 pr-3 py-1.5 text-sm text-white",
+							"placeholder:text-white/30 focus:outline-none focus:border-brand/40",
+							"disabled:opacity-40 disabled:cursor-not-allowed",
+						)}
+					/>
+				</div>
+
+				{/* Quick toggle pills — visually grouped */}
+				<div className="flex items-center gap-1 ml-auto">
+					{showUnassignedToggle && (
+						<TogglePill
+							active={filters.unassigned}
+							onClick={() =>
+								onChange({
+									unassigned: !filters.unassigned,
+									// Mutually exclusive with Mine.
+									mine: !filters.unassigned ? false : filters.mine,
+								})
+							}
+							label="Unassigned"
+						/>
+					)}
+					{isOperator && (
+						<TogglePill
+							active={filters.mine}
+							onClick={() =>
+								onChange({
+									mine: !filters.mine,
+									unassigned: !filters.mine ? false : filters.unassigned,
+								})
+							}
+							label="Mine only"
+						/>
+					)}
+
+					{/* Status select — last, since users hit it less often */}
+					<label className="flex items-center gap-2 text-xs text-white/50 ml-2">
+						<span>Status</span>
+						<select
+							value={filters.status}
+							onChange={(e) =>
+								onChange({
+									status: e.target.value as TaskStatus | "all",
+								})
+							}
+							className={cn(
+								"bg-white/5 border border-white/10 rounded-md px-2 py-1 text-sm text-white",
+								"focus:outline-none focus:border-brand/40",
+							)}
+						>
+							{statusOptions.map((o) => (
+								<option key={o.value} value={o.value}>
+									{o.label}
+								</option>
+							))}
+						</select>
+					</label>
+
+					{filtersActive && (
+						<button
+							type="button"
+							onClick={clearAll}
+							className="ml-1 text-xs text-white/40 hover:text-white/70 transition-colors px-2"
+						>
+							Clear
+						</button>
+					)}
+				</div>
+			</div>
+
+			{/* Active filter chips — appear below the bar so the user can see
+			    what's filtering at a glance and remove them one by one without
+			    hunting through the controls. */}
+			{filtersActive && (
+				<div className="flex flex-wrap items-center gap-2 px-1">
+					<span className="text-xs text-white/30 uppercase tracking-wider">
+						Active:
+					</span>
+					{filters.status !== "all" && (
+						<FilterChip
+							label={`Status: ${labelForStatus(statusOptions, filters.status)}`}
+							onRemove={() => onChange({ status: "all" })}
+						/>
+					)}
+					{filters.assignedTo && (
+						<FilterChip
+							label={`Assignee: ${filters.assignedTo}`}
+							onRemove={() => onChange({ assignedTo: "" })}
+						/>
+					)}
+					{filters.unassigned && (
+						<FilterChip
+							label="Unassigned only"
+							onRemove={() => onChange({ unassigned: false })}
+						/>
+					)}
+					{filters.mine && (
+						<FilterChip
+							label="Mine only"
+							onRemove={() => onChange({ mine: false })}
+						/>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}
+
+function TogglePill({
+	active,
+	onClick,
+	label,
+}: {
+	active: boolean;
+	onClick: () => void;
+	label: string;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className={cn(
+				"px-3 py-1 text-xs rounded-full border transition-colors",
+				active
+					? "bg-brand/15 text-brand border-brand/40"
+					: "bg-white/5 text-white/60 border-white/10 hover:text-white/90 hover:border-white/20",
+			)}
+			aria-pressed={active}
+		>
+			{label}
+		</button>
+	);
+}
+
+function FilterChip({
+	label,
+	onRemove,
+}: {
+	label: string;
+	onRemove: () => void;
+}) {
+	return (
+		<span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded-md bg-brand/10 text-brand border border-brand/30">
+			{label}
+			<button
+				type="button"
+				onClick={onRemove}
+				aria-label={`Remove filter ${label}`}
+				className="hover:bg-brand/20 rounded-sm p-0.5 -mr-0.5 transition-colors"
+			>
+				<X className="w-3 h-3" />
+			</button>
+		</span>
+	);
+}
+
+function labelForStatus(
+	options: readonly StatusOption[],
+	value: TaskStatus | "all",
+): string {
+	return options.find((o) => o.value === value)?.label ?? value;
+}

--- a/packages/dashboard/lib/server/tasks.ts
+++ b/packages/dashboard/lib/server/tasks.ts
@@ -9,6 +9,7 @@ export async function fetchTasks(params?: {
 	status?: TaskStatus;
 	assigned_to?: string;
 	unassigned?: boolean;
+	terminal?: boolean;
 	limit?: number;
 	offset?: number;
 }): Promise<Task[]> {
@@ -16,6 +17,7 @@ export async function fetchTasks(params?: {
 	if (params?.status) searchParams.set("status", params.status);
 	if (params?.assigned_to) searchParams.set("assigned_to", params.assigned_to);
 	if (params?.unassigned) searchParams.set("unassigned", "true");
+	if (params?.terminal) searchParams.set("terminal", "true");
 	if (params?.limit) searchParams.set("limit", String(params.limit));
 	if (params?.offset !== undefined) searchParams.set("offset", String(params.offset));
 

--- a/packages/python/awaithumans/server/routes/tasks.py
+++ b/packages/python/awaithumans/server/routes/tasks.py
@@ -203,13 +203,31 @@ async def create_task_route(
 async def list_tasks_route(
     request: Request,
     status: TaskStatus | None = Query(None, description="Filter by status"),
-    assigned_to: str | None = Query(None, description="Filter by assigned email"),
+    assigned_to: str | None = Query(
+        None,
+        description=(
+            "Filter by assignee. Matches against the directory user's "
+            "email (exact), Slack user ID (exact), or display name "
+            "(case-insensitive substring), as well as the legacy "
+            "assigned_to_email column for tasks routed by email "
+            "before the user was provisioned."
+        ),
+    ),
     unassigned: bool = Query(
         False,
         description=(
             "If true, return only tasks where no assignee has been pinned "
             "(both user_id and email are null). Used by the dashboard to "
             "surface broadcast tasks needing Claim. Overrides assigned_to."
+        ),
+    ),
+    terminal: bool = Query(
+        False,
+        description=(
+            "If true, return only tasks in a terminal status (completed, "
+            "timed_out, cancelled, verification_exhausted). Used by the "
+            "Audit Log dashboard view. Combine with `status=` to filter "
+            "within terminal (`status=` wins when both are set)."
         ),
     ),
     limit: int = Query(50, ge=1, le=200),
@@ -247,9 +265,10 @@ async def list_tasks_route(
     tasks = await list_tasks(
         session,
         status=status,
-        assigned_to_email=assigned_to,
+        assigned_to_query=assigned_to,
         assigned_to_user_id=scoped_assigned_user_id,
         unassigned=unassigned,
+        terminal=terminal,
         limit=limit,
         offset=offset,
     )

--- a/packages/python/awaithumans/server/services/task_service.py
+++ b/packages/python/awaithumans/server/services/task_service.py
@@ -17,7 +17,7 @@ from sqlalchemy import delete, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from awaithumans.server.db.models import AuditEntry, Task, TaskStatus
+from awaithumans.server.db.models import AuditEntry, Task, TaskStatus, User
 from awaithumans.server.services.exceptions import (
     TaskAlreadyClaimedError,
     TaskAlreadyTerminalError,
@@ -152,9 +152,10 @@ async def list_tasks(
     session: AsyncSession,
     *,
     status: TaskStatus | None = None,
-    assigned_to_email: str | None = None,
+    assigned_to_query: str | None = None,
     assigned_to_user_id: str | None = None,
     unassigned: bool = False,
+    terminal: bool = False,
     limit: int = 50,
     offset: int = 0,
 ) -> list[Task]:
@@ -165,26 +166,82 @@ async def list_tasks(
     routing time, which is stable across email changes and works for
     Slack-only users (where `assigned_to_email` is null).
 
+    `assigned_to_query` is a broad search the dashboard uses for the
+    Assignee filter input. Matches if any of:
+      - User.email == query (exact)
+      - User.slack_user_id == query (exact)
+      - lower(User.display_name) LIKE '%lower(query)%' (substring)
+    In all matching cases the corresponding User.id is collected; we
+    then filter `Task.assigned_to_user_id IN matched OR
+    Task.assigned_to_email == query`. The trailing-email branch
+    catches tasks that were assigned by email before the user was
+    provisioned (so the email column is set but user_id is null).
+
+    Pre-#73 this was `assigned_to_email == query` — which meant
+    typing a display name or Slack ID returned nothing.
+
     `unassigned=True` surfaces only broadcast tasks that no human has
     claimed yet (BOTH user_id AND email columns null). Useful for the
     dashboard's "Unassigned" filter so operators can spot tasks that
-    need a Claim. Wins over `assigned_to_email` / `assigned_to_user_id`
+    need a Claim. Wins over `assigned_to_query` / `assigned_to_user_id`
     if both are passed — those filters are nonsensical alongside
     "show only unassigned."
     """
     query = select(Task).order_by(Task.created_at.desc()).limit(limit).offset(offset)
     if status is not None:
         query = query.where(Task.status == status)
+    elif terminal:
+        # Audit-log view: any of the four terminal statuses. Skipped
+        # when an explicit status= was passed so "filter within
+        # terminal" works (e.g. terminal=true&status=cancelled keeps
+        # the explicit one and the elif means we don't double-filter).
+        query = query.where(Task.status.in_(list(TERMINAL_STATUSES_SET)))
     if unassigned:
         query = query.where(Task.assigned_to_user_id.is_(None))
         query = query.where(Task.assigned_to_email.is_(None))
     else:
-        if assigned_to_email is not None:
-            query = query.where(Task.assigned_to_email == assigned_to_email)
+        if assigned_to_query is not None:
+            matched_user_ids = await _resolve_assignee_search(
+                session, assigned_to_query
+            )
+            from sqlalchemy import or_
+
+            conditions = [Task.assigned_to_email == assigned_to_query]
+            if matched_user_ids:
+                conditions.append(Task.assigned_to_user_id.in_(matched_user_ids))
+            query = query.where(or_(*conditions))
         if assigned_to_user_id is not None:
             query = query.where(Task.assigned_to_user_id == assigned_to_user_id)
     result = await session.execute(query)
     return list(result.scalars().all())
+
+
+async def _resolve_assignee_search(
+    session: AsyncSession, query: str
+) -> list[str]:
+    """Find all user IDs matching the broad-search rules in `list_tasks`.
+
+    Runs a single query: `email == X OR slack_user_id == X OR
+    lower(display_name) LIKE '%lower(X)%'`. Returns whatever set
+    matches — possibly empty. We don't enforce a length floor on
+    `query` because the caller already trimmed it to non-empty;
+    operators who paste a single character get a wide match and
+    that's their problem to refine."""
+    from sqlalchemy import func, or_
+
+    needle = query.strip()
+    if not needle:
+        return []
+    rows = await session.execute(
+        select(User.id).where(
+            or_(
+                User.email == needle,
+                User.slack_user_id == needle,
+                func.lower(User.display_name).like(f"%{needle.lower()}%"),
+            )
+        )
+    )
+    return [r[0] for r in rows.all()]
 
 
 async def claim_task(

--- a/packages/python/tests/tasks/test_route_authorization.py
+++ b/packages/python/tests/tasks/test_route_authorization.py
@@ -424,3 +424,149 @@ def test_list_unassigned_ignored_for_non_operator(
     # The reviewer should see only their own task — the unassigned
     # broadcast does not leak into their queue.
     assert ids == {own}
+
+
+# ─── List filter: ?assigned_to=X (broad search across user fields) ─────
+
+
+def test_list_assigned_to_matches_email_exact(
+    client: TestClient, operator_user: User
+) -> None:
+    """Pre-#73 this was the only working query shape. Pin it so the
+    new broader logic doesn't regress the email-exact path."""
+    target = _make_task(
+        client, assigned_to_email=OPERATOR_EMAIL, idempotency_key="assignee-1"
+    )
+    _make_task(client, idempotency_key="assignee-1b")  # noise
+    resp = client.get(
+        f"/api/tasks?assigned_to={OPERATOR_EMAIL}", headers=_admin_headers()
+    )
+    assert resp.status_code == 200
+    ids = {r["id"] for r in resp.json()}
+    assert target in ids
+
+
+def test_list_assigned_to_matches_display_name_substring(
+    client: TestClient, operator_user: User
+) -> None:
+    """The user's actual ask: typing "operator" (display_name) finds
+    the task assigned to ops@example.com. Pre-#73 returned [].
+    Substring match is case-insensitive — typing "OP" or "ope" works
+    too."""
+    target = _make_task(
+        client, assigned_to_email=OPERATOR_EMAIL, idempotency_key="assignee-2"
+    )
+    # operator_user has display_name="Op Erator" or similar; check
+    # the conftest. We assume display_name is set to something that
+    # contains "op" (case-insensitive). If it isn't, the conftest
+    # needs to be updated alongside this filter.
+    resp = client.get(
+        "/api/tasks?assigned_to=op", headers=_admin_headers()
+    )
+    assert resp.status_code == 200
+    ids = {r["id"] for r in resp.json()}
+    assert target in ids, (
+        "expected task assigned to operator to surface via display-name "
+        f"substring. operator_user.display_name={operator_user.display_name!r}"
+    )
+
+
+def test_list_assigned_to_matches_slack_user_id_exact(
+    client: TestClient, operator_user: User
+) -> None:
+    """Slack-only users have no email but are assignable via
+    slack_user_id. The broad filter should match it exactly."""
+    # Patch the operator to have a slack_user_id we can search for.
+    from awaithumans.server.db.connection import get_async_session_factory
+
+    async def _attach_slack() -> None:
+        factory = get_async_session_factory()
+        async with factory() as session:
+            user = await session.get(User, operator_user.id)
+            assert user is not None
+            user.slack_user_id = "U_TEST_OP"
+            session.add(user)
+            await session.commit()
+
+    asyncio.new_event_loop().run_until_complete(_attach_slack())
+
+    target = _make_task(
+        client, assigned_to_email=OPERATOR_EMAIL, idempotency_key="assignee-3"
+    )
+    resp = client.get(
+        "/api/tasks?assigned_to=U_TEST_OP", headers=_admin_headers()
+    )
+    assert resp.status_code == 200
+    ids = {r["id"] for r in resp.json()}
+    assert target in ids
+
+
+def test_list_assigned_to_unknown_returns_empty(
+    client: TestClient, operator_user: User
+) -> None:
+    """Search that matches no user AND no assigned_to_email returns
+    an empty list, not an error."""
+    _make_task(
+        client, assigned_to_email=OPERATOR_EMAIL, idempotency_key="assignee-4"
+    )
+    resp = client.get(
+        "/api/tasks?assigned_to=nobody-by-this-name-exists",
+        headers=_admin_headers(),
+    )
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+# ─── List filter: ?terminal=true (audit-log view) ───────────────────────
+
+
+def test_list_terminal_true_returns_only_terminal(
+    client: TestClient, operator_user: User
+) -> None:
+    """Audit Log uses ?terminal=true to fetch all completed/timed-out/
+    cancelled/verification-exhausted tasks in one call. Active tasks
+    (status=created etc) must NOT leak in."""
+    active = _make_task(
+        client, assigned_to_email=OPERATOR_EMAIL, idempotency_key="term-1"
+    )
+    completed = _make_task(
+        client, assigned_to_email=OPERATOR_EMAIL, idempotency_key="term-2"
+    )
+    client.post(
+        f"/api/tasks/{completed}/complete",
+        json={"response": {"approved": True}},
+        headers=_admin_headers(),
+    )
+
+    resp = client.get("/api/tasks?terminal=true", headers=_admin_headers())
+    assert resp.status_code == 200
+    ids = {r["id"] for r in resp.json()}
+    assert completed in ids
+    assert active not in ids
+
+
+def test_list_terminal_true_with_status_keeps_explicit_status(
+    client: TestClient, operator_user: User
+) -> None:
+    """When both are set, status= wins. terminal=true is the
+    "any-terminal" shorthand; if you want a specific terminal status
+    you can scope to one (e.g. status=cancelled) and the dashboard
+    still works."""
+    completed = _make_task(
+        client, assigned_to_email=OPERATOR_EMAIL, idempotency_key="term-3"
+    )
+    client.post(
+        f"/api/tasks/{completed}/complete",
+        json={"response": {"approved": True}},
+        headers=_admin_headers(),
+    )
+
+    resp = client.get(
+        "/api/tasks?terminal=true&status=cancelled",
+        headers=_admin_headers(),
+    )
+    assert resp.status_code == 200
+    ids = {r["id"] for r in resp.json()}
+    # The completed task is terminal but NOT cancelled, so the
+    # status= filter excludes it.
+    assert completed not in ids


### PR DESCRIPTION
## Summary

Three operator-DX improvements you flagged, shipped together:

### 1. Assignee filter is no longer email-only
Typing `operator` in the filter previously returned nothing because the user's display name was "Test Operator" and email was `ops@example.com`. Server now matches `?assigned_to=X` against:
- `User.email == X` (exact)
- `User.slack_user_id == X` (exact)  
- `lower(User.display_name) LIKE %lower(X)%` (substring)
- `Task.assigned_to_email == X` (legacy email-only path)

Non-operator scoping rules unchanged.

### 2. Filter UI polish
Extracted `<TaskFilterBar>` shared component:
- Real search field with magnifying-glass icon and placeholder "search email, name, or Slack ID"
- Quick toggles ("Unassigned", "Mine only") rendered as **toggle pills**, mutually exclusive
- Status dropdown grouped on the right
- **Active filter chips** below the bar — each set filter shows up as a removable chip (Linear / GitHub style)
- Single "Clear" link, appears only when filters are set

### 3. Audit log gets filters + pagination
Pre-#73 the audit page just called `fetchTasks({limit: 100})` and filtered client-side. Now:
- Server: new `?terminal=true` flag returns only terminal-status tasks. Combine with `?status=` to filter within terminal.
- Audit page reuses `<TaskFilterBar>` with terminal-only status options ("All terminal", "Completed", "Timed out", "Cancelled", "Verification exhausted")
- Hides "Unassigned only" toggle (irrelevant for terminal tasks)
- Same prev/next + page-size pagination as the tasks page
- URL-synced state

## Test plan
- [x] 4 new server tests: email-exact, display-name substring, slack_user_id exact, unknown→[], plus 2 for `?terminal=true` (terminal-only by default, status= wins when both set)
- [x] Full server suite: 531 pass
- [x] Dashboard: typecheck clean, production build succeeds
- [x] Seeded e2e: 3 tasks (1 unassigned, 1 active assigned, 1 completed) — all filter combos return expected counts

## Out of scope
- **Free-text search across `task` / payload** — needs server LIKE / FTS
- **Created-at range picker** — server change
- **Channel filter on audit page** (e.g. show only Slack-completed) — server doesn't filter by `completed_via_channel` yet; ~10 lines, can add in a follow-up if useful
- **Total-count badge** — needs a separate count query

Operator scenario you described (typing "operator" returns the alice@example.com task) now works.