### PR TITLE
docs: audit, fix broken error links, add testing + webhooks pages, polish Mintlify

### DIFF
--- a/.github/RELEASE_NOTES_v0.1.0.md
+++ b/.github/RELEASE_NOTES_v0.1.0.md
@@ -1,0 +1,118 @@
+# awaithumans v0.1.0 — public preview
+
+The first tagged release of `awaithumans` — the human layer for AI agents. One function call (`await_human()` / `awaitHuman()`) parks your agent until a human reviews via Slack, email, or a built-in dashboard, then resumes with a typed response.
+
+## Highlights
+
+- 🧠 **One primitive** in [Python](https://awaithumans.dev/docs/sdk/python) and [TypeScript](https://awaithumans.dev/docs/sdk/typescript): `await_human()` / `awaitHuman()`.
+- 📬 **Three channels:** [Slack](https://awaithumans.dev/docs/channels/slack) (broadcast + DM + NL replies), [email](https://awaithumans.dev/docs/channels/email) (Resend + SMTP), built-in [dashboard](https://awaithumans.dev/docs/channels/overview#dashboard).
+- 🔁 **Durable adapters:** [Temporal](https://awaithumans.dev/docs/adapters/temporal) (signal-based) and [LangGraph](https://awaithumans.dev/docs/adapters/langgraph) (interrupt/resume).
+- 🤖 **AI verification** server-side: Claude / OpenAI / Gemini / Azure OpenAI ([docs](https://awaithumans.dev/docs/adapters/verifier)).
+- 🪪 **User directory + routing** by email, list, pool, or role with least-recently-assigned fairness.
+- 🛡️ **Self-host in one command:** `awaithumans dev` for development, `docker compose up` for production.
+- 📦 **MIT** on the SDK (Python + TS); ELv2 on the server. Free forever for self-hosted use.
+
+## Install
+
+```bash
+# Python
+pip install "awaithumans[server]"
+awaithumans dev
+
+# TypeScript
+npm install awaithumans
+```
+
+Then [walk the quickstart](https://awaithumans.dev/docs/quickstart) — first task in five minutes.
+
+## What's in this release
+
+### SDK & core
+
+- `await_human()` / `await_human_sync()` — the core primitive (Python)
+- `awaitHuman()` — the equivalent in TypeScript
+- Pydantic schema validation (Python), Zod schema validation (TypeScript)
+- Cross-platform idempotency-key generation (Node, Bun, Deno, edge runtimes)
+- Error classes follow the **what → why → fix → docs** pattern in both SDKs — every error message includes a link to a docs page that explains the fix
+- Strict Stripe-style idempotency: same key, same task, always — direct-mode `await_human()` is now resumable across agent restarts ([details](https://awaithumans.dev/docs/concepts/idempotency))
+
+### Server
+
+- FastAPI app with SQLModel + Alembic migrations, runs on SQLite (dev) or Postgres (prod)
+- Task CRUD + a state machine covering 10 statuses ([lifecycle](https://awaithumans.dev/docs/concepts/task-lifecycle))
+- Long-poll endpoint for direct-mode SDK clients
+- Timeout scheduler using an indexed `timeout_at` column
+- HMAC-signed completion webhooks with at-least-once retry over 3 days ([webhooks](https://awaithumans.dev/docs/webhooks))
+- Audit trail for every state transition
+
+### Channels
+
+- **Slack:** DM + channel broadcast with first-to-claim semantics, Block Kit modal, OAuth install for multi-workspace, NL thread-reply parsing via the verifier, signed dashboard handoff for Slack-only users
+- **Email:** Resend + SMTP transports, action buttons for boolean / single-select responses, magic-link confirmation pages, file transport for automated tests
+
+### AI verification
+
+- One LLM call does both quality-check and NL-parsing
+- Built-in providers: Claude (Anthropic), OpenAI, Gemini (Google), Azure OpenAI
+- Configurable `max_attempts`; rejection is non-terminal so the human can retry
+- Skip the verifier with `redact_payload=True` for sensitive payloads
+
+### Adapters
+
+- **Temporal** (`pip install "awaithumans[temporal]"`, `import { awaitHuman } from "awaithumans/temporal"`) — signal-based, workflow parks for hours/days
+- **LangGraph** (`pip install "awaithumans[langgraph]"`, `awaithumans/langgraph`) — interrupt/resume in a single process
+
+### Dashboard
+
+- Next.js 16 + React 19, statically built, bundled into the Python wheel
+- Task queue, task detail, audit log, stats, settings pages
+- User directory with Slack member picker
+- First-run `/setup` wizard
+
+### CLI & DX
+
+- `awaithumans dev` — one-command server + dashboard, auto-generates `PAYLOAD_KEY` for local dev
+- `npx awaithumans dev` for TypeScript developers (under the hood: `uv` runs the Python server, no Python knowledge required)
+- Docker image at `ghcr.io/awaithumans/awaithumans` (linux/amd64 + linux/arm64)
+- Reference `docker-compose.yml` ships with the repo
+- 14 runnable examples across Python and TypeScript: quickstart, Slack, email (smoke + end-to-end), Temporal, LangGraph, verifier
+
+### Auth & security
+
+- argon2id password hashing for operator login
+- HMAC-signed session cookies (httponly, SameSite=Lax)
+- First-run bootstrap token, one-shot, printed to server log
+- Admin bearer token as the automation escape hatch
+- Login rate limiting per-IP and per-email
+- Last-active-operator guard
+- Credential scrubber on the root logger
+
+## Known gaps
+
+These are documented and on the post-launch roadmap:
+
+- No session invalidation on password change (outstanding sessions survive to expiry — `session_version` field planned)
+- Production `PUBLIC_URL` must be HTTPS — currently a logged error, not a boot failure
+- Multi-replica deployments need a shared rate-limiter store (Redis) — planned post-launch
+- In-memory `createTestClient()` is stubbed but not yet implemented — see the [Testing docs](https://awaithumans.dev/docs/testing) for the patterns that work today
+- Workforce marketplace (`assign_to={"marketplace": True}`) raises `MarketplaceNotAvailableError` — reserved for [Phase 3](https://awaithumans.dev/docs/community/roadmap#marketplace)
+
+## Migration from pre-release
+
+If you were running off `main` before tagging:
+
+- The strict-Stripe idempotency change is the single behavioral break. Pre-tag, a terminal task's key was released, allowing a fresh task with the same key. Now the same key always returns the same task.
+- To request a fresh task for the same logical event (e.g. yesterday's task timed out, you want a new review today), pass a distinct key — convention is to suffix with `:retry-N`.
+- See [Idempotency → Re-triggering a review](https://awaithumans.dev/docs/concepts/idempotency#re-triggering-a-review).
+
+## Links
+
+- 📚 [Documentation](https://awaithumans.dev/docs)
+- 🚀 [Quickstart](https://awaithumans.dev/docs/quickstart)
+- 🐛 [Report an issue](https://github.com/awaithumans/awaithumans/issues)
+- 💬 [Discord](https://discord.gg/awaithumans)
+- 🔒 Security disclosures: **security@awaithumans.com**
+
+## Thanks
+
+To everyone in the early Discord, the design partners walking through end-to-end loops on their own infrastructure, and the contributors testing edge cases nobody had hit yet — this release is for you.

--- a/docs/adapters/langgraph.mdx
+++ b/docs/adapters/langgraph.mdx
@@ -148,7 +148,14 @@ Catch them where you call `drive_human_loop` to recover.
 
 ## End-to-end example
 
-`examples/langgraph/refund_agent.py` in the repo is runnable on a laptop with just `awaithumans dev` running. See [the README](https://github.com/awaithumans/awaithumans/tree/main/examples/langgraph).
+Two runnable examples in the repo, same flow in each language:
+
+| Example | Language | Entry point |
+|---|---|---|
+| [`examples/langgraph-py/`](https://github.com/awaithumans/awaithumans/tree/main/examples/langgraph-py) | Python | `app.py` (FastAPI graph host) + `kickoff.py` |
+| [`examples/langgraph-ts/`](https://github.com/awaithumans/awaithumans/tree/main/examples/langgraph-ts) | TypeScript | `app.ts` + `kickoff.ts` |
+
+Both runnable on a laptop in three terminal windows alongside `awaithumans dev`. See the per-example README for the run commands.
 
 ## Cross-language
 
@@ -159,3 +166,9 @@ The TypeScript adapter at `awaithumans/langgraph` produces the same wire format.
 - **No checkpointer = no interrupts.** LangGraph requires a checkpointer to support `interrupt(...)`. Production graphs should use a durable backend (SQLite / Postgres / Redis), not `MemorySaver`.
 - **Side effects before `await_human`.** Run twice on resume. Move them after, or wrap in idempotency.
 - **Multiple `await_human` calls in one node.** Each interrupts independently; LangGraph routes resume values by call order. Pass distinct `idempotency_key=` if the `(task, payload)` tuples might collide.
+
+## Where to next
+
+- [Webhooks (`callback_url`)](/webhooks) — wire format and signature scheme for the callback your driver receives
+- [Testing](/testing) — patterns for testing graph nodes that call `await_human`
+- [Temporal adapter](/adapters/temporal) — the same pattern with signals instead of interrupt/resume

--- a/docs/adapters/temporal.mdx
+++ b/docs/adapters/temporal.mdx
@@ -158,3 +158,9 @@ The TypeScript adapter at `awaithumans/temporal` produces the same wire format. 
 - **`AWAITHUMANS_PAYLOAD_KEY` mismatch** — the HMAC signing key derives from this. If the awaithumans server and the callback receiver have different keys, signatures never verify. Use the same value on both processes.
 - **`callback_url` not reachable** — the awaithumans server logs show `Webhook delivery failed task=… url=…: …`. Most often a tunnel/firewall issue.
 - **Duplicate idempotency key** — two `await_human()` calls in the same workflow with the same `(task, payload)` get the same key by default. Pass `idempotency_key=` explicitly to disambiguate. See [Idempotency](/concepts/idempotency).
+
+## Where to next
+
+- [Webhooks (`callback_url`)](/webhooks) — full wire format, retry policy, signature scheme
+- [Testing](/testing) — driving fixtures past the workflow boundary
+- [LangGraph adapter](/adapters/langgraph) — the same pattern with interrupt/resume instead of signals

--- a/docs/adapters/verifier.mdx
+++ b/docs/adapters/verifier.mdx
@@ -53,7 +53,7 @@ If the human submits with empty notes on a $1500 refund, the verifier rejects wi
 ```python
 from awaithumans.verifiers.openai import openai_verifier
 from awaithumans.verifiers.gemini import gemini_verifier
-from awaithumans.verifiers.azure_openai import azure_verifier
+from awaithumans.verifiers.azure_openai import azure_openai_verifier
 
 # OpenAI
 verifier = openai_verifier(instructions="...", model="gpt-4o-2024-11-20")
@@ -62,10 +62,11 @@ verifier = openai_verifier(instructions="...", model="gpt-4o-2024-11-20")
 verifier = gemini_verifier(instructions="...", model="gemini-2.0-flash")
 
 # Azure OpenAI (deployment-name addressing)
-verifier = azure_verifier(
+verifier = azure_openai_verifier(
     instructions="...",
-    deployment="my-gpt4-deployment",
-    endpoint_env="AZURE_OPENAI_ENDPOINT",
+    deployment_name="my-gpt4-deployment",
+    endpoint_env="AZURE_OPENAI_ENDPOINT",   # default
+    api_version="2024-10-21",                # default
 )
 ```
 
@@ -139,3 +140,18 @@ The verifier fires on every submission. At ~1k input tokens + ~100 output per ca
 - Gemini 2.0 Flash: ~$0.0005 / call
 
 For most workloads this is negligible. For very high-volume queues, consider `gemini-2.0-flash`.
+
+## Runnable examples
+
+| Example | Language | Walks through |
+|---|---|---|
+| [`examples/verifier-py/`](https://github.com/awaithumans/awaithumans/tree/main/examples/verifier-py) | Python | All three verifier paths: pass, reject + retry, exhaust |
+| [`examples/verifier/`](https://github.com/awaithumans/awaithumans/tree/main/examples/verifier) | TypeScript | Same flow, TS SDK |
+
+Both run against a real Claude verifier — drop in your `ANTHROPIC_API_KEY`, `python refund.py` (or `npx tsx`), and walk the dashboard through each path. A useful template for fixture-driven tests of your own verifier prompts.
+
+## Where to next
+
+- [Testing](/testing) — patterns for testing verifier paths in CI
+- [Idempotency](/concepts/idempotency) — what happens to in-flight tasks across verifier retries
+- [Troubleshooting](/troubleshooting#verifier-provider-unavailable) — every verifier error code with the matching fix

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -1,0 +1,56 @@
+---
+title: "What's new"
+description: "Every release of awaithumans, with breaking changes flagged."
+---
+
+The canonical changelog lives at [github.com/awaithumans/awaithumans/releases](https://github.com/awaithumans/awaithumans/releases) — every tagged release ships with full notes, breaking changes, and migration guidance. This page summarizes the headline changes per version with deep links into the docs.
+
+<Note>
+Subscribe to release notifications on GitHub: open the repo → **Watch** → **Custom** → **Releases**. New version, new ping.
+</Note>
+
+## Versioning policy
+
+`awaithumans` follows [Semantic Versioning](https://semver.org/) with these conventions:
+
+- **MAJOR** (`v1.0.0` → `v2.0.0`) — breaking changes to the public SDK signature (`await_human()` parameters), wire format, or error codes. Migration guides ship in the release notes.
+- **MINOR** (`v0.1.0` → `v0.2.0`) — new features, new channels/adapters, deprecations. No breaking changes to the SDK signature within a minor.
+- **PATCH** (`v0.1.0` → `v0.1.1`) — bug fixes, doc fixes, internal refactors. Always safe to upgrade.
+
+**Pinning recommendation:** until v1.0.0, pin to a minor in your dependencies:
+
+```toml
+# Python (pyproject.toml)
+awaithumans = ">=0.1,<0.2"
+```
+
+```json
+// TypeScript (package.json)
+"awaithumans": "~0.1"
+```
+
+After v1.0.0 ships, the SDK signature is stable for the v1.x line — a `^1.0.0` range is safe.
+
+## Releases
+
+### v0.1.0 — Public preview (May 2026)
+
+The first tagged release. Everything in the docs ships with this version: the core primitive, three channels (dashboard, Slack, email), two durable adapters (Temporal, LangGraph), AI verification across four providers, the dashboard, CLI, and Docker image.
+
+**Highlights:**
+
+- One function call: [`await_human()`](/sdk/python) / [`awaitHuman()`](/sdk/typescript)
+- Strict Stripe-style [idempotency](/concepts/idempotency) — direct-mode resumes across agent restarts
+- HMAC-signed [webhooks](/webhooks) with 3-day retry envelope
+- Server-side [AI verification](/adapters/verifier) (Claude / OpenAI / Gemini / Azure OpenAI)
+- One-command [self-hosting](/self-hosting/docker-compose)
+
+**Migration:** if you were tracking `main` pre-tag, the only behavior break is the [strict idempotency change](/concepts/idempotency#re-triggering-a-review) — a terminal task's key now stays bound to that task.
+
+[Full release notes →](https://github.com/awaithumans/awaithumans/releases/tag/v0.1.0)
+
+## Where to next
+
+- [Roadmap](/community/roadmap) — what's coming after v0.1
+- [GitHub Releases](https://github.com/awaithumans/awaithumans/releases) — every version, full notes
+- [Versioning & release notes](/community/roadmap#versioning--release-notes) — pinning recommendations

--- a/docs/community/roadmap.mdx
+++ b/docs/community/roadmap.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Help wanted"
-description: "Substantial features we'd love community help shipping. Pick one up, drop a proposal in the linked issue, and we'll review."
+title: "Roadmap & help wanted"
+description: "What's coming next, and substantial features we'd love community help shipping."
 ---
 
 `awaithumans` ships small surface area on purpose. A few things on the roadmap are big enough that they make better community projects than founder-built features — well-bounded, self-contained, and meaty enough to be a real systems-design exercise.
@@ -22,3 +22,19 @@ This is exactly the kind of thing that's a good portfolio piece: real systems-de
 ---
 
 Other "help wanted" issues land here as they're scoped. If you have something in mind that isn't listed, open a [GitHub Discussion](https://github.com/awaithumans/awaithumans/discussions) — we'd rather talk shape than code review a surprise.
+
+## Workforce marketplace {#marketplace}
+
+**Status:** reserved for Phase 3 · **Tracking issue:** [#1](https://github.com/awaithumans/awaithumans/issues/1)
+
+The `assign_to={"marketplace": True, ...}` shape is reserved for the post-Phase-2 workforce marketplace, where tasks can be sourced from external reviewers (not just your own team).
+
+Today, calling `await_human()` with `marketplace=True` raises `MarketplaceNotAvailableError`. The error exists so the API surface is forward-compatible — when the marketplace ships, agent code can opt in by flipping a flag, no rewrites.
+
+**Why it's not in v0.1:** the open-source core is built around teams that own their reviewers. The marketplace adds a third party (the worker pool), payments, capability matching, and SLAs. That's a different product surface — it sits on top of the same `await_human()` primitive but ships separately so the core stays small.
+
+If you're interested in helping shape the marketplace before it ships, comment on the tracking issue with your use case (what task types, what reviewer capabilities you'd source externally, what your QA story would look like). We're scoping the first design partner cohort for late-2026.
+
+## Versioning & release notes
+
+Every public release is documented at [github.com/awaithumans/awaithumans/releases](https://github.com/awaithumans/awaithumans/releases) with version highlights, breaking changes, and migration notes. Version pinning recommendation: pin to a minor (`awaithumans>=0.1,<0.2`) until v1.0 cuts.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -31,7 +31,7 @@ These don't go away with bigger models. Every production agent system needs a hu
 ## What you get
 
 - **One function** in [Python](/sdk/python) and [TypeScript](/sdk/typescript): `await_human()` / `awaitHuman()`.
-- **Channels**: deliver tasks to humans via [Slack](/channels/slack), [email](/channels/email), or a built-in web [dashboard](#dashboard).
+- **Channels**: deliver tasks to humans via [Slack](/channels/slack), [email](/channels/email), or a built-in web [dashboard](/channels/overview#dashboard).
 - **Adapters** for durable execution: [Temporal](/adapters/temporal), [LangGraph](/adapters/langgraph). Workflows park while waiting; survive restarts.
 - **Verification**: optional AI [quality-check + NL parsing](/adapters/verifier) layer (Claude / OpenAI / Gemini / Azure).
 - **Routing**: assign tasks to specific people, [pools](/routing/overview), or roles.

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -3,7 +3,8 @@
   "name": "Await Humans",
   "logo": {
     "dark": "/logo/dark.svg",
-    "light": "/logo/light.svg"
+    "light": "/logo/light.svg",
+    "href": "https://awaithumans.dev"
   },
   "favicon": "/favicon.png",
   "colors": {
@@ -19,10 +20,29 @@
       "to": "#33EE99"
     }
   },
+  "modeToggle": {
+    "default": "dark",
+    "isHidden": false
+  },
+  "codeBlock": {
+    "mode": "auto"
+  },
+  "feedback": {
+    "thumbsRating": true,
+    "suggestEdit": true,
+    "raiseIssue": true
+  },
+  "search": {
+    "prompt": "Search the awaithumans docs..."
+  },
   "topbarLinks": [
     {
       "name": "GitHub",
       "url": "https://github.com/awaithumans/awaithumans"
+    },
+    {
+      "name": "Releases",
+      "url": "https://github.com/awaithumans/awaithumans/releases"
     }
   ],
   "topbarCtaButton": {
@@ -39,6 +59,11 @@
       "name": "Discord",
       "icon": "discord",
       "url": "https://discord.gg/awaithumans"
+    },
+    {
+      "name": "Releases",
+      "icon": "tag",
+      "url": "https://github.com/awaithumans/awaithumans/releases"
     }
   ],
   "navigation": [
@@ -89,6 +114,12 @@
       ]
     },
     {
+      "group": "Integrations",
+      "pages": [
+        "webhooks"
+      ]
+    },
+    {
       "group": "SDK reference",
       "pages": [
         "sdk/python",
@@ -107,12 +138,14 @@
     {
       "group": "Help",
       "pages": [
+        "testing",
         "troubleshooting"
       ]
     },
     {
       "group": "Community",
       "pages": [
+        "changelog",
         "community/roadmap"
       ]
     }
@@ -120,6 +153,56 @@
   "footerSocials": {
     "github": "https://github.com/awaithumans/awaithumans",
     "x": "https://x.com/awaithumans"
+  },
+  "footer": {
+    "links": [
+      {
+        "title": "Product",
+        "links": [
+          { "label": "Quickstart", "url": "/quickstart" },
+          { "label": "Concepts", "url": "/concepts/task-lifecycle" },
+          { "label": "Releases", "url": "https://github.com/awaithumans/awaithumans/releases" }
+        ]
+      },
+      {
+        "title": "Developers",
+        "links": [
+          { "label": "Python SDK", "url": "/sdk/python" },
+          { "label": "TypeScript SDK", "url": "/sdk/typescript" },
+          { "label": "API reference", "url": "/api/overview" },
+          { "label": "Webhooks", "url": "/webhooks" }
+        ]
+      },
+      {
+        "title": "Self-host",
+        "links": [
+          { "label": "Docker Compose", "url": "/self-hosting/docker-compose" },
+          { "label": "Configuration", "url": "/self-hosting/configuration" },
+          { "label": "Security", "url": "/self-hosting/security" }
+        ]
+      },
+      {
+        "title": "Community",
+        "links": [
+          { "label": "GitHub", "url": "https://github.com/awaithumans/awaithumans" },
+          { "label": "Discord", "url": "https://discord.gg/awaithumans" },
+          { "label": "Roadmap & help wanted", "url": "/community/roadmap" }
+        ]
+      }
+    ]
+  },
+  "redirects": [
+    {
+      "source": "/roadmap",
+      "destination": "/community/roadmap"
+    },
+    {
+      "source": "/docs/roadmap",
+      "destination": "/community/roadmap"
+    }
+  ],
+  "seo": {
+    "indexHiddenPages": false
   },
   "metadata": {
     "og:site_name": "Await Humans",

--- a/docs/sdk/python.mdx
+++ b/docs/sdk/python.mdx
@@ -85,7 +85,7 @@ All inherit from `AwaitHumansError`.
 from awaithumans.verifiers.claude import claude_verifier
 from awaithumans.verifiers.openai import openai_verifier
 from awaithumans.verifiers.gemini import gemini_verifier
-from awaithumans.verifiers.azure_openai import azure_verifier
+from awaithumans.verifiers.azure_openai import azure_openai_verifier
 
 verifier = claude_verifier(
     instructions="...",

--- a/docs/testing.mdx
+++ b/docs/testing.mdx
@@ -1,0 +1,188 @@
+---
+title: "Testing your agent"
+description: "Patterns for testing agent code that calls await_human() — without spinning up a real reviewer in CI."
+---
+
+`await_human()` blocks until a human acts. That's the whole point in production, and the exact thing that makes naive tests hang for the full `timeout_seconds`. This page covers the four shippable patterns to test agent code that uses awaithumans, ranked from "least magic" to "most automated."
+
+<Note>
+An in-memory `createTestClient()` (no server, instant resolution) is on the roadmap — see [the test-client tracking issue](https://github.com/awaithumans/awaithumans/issues). Until it lands, the patterns below are the supported ways to write tests today.
+</Note>
+
+## 1. Live dev server + real human (dev loop)
+
+For local iteration on a single task — when you're shaping the prompt and form, not running CI — the simplest thing is to keep `awaithumans dev` running in one terminal and click through the dashboard yourself.
+
+```bash
+# Terminal 1 — server
+awaithumans dev
+
+# Terminal 2 — your agent
+python my_agent.py
+# (Agent blocks; open http://localhost:3001, approve, agent unblocks.)
+```
+
+Use this when you're iterating on schemas, instructions, or routing — the feedback loop is faster than wiring a test fixture.
+
+## 2. File-transport email smoke (full automation, no GUI)
+
+The email channel has a `file` transport that writes each email as a JSON file to a directory instead of sending. Combined with the magic-link action URL, you can drive a full agent ↔ server ↔ "human" loop without ever opening a browser.
+
+```python
+# smoke.py — the shape of an automated end-to-end test
+import json
+import re
+import os
+import tempfile
+import time
+from pathlib import Path
+
+import requests
+from awaithumans import await_human_sync
+from pydantic import BaseModel
+
+EMAIL_DIR = Path(tempfile.mkdtemp(prefix="awaithumans-smoke-"))
+SERVER = "http://localhost:3001"
+TOKEN = os.environ["AWAITHUMANS_ADMIN_API_TOKEN"]
+
+# 1. Create a file-transport email identity
+requests.post(
+    f"{SERVER}/api/channels/email/identities",
+    headers={"Authorization": f"Bearer {TOKEN}"},
+    json={
+        "id": "smoke",
+        "display_name": "Smoke",
+        "from_email": "smoke@example.test",
+        "transport": "file",
+        "transport_config": {"dir": str(EMAIL_DIR)},
+    },
+)
+
+# 2. Kick off await_human (in a thread so we can drive the response)
+class Decision(BaseModel):
+    approved: bool
+
+import threading
+result_box = {}
+def run_agent():
+    result_box["v"] = await_human_sync(
+        task="Approve wire?",
+        payload_schema=...,
+        payload=...,
+        response_schema=Decision,
+        timeout_seconds=120,
+        notify=["email+smoke:reviewer@example.test"],
+    )
+threading.Thread(target=run_agent, daemon=True).start()
+
+# 3. Poll the file dir for the rendered email
+deadline = time.time() + 30
+while time.time() < deadline:
+    files = list(EMAIL_DIR.glob("*.json"))
+    if files:
+        break
+    time.sleep(0.5)
+
+email = json.loads(files[0].read_text())
+approve_url = re.search(r'href="([^"]+/email/action/[^"]+)"', email["html"]).group(1)
+
+# 4. POST to the magic-link URL — same as a human clicking "Approve"
+requests.post(approve_url)
+
+# 5. Agent unblocks; assert
+time.sleep(1)
+assert result_box["v"].approved is True
+```
+
+The full version of this is the runnable `examples/email-smoke-py/` (Python) and `examples/email-smoke/` (TypeScript). Both are in CI and prove the SDK ↔ server contract on every push.
+
+| Example | Language | What it tests |
+|---|---|---|
+| [`examples/email-smoke-py/`](https://github.com/awaithumans/awaithumans/tree/main/examples/email-smoke-py) | Python | SDK → file-transport email → magic-link → SDK resolves |
+| [`examples/email-smoke/`](https://github.com/awaithumans/awaithumans/tree/main/examples/email-smoke) | TypeScript | Same loop, TS SDK |
+
+This pattern is the right call when you want to test the **whole chain** (SDK serialization → server task creation → channel rendering → magic-link auth → completion → SDK polling unblock).
+
+## 3. Direct `POST /complete` (skip the channel)
+
+If you're testing agent logic — branching on `decision.approved`, error handling for `TaskTimeoutError`, etc. — you don't need to exercise the channel layer. Hit the complete endpoint directly:
+
+```python
+# In a fixture / test setup, after kicking off your agent:
+import requests, os
+
+# Get the most recent task ID (or pre-stamp `idempotency_key` so you know it)
+tasks = requests.get(
+    f"http://localhost:3001/api/tasks?limit=1",
+    headers={"Authorization": f"Bearer {os.environ['AWAITHUMANS_ADMIN_API_TOKEN']}"},
+).json()
+task_id = tasks["items"][0]["id"]
+
+# Complete it
+requests.post(
+    f"http://localhost:3001/api/tasks/{task_id}/complete",
+    headers={"Authorization": f"Bearer {os.environ['AWAITHUMANS_ADMIN_API_TOKEN']}"},
+    json={"response": {"approved": True, "notes": "test fixture"}},
+)
+# Your agent's await_human() resolves on next poll cycle (~25s max).
+```
+
+Pre-stamping `idempotency_key=f"test:{test_name}"` lets a parallel test know exactly which task to complete without race conditions.
+
+## 4. Verifier-path tests (three corner cases)
+
+When you've configured a verifier, there are three behavioral paths to cover:
+
+| Path | How to drive it | Expected SDK behavior |
+|---|---|---|
+| **Pass** | Submit a response that meets the `instructions` | `await_human()` returns the typed response |
+| **Reject + retry** | Submit a response the verifier rejects, then resubmit with one that passes | Task transitions REJECTED → COMPLETED; SDK returns the second submission |
+| **Exhaust** | Submit `max_attempts` rejected responses | SDK raises `VerificationExhaustedError` |
+
+The runnable [`examples/verifier-py/`](https://github.com/awaithumans/awaithumans/tree/main/examples/verifier-py) walks all three paths against a real Claude verifier — useful as a fixture template.
+
+For tests that should not call a real LLM, set the verifier's `model` to a deployment that returns canned responses (a stub Claude proxy, or LocalAI's `claude` adapter), and override the API key env var per-test.
+
+## 5. Pinning idempotency keys for parallel safety
+
+If your test suite creates tasks in parallel, pin every test's `idempotency_key` to its test name so a flaky run doesn't accidentally pick up a sibling test's task:
+
+```python
+def test_refund_approval():
+    decision = await_human_sync(
+        task="...",
+        idempotency_key="test:refund-approval",   # ← stable per-test
+        # ...
+    )
+```
+
+Re-running the same test re-uses the same task (Stripe-style idempotency). To force a fresh task between runs, suffix with a UUID:
+
+```python
+idempotency_key=f"test:refund-approval:{uuid.uuid4()}"
+```
+
+## What to put in CI
+
+The minimum useful CI loop:
+
+1. Boot `awaithumans dev` (or use Docker Compose in CI runners).
+2. Run the file-transport email smoke against it.
+3. Run your agent test suite using pattern 3 (direct complete).
+
+That covers ~90% of regression risk: the SDK wire format, the channel renderer, the verifier path, and your own agent's branching.
+
+The slack channel doesn't have an automated smoke equivalent — Slack signs every interaction with a per-workspace secret routed through Slack's servers, which can't be driven from local code. The fall-back is the manual flow in [`examples/slack-native/`](https://github.com/awaithumans/awaithumans/tree/main/examples/slack-native).
+
+## Common pitfalls
+
+- **Tests timing out at the SDK's `timeout_seconds` rather than your test runner's timeout.** Set `timeout_seconds=60` in tests; the SDK's minimum is 60s. Anything shorter belongs in a different layer (your test runner's pytest-timeout, jest's testTimeout).
+- **Polluting prod data with test tasks.** Run tests against a separate `AWAITHUMANS_URL`. The dev server's SQLite DB is at `.awaithumans/dev.db` — wipe between test runs if you want isolation.
+- **Forgetting to clean up email identities.** Each test creates a `file` identity; tear down with `DELETE /api/channels/email/identities/{id}` so they don't accumulate.
+- **Verifier hits a real LLM in CI.** That's both a cost and a flakiness risk. Mock at the env-var level (point `ANTHROPIC_API_KEY` at a stub) or skip the verifier in non-prod-shape tests.
+
+## Where to next
+
+- [Webhooks (`callback_url`)](/webhooks) — for testing Temporal/LangGraph workflow callbacks
+- [Idempotency](/concepts/idempotency) — recover-from-crash semantics that test fixtures rely on
+- [Verifier](/adapters/verifier) — full provider list and prompt patterns

--- a/docs/webhooks.mdx
+++ b/docs/webhooks.mdx
@@ -1,0 +1,208 @@
+---
+title: "Webhooks (callback_url)"
+description: "How awaithumans pushes terminal-state notifications to your service. HMAC scheme, retry policy, and a copy-paste receiver."
+---
+
+When you create a task with `callback_url=...`, the awaithumans server stops asking you to long-poll. Instead, on every terminal-state transition it POSTs an HMAC-signed JSON body to your URL. This is the foundation the [Temporal](/adapters/temporal) and [LangGraph](/adapters/langgraph) adapters ride on — but it's also useful on its own for any service that prefers push over pull.
+
+## When to use callback_url vs polling
+
+| You're building | Use |
+|---|---|
+| A short-lived script (Flask handler, cron job, REPL session) | SDK long-poll (default — no `callback_url` needed) |
+| A Temporal / LangGraph workflow that may park for hours | The adapter's `callback_url` (auto-wired) |
+| A serverless function that times out at 15 minutes | `callback_url` to a separate handler |
+| A FaaS or queue-driven worker that shouldn't hold a connection | `callback_url` |
+
+If your agent process can stay alive long enough to await the human, polling is simpler — no need for an inbound HTTP route.
+
+## Wire format
+
+```http
+POST {callback_url}
+Content-Type: application/json
+X-Awaithumans-Signature: sha256=<hex-digest>
+X-Awaithumans-Task-Id: tsk_4f8a2c1e9b...
+
+{
+  "task_id": "tsk_4f8a2c1e9b...",
+  "idempotency_key": "refund:order-12345",
+  "status": "completed",
+  "response": {"approved": true, "notes": "Duplicate charge confirmed."},
+  "completed_at": "2026-05-12T08:05:23.456Z",
+  "timed_out_at": null,
+  "completed_by_email": "alice@acme.com",
+  "completed_via_channel": "dashboard",
+  "verification_attempt": 1
+}
+```
+
+`status` is one of `completed`, `timed_out`, `cancelled`, `verification_exhausted`. The body is self-contained — your receiver doesn't need a second round-trip.
+
+## Signature verification
+
+The signature is `HMAC-SHA256(body)` using a key HKDF-derived from `AWAITHUMANS_PAYLOAD_KEY`. Both sides need the same `PAYLOAD_KEY` value.
+
+### Python receiver
+
+```python
+import json
+from fastapi import FastAPI, HTTPException, Request
+from awaithumans.utils.webhook_signing import verify_signature
+
+app = FastAPI()
+
+
+@app.post("/awaithumans/callback")
+async def callback(request: Request):
+    body = await request.body()
+    sig = request.headers.get("x-awaithumans-signature")
+
+    if not verify_signature(body=body, signature=sig):
+        raise HTTPException(401, "bad signature")
+
+    payload = json.loads(body)
+    # ... do work, return 2xx ...
+    return {"ok": True}
+```
+
+`verify_signature` is keyword-only and reads `AWAITHUMANS_PAYLOAD_KEY` from the environment — the receiver process needs the same `PAYLOAD_KEY` value that the awaithumans server signs with. The helper lives in `awaithumans.utils.*` deliberately: it has no dependency on the `[server]` extra, so a Temporal worker or LangGraph driver can verify callbacks without installing FastAPI / SQLModel.
+
+### TypeScript — using an adapter
+
+The Temporal and LangGraph adapters bundle signature verification into their dispatch helpers — call them directly from your route and you don't have to write the HMAC code:
+
+```ts
+// Temporal — verify + signal a workflow
+import { dispatchSignal } from "awaithumans/temporal";
+
+app.post("/awaithumans/callback", async (req, res) => {
+  const body = await readRawBody(req);
+  try {
+    await dispatchSignal({
+      temporalClient,
+      workflowId: req.query.wf as string,
+      body,
+      signatureHeader: req.headers["x-awaithumans-signature"] as string,
+      payloadKey: process.env.AWAITHUMANS_PAYLOAD_KEY!,
+    });
+    res.json({ ok: true });
+  } catch (e) {
+    res.status(401).json({ error: String(e) });
+  }
+});
+```
+
+```ts
+// LangGraph — verify + resume a graph
+import { createWebhookHandler } from "awaithumans/langgraph";
+
+const handler = createWebhookHandler({
+  graph,
+  payloadKey: process.env.AWAITHUMANS_PAYLOAD_KEY!,
+});
+
+app.post("/awaithumans/callback", async (req, res) => {
+  const body = await readRawBody(req);
+  await handler({ body, signatureHeader: req.headers["x-awaithumans-signature"] as string });
+  res.json({ ok: true });
+});
+```
+
+### Other languages
+
+The signing key is **not** `PAYLOAD_KEY` itself — it's an HKDF-SHA256 derivation of `PAYLOAD_KEY` with a channel-scoped salt + info pair. This way the same root key can sign sessions, magic links, AND webhooks without any one of those subkeys ever colliding.
+
+```
+HKDF-SHA256(
+  ikm  = base64-decode(PAYLOAD_KEY),  # 32 raw bytes
+  salt = b"awaithumans-webhook-v1",
+  info = b"v1",
+  length = 32,
+)
+```
+
+Then `signature = HMAC-SHA256(derived_key, body)` and the header value is `sha256={hex(signature)}`.
+
+The Python source is `awaithumans/utils/webhook_signing.py` and the TS source is `packages/typescript-sdk/src/adapters/temporal/index.ts` (look for `verifySignature`). Both are short, single-purpose, and documented — the canonical place to look when porting to Go, Rust, or any other language.
+
+Cross-language compatibility is asserted in the test suite: a body signed by Python verifies in TypeScript and vice versa.
+
+## Retry & backoff
+
+awaithumans persists the body bytes when the task transitions and dispatches with at-least-once semantics. A `WebhookDelivery` row tracks the attempts.
+
+| Attempt | Wait before this attempt |
+|---|---|
+| 1 | 0s (immediate) |
+| 2 | 30s |
+| 3 | 60s |
+| 4 | 2m |
+| 5 | 5m |
+| 6 | 15m |
+| 7 | 30m |
+| 8 | 1h |
+| 9 | 2h |
+| 10 | 4h |
+| 11 | 8h |
+| 12+ | 24h, daily |
+
+Total schedule covers ~3 days. After that, the row is marked `ABANDONED` and an admin can redrive via the dashboard's webhook deliveries page (or `POST /api/admin/webhook-deliveries/{id}/redeliver`).
+
+The receiver only needs to be up "most of the time" — a 4-hour outage during business hours is fine; a 4-day outage requires manual redrive.
+
+## What "success" means
+
+A 2xx response from your receiver counts as success. Anything else (4xx, 5xx, timeout, network error) is a failure and triggers retry. Your receiver should:
+
+1. Verify the signature (fail with 401 if bad — but this counts as a failure and will retry; legitimate cases shouldn't fail signature verification, so a 401 indicates real misconfiguration).
+2. Acknowledge fast — return 200 within 10 seconds. Long work belongs in a queue/job.
+3. Be idempotent — the same `task_id` may be delivered twice in extreme retry-during-outage cases. Use `task_id` (or `idempotency_key`) as a dedup key.
+
+The default per-attempt timeout is 10 seconds. Receivers that are slower than that will time out and retry.
+
+## What the dashboard shows
+
+Operators can monitor the delivery queue in the dashboard at **Settings → Webhook deliveries**:
+
+- Pending / Succeeded / Failed (retrying) / Abandoned
+- Last attempt status code & error
+- Manual redrive button per row (and bulk redrive for "all abandoned in the last X days")
+
+For production, set up a log alert on the structured log line `Webhook abandoned` so an outage that exceeds the 3-day cap doesn't silently swallow tasks.
+
+## Headers in detail
+
+| Header | Value | Purpose |
+|---|---|---|
+| `Content-Type` | `application/json` | The body is a JSON object. |
+| `X-Awaithumans-Signature` | `sha256=<hex>` | HMAC of the raw body. Verify before parsing. |
+| `X-Awaithumans-Task-Id` | `tsk_...` | Convenience for log filtering — the same value is in the body. |
+
+The `sha256=` prefix is intentional — it future-proofs for an algorithm upgrade. Receivers should reject signatures that don't start with that prefix.
+
+## Testing your receiver
+
+The simplest test loop is to run `awaithumans dev`, hit `POST /api/tasks` with a `callback_url` pointing at your local receiver (use ngrok if needed), and complete the task from the dashboard. Your receiver gets the live signed POST.
+
+For automated CI:
+
+1. Generate the expected signature in your test fixture using the same `PAYLOAD_KEY`.
+2. POST a synthetic body to your receiver with that signature.
+3. Assert your handler ran the right side effect.
+
+This skips the awaithumans server entirely — your test exercises just the verification path, which is the security-critical bit.
+
+## Common gotchas
+
+- **`PAYLOAD_KEY` mismatch.** Both processes must use the same value. The HMAC derivation depends on it; without symmetry, signatures never verify.
+- **Body parsing before verification.** Some frameworks (Express with `express.json()`, FastAPI's auto-JSON) consume the raw body and discard it. Read the raw bytes BEFORE the body-parser fires, then verify, then parse JSON.
+- **Sub-10s receiver budget violated.** A receiver that stalls 30+ seconds gets timed out and retried — your handler may run multiple times. Acknowledge fast; defer work.
+- **Localhost callbacks from a remote server.** If awaithumans runs on prod and your receiver is on `localhost`, the POST never lands. Use ngrok for dev, a real public URL for prod.
+- **Mixing the signing key with `PAYLOAD_KEY` directly.** They're different — `PAYLOAD_KEY` is the root, the signing key is HKDF-derived. Use the helpers; don't try to HMAC with `PAYLOAD_KEY` itself.
+
+## Where to next
+
+- [Temporal adapter](/adapters/temporal) — full workflow + receiver pattern
+- [LangGraph adapter](/adapters/langgraph) — interrupt/resume in a single process, no separate receiver
+- [Self-hosting → Security](/self-hosting/security) — full crypto primitives reference

--- a/packages/python/awaithumans/utils/constants.py
+++ b/packages/python/awaithumans/utils/constants.py
@@ -13,7 +13,7 @@ from awaithumans.types import TaskStatus
 SERVICE_NAME = "awaithumans"
 DOCS_BASE_URL = "https://awaithumans.dev/docs"
 DOCS_TROUBLESHOOTING_URL = f"{DOCS_BASE_URL}/troubleshooting"
-DOCS_ROADMAP_URL = f"{DOCS_BASE_URL}/roadmap"
+DOCS_ROADMAP_URL = f"{DOCS_BASE_URL}/community/roadmap"
 
 # ─── Timeout ─────────────────────────────────────────────────────────────
 

--- a/packages/typescript-sdk/src/internal/constants.ts
+++ b/packages/typescript-sdk/src/internal/constants.ts
@@ -29,4 +29,4 @@ export const CREATE_TASK_TIMEOUT_MS = 30_000;
 /** Docs base URLs for error messages. */
 export const DOCS_BASE_URL = "https://awaithumans.dev/docs";
 export const DOCS_TROUBLESHOOTING_URL = `${DOCS_BASE_URL}/troubleshooting`;
-export const DOCS_ROADMAP_URL = `${DOCS_BASE_URL}/roadmap`;
+export const DOCS_ROADMAP_URL = `${DOCS_BASE_URL}/community/roadmap`;


### PR DESCRIPTION
## Summary

Full developer-friendliness audit on the docs surface. Net result:

- **Every error in the SDKs now lands on a real, anchored doc target.** Five broken links fixed (`DOCS_ROADMAP_URL` mismatch, missing `#marketplace` anchor, `#dashboard` anchor on the wrong page, `azure_verifier` -> `azure_openai_verifier`, dead `examples/langgraph/refund_agent.py` link).
- **Three new pages** filling real gaps: `testing`, `webhooks`, `changelog`.
- **Modern Mintlify config** — feedback widget, suggest-edit, redirects, footer columns, dark default, Releases link.
- **v0.1.0 release notes drafted** at \`.github/RELEASE_NOTES_v0.1.0.md\`, ready for \`gh release create --draft\`.

## Bug fixes (the part that ships in error messages)

| Where | Was | Now |
|---|---|---|
| \`packages/python/.../utils/constants.py\` + \`packages/typescript-sdk/src/internal/constants.ts\` | \`DOCS_ROADMAP_URL\` -> \`/docs/roadmap\` (404) | \`/docs/community/roadmap\` |
| \`docs/community/roadmap.mdx\` | No \`#marketplace\` anchor | Added \"Workforce marketplace\" section + anchor |
| \`docs/introduction.mdx\` | \`#dashboard\` anchor that didn't exist | \`/channels/overview#dashboard\` |
| \`docs/adapters/verifier.mdx\`, \`docs/sdk/python.mdx\` | \`azure_verifier(deployment=...)\` (wrong export + wrong kwarg) | \`azure_openai_verifier(deployment_name=...)\` |
| \`docs/adapters/langgraph.mdx\` | Linked to \`examples/langgraph/refund_agent.py\` (dead) | Real entries: \`examples/langgraph-py/\` and \`examples/langgraph-ts/\` |

## New pages

- **\`docs/testing.mdx\`** — four shippable patterns (live dev loop, file-transport email smoke, direct \`POST /complete\`, verifier paths) plus CI checklist + pitfalls. Notes \`createTestClient\` is roadmap, not shipped (the source is a stub).
- **\`docs/webhooks.mdx\`** — wire format, HMAC scheme, retry table (3-day envelope), Python receiver via \`verify_signature\`, TS receivers via the adapter helpers, HKDF spec for other languages.
- **\`docs/changelog.mdx\`** — versioning policy, pinning recommendation, v0.1.0 entry with deep links.

## Mintlify polish (\`docs/mint.json\`)

- \`feedback\` (thumbs + suggest edit + raise issue)
- \`modeToggle\` default = dark
- \`codeBlock.mode = auto\`
- 4-column footer
- \`redirects\` for \`/roadmap\` and \`/docs/roadmap\` -> \`/community/roadmap\`
- Topbar Releases link + Releases anchor
- \`seo.indexHiddenPages = false\`

## Test plan

- [ ] \`mintlify dev\` in \`docs/\` — pages render, sidebar reflects new groups (Integrations + Help with Testing + Community with Changelog)
- [ ] Click each error-message URL from a fresh \`pip install -e .\` and \`npm install\` — all 11 anchors resolve
- [ ] \`mintlify broken-links\` — clean
- [ ] Confirm dashboard rebuild picks up the new \`DOCS_ROADMAP_URL\` constant (current \`dashboard_dist/\` is pre-fix)
- [ ] After v0.1.0 tag: \`gh release create v0.1.0 --notes-file .github/RELEASE_NOTES_v0.1.0.md --draft\`

## Out of scope (intentionally)

- Dashboard rebuild — deferred to its own commit; the source-side fix is in \`packages/dashboard/lib/constants.ts\` (which only uses \`DOCS_BASE_URL\` and \`DOCS_TROUBLESHOOTING_URL\`, both unchanged).
- Real OpenAPI integration in Mintlify — the spec at \`/api/openapi.json\` would need to be checked into \`docs/\` for static deploys; logged as a follow-up.