### PR TITLE
Drop blank optional fields before dashboard submit

### DIFF
--- a/packages/dashboard/app/(dashboard)/task/page.tsx
+++ b/packages/dashboard/app/(dashboard)/task/page.tsx
@@ -27,6 +27,7 @@ import { Eyebrow } from "@/components/eyebrow";
 import { StatusBadge } from "@/components/status-badge";
 import { TerminalSpinner } from "@/components/terminal-spinner";
 import {
+	buildResponseValue,
 	FormRenderer,
 	initialValueFor,
 	type FormValue,
@@ -112,8 +113,14 @@ function TaskDetailPageInner() {
 		if (!task) return;
 		setSubmitting(true);
 		try {
+			// Drop blank optional fields before sending so Pydantic
+			// schemas with defaults (`field: str = ""`, etc.) apply
+			// server-side instead of failing validation on a wire null.
+			const responseBody = task.form_definition
+				? buildResponseValue(task.form_definition, formData)
+				: formData;
 			await completeTask(task.id, {
-				response: formData,
+				response: responseBody,
 				completed_via_channel: "dashboard",
 			});
 			await loadTask();

--- a/packages/dashboard/components/form-renderer/build-response-value.test.ts
+++ b/packages/dashboard/components/form-renderer/build-response-value.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Unit tests for `buildResponseValue` — the wire-shaping step the
+ * dashboard runs before posting a completion to the server.
+ *
+ * Pins the rule that motivated the helper:
+ *   - blank (null/undefined) optional fields are DROPPED from the JSON
+ *   - required fields with null are KEPT (so server-side validation
+ *     surfaces a clear error rather than the dashboard silently
+ *     swallowing the violation)
+ *   - empty strings stay as empty strings (user explicitly cleared
+ *     the field; "" is a meaningful value distinct from "untouched")
+ *   - empty arrays stay as empty arrays (multi_select with nothing
+ *     picked is a valid value, not "untouched")
+ *   - section_collapse children are flat at the same FormValue level
+ *   - subform / table rows recurse so the same rule applies per row
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { FormDefinition } from "@/lib/form-types";
+
+import { buildResponseValue } from "./build-response-value";
+import type { FormValue } from "./types";
+
+function form(fields: FormDefinition["fields"]): FormDefinition {
+	return { version: 1, fields };
+}
+
+// Compact field factories — the unit tests only care about
+// `kind`, `name`, `required`, and (where relevant) nested `fields`.
+// The runtime checks at the FormField level are the responsibility
+// of the discriminated-union parser elsewhere.
+function shortText(name: string, required: boolean) {
+	return {
+		kind: "short_text",
+		name,
+		label: name,
+		required,
+		hint: null,
+		placeholder: null,
+		max_length: null,
+		min_length: null,
+		default: null,
+		subtype: "plain",
+	} as unknown as FormDefinition["fields"][number];
+}
+
+function multiSelect(name: string, required: boolean) {
+	return {
+		kind: "multi_select",
+		name,
+		label: name,
+		required,
+		hint: null,
+		options: [],
+		default: null,
+	} as unknown as FormDefinition["fields"][number];
+}
+
+function aSwitch(name: string, required: boolean) {
+	return {
+		kind: "switch",
+		name,
+		label: name,
+		required,
+		hint: null,
+		true_label: "Yes",
+		false_label: "No",
+		default: null,
+	} as unknown as FormDefinition["fields"][number];
+}
+
+describe("buildResponseValue", () => {
+	it("drops null on a non-required field", () => {
+		const f = form([shortText("reason", false), aSwitch("approved", true)]);
+		const value: FormValue = { reason: null, approved: true };
+
+		expect(buildResponseValue(f, value)).toEqual({ approved: true });
+	});
+
+	it("keeps null on a required field so server can flag it", () => {
+		const f = form([aSwitch("approved", true), shortText("reason", true)]);
+		const value: FormValue = { approved: null, reason: null };
+
+		expect(buildResponseValue(f, value)).toEqual({
+			approved: null,
+			reason: null,
+		});
+	});
+
+	it("preserves empty string distinctly from null", () => {
+		// User typing and clearing produces "". That's a meaningful
+		// value (the human said "the answer is empty") versus null
+		// ("untouched"). Send it as-is.
+		const f = form([shortText("reason", false)]);
+		expect(buildResponseValue(f, { reason: "" })).toEqual({ reason: "" });
+	});
+
+	it("preserves empty arrays for multi_select", () => {
+		// "Nothing selected" is a valid completion for an optional
+		// multi_select; don't drop it.
+		const f = form([multiSelect("tags", false)]);
+		expect(buildResponseValue(f, { tags: [] })).toEqual({ tags: [] });
+	});
+
+	it("drops undefined the same as null", () => {
+		const f = form([shortText("reason", false)]);
+		expect(buildResponseValue(f, { reason: undefined })).toEqual({});
+	});
+
+	it("flattens section_collapse children at the same level", () => {
+		const collapse = {
+			kind: "section_collapse",
+			name: "advanced",
+			label: "advanced",
+			required: false,
+			hint: null,
+			title: "Advanced",
+			subtitle: null,
+			default_open: false,
+			fields: [shortText("tier", false), shortText("ref", true)],
+		} as unknown as FormDefinition["fields"][number];
+		const f = form([aSwitch("approved", true), collapse]);
+
+		const value: FormValue = {
+			approved: true,
+			tier: null,
+			ref: null,
+		};
+
+		// `tier` (optional) is dropped; `ref` (required) is kept.
+		expect(buildResponseValue(f, value)).toEqual({
+			approved: true,
+			ref: null,
+		});
+	});
+
+	it("recurses into subform rows", () => {
+		const subform = {
+			kind: "subform",
+			name: "items",
+			label: "items",
+			required: true,
+			hint: null,
+			min_count: null,
+			max_count: null,
+			initial_count: 1,
+			add_label: "Add",
+			remove_label: "Remove",
+			fields: [shortText("sku", true), shortText("note", false)],
+		} as unknown as FormDefinition["fields"][number];
+		const f = form([subform]);
+
+		const value: FormValue = {
+			items: [
+				{ sku: "A-1", note: "ok" },
+				{ sku: "A-2", note: null },
+			],
+		};
+
+		expect(buildResponseValue(f, value)).toEqual({
+			items: [
+				{ sku: "A-1", note: "ok" },
+				{ sku: "A-2" },
+			],
+		});
+	});
+
+	it("recurses into table rows by column", () => {
+		const table = {
+			kind: "table",
+			name: "amounts",
+			label: "amounts",
+			required: false,
+			hint: null,
+			min_rows: null,
+			max_rows: null,
+			initial_rows: 1,
+			allow_add_row: true,
+			allow_remove_row: true,
+			columns: [
+				{
+					name: "currency",
+					label: "currency",
+					kind: "short_text",
+					required: true,
+					placeholder: null,
+					options: null,
+					currency_code: null,
+					min_value: null,
+					max_value: null,
+					default: null,
+				},
+				{
+					name: "memo",
+					label: "memo",
+					kind: "short_text",
+					required: false,
+					placeholder: null,
+					options: null,
+					currency_code: null,
+					min_value: null,
+					max_value: null,
+					default: null,
+				},
+			],
+		} as unknown as FormDefinition["fields"][number];
+		const f = form([table]);
+
+		const value: FormValue = {
+			amounts: [
+				{ currency: "USD", memo: null },
+				{ currency: "EUR", memo: "" },
+			],
+		};
+
+		expect(buildResponseValue(f, value)).toEqual({
+			amounts: [{ currency: "USD" }, { currency: "EUR", memo: "" }],
+		});
+	});
+});

--- a/packages/dashboard/components/form-renderer/build-response-value.ts
+++ b/packages/dashboard/components/form-renderer/build-response-value.ts
@@ -1,0 +1,112 @@
+/**
+ * Build the response payload to submit to `POST /api/tasks/{id}/complete`.
+ *
+ * Walks the form definition and the user's value object together,
+ * dropping any field whose value is `null`/`undefined` AND whose
+ * schema marks it as not required.
+ *
+ * Without this, an unfilled optional `short_text` field renders an
+ * untouched value of `null` (the renderer initializes plain-input
+ * kinds blank) and the dashboard sends `{"reason": null}` to the
+ * server. That fails Pydantic validation against the common
+ * `field: str = ""` shape — Pydantic accepts `""` but not `None` for
+ * a non-Optional `str`. Omitting the key lets the server's Pydantic
+ * schema apply its default ("" or whatever) instead of choking on a
+ * wire payload the agent's schema couldn't have produced anyway.
+ *
+ * Required fields keep their `null` so server-side validation can
+ * surface a clear error rather than silently dropping the violation.
+ *
+ * Subform / table rows are recursed into so a blank optional column
+ * or nested field gets the same treatment per row.
+ *
+ * Kept in a `.ts` (not `.tsx`) file so it's testable without a JSX
+ * vite plugin. The renderer's `index.tsx` re-exports it for callers.
+ */
+
+import type { FormDefinition, FormField } from "@/lib/form-types";
+
+import type { FormValue } from "./types";
+
+// Layout / display primitives that have a `name` for layout purposes
+// but never contribute a value to the response. Mirrors the same set
+// in `index.tsx`'s `walk()` — duplicated rather than shared because
+// the constant is small and tying the two files together via an
+// intermediate module would obscure intent more than it would help.
+const NON_INPUT_KINDS = new Set([
+	"display_text",
+	"image",
+	"video",
+	"pdf_viewer",
+	"html",
+	"section",
+	"divider",
+]);
+
+export function buildResponseValue(
+	form: FormDefinition,
+	value: FormValue,
+): FormValue {
+	return cleanLevel(form.fields, value);
+}
+
+function cleanLevel(fields: FormField[], value: FormValue): FormValue {
+	const out: FormValue = {};
+	for (const f of fields) {
+		if (!f.name) continue;
+		if (NON_INPUT_KINDS.has(f.kind)) continue;
+
+		// section_collapse flattens — its child fields' names live at
+		// the same level as the parent in `value`, matching how the
+		// renderer's `walk()` builds the initial state.
+		if (f.kind === "section_collapse") {
+			Object.assign(out, cleanLevel(f.fields, value));
+			continue;
+		}
+
+		const v = value[f.name];
+
+		// The core rule: drop null on non-required fields so Pydantic
+		// defaults apply server-side. Required fields keep null so
+		// server-side validation can flag the violation explicitly.
+		if (v == null && !f.required) {
+			continue;
+		}
+
+		// subform: array of nested FormValues; recurse into each row.
+		if (f.kind === "subform") {
+			const rows = Array.isArray(v) ? v : [];
+			out[f.name] = rows.map((row) =>
+				cleanLevel(f.fields, (row ?? {}) as FormValue),
+			);
+			continue;
+		}
+
+		// table: array of column-keyed objects. Same shape as a flat
+		// FormValue per row, so the per-column null-on-not-required
+		// rule applies.
+		if (f.kind === "table") {
+			const rows = Array.isArray(v) ? v : [];
+			out[f.name] = rows.map((row) =>
+				cleanTableRow(f.columns, (row ?? {}) as FormValue),
+			);
+			continue;
+		}
+
+		out[f.name] = v;
+	}
+	return out;
+}
+
+function cleanTableRow(
+	columns: { name: string; required: boolean }[],
+	row: FormValue,
+): FormValue {
+	const out: FormValue = {};
+	for (const col of columns) {
+		const v = row[col.name];
+		if (v == null && !col.required) continue;
+		out[col.name] = v;
+	}
+	return out;
+}

--- a/packages/dashboard/components/form-renderer/index.tsx
+++ b/packages/dashboard/components/form-renderer/index.tsx
@@ -49,8 +49,10 @@ import {
 	SectionRenderer,
 } from "./layout";
 import { SubformRenderer, TableRenderer } from "./complex";
+import type { FormValue } from "./types";
 
-export type FormValue = Record<string, unknown>;
+export { buildResponseValue } from "./build-response-value";
+export type { FormValue } from "./types";
 
 type Props = {
 	form: FormDefinition;
@@ -398,3 +400,4 @@ function walk(fields: FormField[], out: FormValue): void {
 		}
 	}
 }
+

--- a/packages/dashboard/components/form-renderer/types.ts
+++ b/packages/dashboard/components/form-renderer/types.ts
@@ -1,0 +1,8 @@
+/**
+ * Shared types for the form-renderer module. Kept in a `.ts` (not
+ * `.tsx`) file so test files and other non-JSX consumers can import
+ * them without dragging the renderer's React surface through Vite's
+ * import analysis.
+ */
+
+export type FormValue = Record<string, unknown>;


### PR DESCRIPTION
## Summary

When a human leaves an optional text field blank in the dashboard, the form renderer currently submits `{"reason": null}` to the server. That fails Pydantic validation against the common `field: str = ""` shape — the schema accepts `""` but not `None` for a non-Optional `str`. End result: the dashboard shows the task completed but the agent process raises `SchemaValidationError`. Surfaced while running the manual test plan for #65 / #67 with a `reason: str = ""` decision schema.

This PR fixes it by walking the form definition and the user's value together at submit time and dropping any field whose value is `null`/`undefined` AND whose schema marks it as not required. Pydantic then applies the field's default server-side instead of choking on a wire `null` the agent's schema couldn't have produced anyway.

## What's in here

**Logic**
- `packages/dashboard/components/form-renderer/build-response-value.ts` — new pure function `buildResponseValue(form, value)`. Recurses into `section_collapse` (children flatten to the same level as the parent), `subform` (rows of nested FormValues), and `table` (rows of column-keyed objects).
- `packages/dashboard/components/form-renderer/types.ts` — extracted `FormValue` type. Lets the test import it without pulling JSX through Vite's import analysis.
- `packages/dashboard/components/form-renderer/index.tsx` — re-exports `buildResponseValue` and `FormValue` for existing callers; the actual function is gone from this file.
- `packages/dashboard/app/(dashboard)/task/page.tsx` — submit path now runs the response through `buildResponseValue` if a `form_definition` is present.

**Tests**
- `packages/dashboard/components/form-renderer/build-response-value.test.ts` — 8 tests pinning the contract:
  - drops `null` on a non-required field
  - keeps `null` on a required field (so server-side validation can flag it)
  - preserves empty strings (the human deliberately cleared the field — distinct from "untouched")
  - preserves empty arrays for `multi_select` ("no selection" is a valid completion)
  - drops `undefined` the same as `null`
  - flattens `section_collapse` children at the same level
  - recurses into `subform` rows
  - recurses into `table` rows by column

This is the first vitest test in the dashboard package (`vitest` was already a dev dep, just unused). No config file needed — the file naturally picks up vitest's defaults.

## Test plan

- [x] `npx vitest run components/form-renderer/build-response-value.test.ts` — 8 passed
- [x] `npx tsc --noEmit` in `packages/dashboard` — clean
- [x] `npx biome check` on all 5 modified/new files — clean
- [ ] Manual: pull the merge, `make bundle-dashboard`, restart `awaithumans dev`, re-run Test 3 from the resumable-direct-mode test plan with the original `reason: str = ""` schema — should now complete cleanly without the SchemaValidationError seen on `main` today.

## Out of scope

- Server-side coercion (the server still trusts whatever JSON the dashboard submits). The dashboard is the source of the wire `null`; fixing it at the source is cleaner than masking it server-side.
- Other channels' completion paths (Slack, email magic links). Those don't go through the dashboard's form renderer; they have their own form handling. Worth auditing separately if the same pattern shows up there.

## Related

- Surfaced during manual verification of the resumable-direct-mode work in #65 and #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)