### PR TITLE
docs: BYOK callout for verifier + Slack-setup-first warning in quickstart

### DIFF
--- a/docs/adapters/verifier.mdx
+++ b/docs/adapters/verifier.mdx
@@ -10,18 +10,33 @@ The verifier runs server-side after a human submits, before the task lands in `C
 
 If the verifier rejects, the task goes to `REJECTED` (non-terminal), the reason is shown to the reviewer, and they get to retry. After `max_attempts`, it's `VERIFICATION_EXHAUSTED` (terminal) and the agent gets a typed error.
 
-## Providers
+## BYOK — bring your own key
 
-Built-in:
+<Warning>
+**The verifier LLM call runs server-side, not in your agent process.** That has two consequences worth internalizing before you wire anything up:
 
-| Provider | Install | Default model |
-|---|---|---|
-| `claude` | `pip install "awaithumans[verifier-claude]"` | `claude-sonnet-4-5` |
-| `openai` | `pip install "awaithumans[verifier-openai]"` | `gpt-4o-2024-11-20` |
-| `gemini` | `pip install "awaithumans[verifier-gemini]"` | `gemini-2.0-flash` |
-| `azure` | `pip install "awaithumans[verifier-azure]"` | (operator-supplied) |
+1. **Your provider API key must live on the awaithumans server's environment**, not the agent's. The agent process never sees the key, never sends it over the wire, and doesn't need it installed.
+2. **Your LLM provider bills you directly.** awaithumans has no inference layer of its own — every verifier call goes from your server to Anthropic / OpenAI / Google / Azure, on your account, at provider list price. There's no markup and no proxy.
+</Warning>
 
-Each provider's API key reads from an env var on the awaithumans **server** (NOT the agent process). Defaults: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, `AZURE_OPENAI_API_KEY`. Override via `api_key_env=` in the config.
+Each provider needs **two things** on the server: the SDK extra installed, and the API key exported as an env var.
+
+| Provider | Install | Required env var | Default model |
+|---|---|---|---|
+| `claude` | `pip install "awaithumans[verifier-claude]"` | `ANTHROPIC_API_KEY` | `claude-sonnet-4-5` |
+| `openai` | `pip install "awaithumans[verifier-openai]"` | `OPENAI_API_KEY` | `gpt-4o-2024-11-20` |
+| `gemini` | `pip install "awaithumans[verifier-gemini]"` | `GEMINI_API_KEY` | `gemini-2.0-flash` |
+| `azure` | `pip install "awaithumans[verifier-azure]"` | `AZURE_OPENAI_API_KEY` + `AZURE_OPENAI_ENDPOINT` | (operator-supplied deployment name) |
+
+Override the env var name with `api_key_env=` if you'd rather not use the default — e.g. `claude_verifier(api_key_env="ACME_CLAUDE_KEY")`.
+
+```bash
+# On the same shell that runs `awaithumans dev` (or in the server's .env):
+export ANTHROPIC_API_KEY=sk-ant-...
+awaithumans dev   # restart so the new var is picked up
+```
+
+Forget this step and the first verifier call returns `HTTP 500 VERIFIER_API_KEY_MISSING` with a docs link to [the troubleshooting page](/troubleshooting#verifier-api-key-missing). Set the key, restart the server, the failed task can be resubmitted by the human — the verifier didn't burn an attempt.
 
 ## Quickstart
 
@@ -47,6 +62,8 @@ decision = await_human_sync(
 ```
 
 If the human submits with empty notes on a $1500 refund, the verifier rejects with the reason "Amount over $1000 requires notes." The dashboard shows the reason; the reviewer fills the field and resubmits.
+
+Note that `claude_verifier(...)` doesn't take an API key — it just declares the config. The agent ships that config to the server, and the server reads `ANTHROPIC_API_KEY` from its own env.
 
 ## Other providers
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -198,11 +198,59 @@ decision = await_human_sync(
 )
 ```
 
-See [Channels: Slack](/channels/slack) for setup. Email works the same way: `notify=["email:approvals@acme.com"]`.
+<Warning>
+**Set up the Slack channel first**, otherwise the `notify=` line is silently dropped and the task only appears in the dashboard — the snippet above won't post to any Slack workspace until you've configured the bot.
+
+You need three things on the **awaithumans server** (the process running `awaithumans dev`):
+
+1. A Slack app installed in your workspace with the right scopes ([app manifest in the Slack docs](/channels/slack#1-create-a-slack-app)).
+2. `AWAITHUMANS_SLACK_BOT_TOKEN` (`xoxb-...`) and `AWAITHUMANS_SLACK_SIGNING_SECRET` exported in the server's environment.
+3. The bot invited to the channel you're posting to (`/invite @Await Humans` in `#approvals`).
+
+Restart `awaithumans dev` after setting the env vars. Without this, the SDK call still succeeds — Slack delivery happens in a background task and only logs the failure server-side.
+</Warning>
+
+See [Channels: Slack](/channels/slack) for the full setup walkthrough (static-token mode is the fastest path; OAuth multi-workspace mode is also documented).
+
+Email works the same way — `notify=["email:approvals@acme.com"]` — and has the same prerequisite: configure a transport (Resend or SMTP) on the server first. See [Channels: Email](/channels/email).
 
 ## Add AI verification
 
-Have an LLM gut-check the human's decision before it lands:
+Have an LLM gut-check the human's decision before it lands.
+
+<Note>
+**Bring your own key.** The verifier runs **server-side**, not in your agent process. That means your LLM provider API key must be exported on the awaithumans server's environment (the same shell that ran `awaithumans dev`), **not** the shell running your agent script. If you skip this step, the task fails with `VERIFIER_API_KEY_MISSING` at submit time.
+</Note>
+
+In the terminal that's running `awaithumans dev` (or in your `.env`), set the key for whichever provider you'll use:
+
+<CodeGroup>
+```bash Claude (Anthropic)
+export ANTHROPIC_API_KEY=sk-ant-...
+# then restart: awaithumans dev
+```
+
+```bash OpenAI
+export OPENAI_API_KEY=sk-...
+```
+
+```bash Gemini (Google)
+export GEMINI_API_KEY=AIza...
+```
+
+```bash Azure OpenAI
+export AZURE_OPENAI_API_KEY=...
+export AZURE_OPENAI_ENDPOINT=https://my-resource.openai.azure.com
+```
+</CodeGroup>
+
+You also need the provider's SDK installed in the awaithumans server's Python environment:
+
+```bash
+pip install "awaithumans[verifier-claude]"   # for Claude — pick the one matching your provider
+```
+
+Then attach the verifier to your `await_human` call:
 
 ```python
 from awaithumans.verifiers.claude import claude_verifier
@@ -219,7 +267,9 @@ decision = await_human_sync(
 )
 ```
 
-See [Verifier](/adapters/verifier) for the full provider list and NL-parsing tricks.
+Your agent code doesn't carry any API key — it just declares the verifier config; the server does the LLM call.
+
+See [Verifier](/adapters/verifier) for the full provider list, custom env var names, and NL-parsing tricks.
 
 ## Next steps
 

--- a/examples/langgraph-py/README.md
+++ b/examples/langgraph-py/README.md
@@ -45,7 +45,9 @@ end-to-end flow.
 ## Prerequisites
 
 - Python 3.10+
-- The awaithumans dev server running locally (`awaithumans dev`)
+- `awaithumans dev` running locally (in another terminal). The Python SDK auto-discovers the URL + admin token via `~/.awaithumans-dev.json`.
+- The LangGraph adapter extra. This example's `requirements.txt` installs `awaithumans[langgraph]` for you. If you're copying this code into your own project, run `pip install "awaithumans[langgraph]"` — without the extra, importing `awaithumans.adapters.langgraph` fails.
+- Both this app and the awaithumans server need the **same** `AWAITHUMANS_PAYLOAD_KEY`. The dev server writes its key to `<cwd-of-awaithumans-dev>/.awaithumans/payload.key` on first boot — find that path and export it as shown in step 2 below.
 
 ## Run it
 
@@ -59,7 +61,12 @@ awaithumans dev
 cd examples/langgraph-py
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
-export AWAITHUMANS_PAYLOAD_KEY=$(cat /tmp/<your-dev-cwd>/.awaithumans/payload.key)
+
+# AWAITHUMANS_PAYLOAD_KEY lives at .awaithumans/payload.key relative to wherever
+# you ran `awaithumans dev`. Easiest way to find it:
+#   cd <that-directory> && pwd && ls .awaithumans/payload.key
+# Then point this export at it:
+export AWAITHUMANS_PAYLOAD_KEY=$(cat /path/to/awaithumans-dev-cwd/.awaithumans/payload.key)
 # Demo-only: pre-assign every human-review task to your dashboard
 # login so the Approve / Reject form renders immediately. Leave
 # unset in production — operators claim tasks from the dashboard.

--- a/examples/langgraph-ts/README.md
+++ b/examples/langgraph-ts/README.md
@@ -45,7 +45,10 @@ resume model instead of Temporal signals.
 ## Prerequisites
 
 - Node 20+
-- The awaithumans dev server running locally (`awaithumans dev`)
+- [uv](https://docs.astral.sh/uv/) if you're booting the server via `npx awaithumans dev`. Install with `curl -LsSf https://astral.sh/uv/install.sh | sh`.
+- `awaithumans dev` running locally (in another terminal). The TS SDK auto-discovers the URL + admin token via `~/.awaithumans-dev.json`.
+- The LangGraph adapter peer dep. This example's `package.json` already lists `@langchain/langgraph`. If you're copying this code into your own project, run `npm install awaithumans @langchain/langgraph`.
+- Both this app and the awaithumans server need the **same** `AWAITHUMANS_PAYLOAD_KEY`. The dev server writes its key to `<cwd-of-awaithumans-dev>/.awaithumans/payload.key` on first boot — find that path and export it as shown in step 2 below.
 
 ## Run it
 
@@ -58,7 +61,12 @@ awaithumans dev
 # Terminal 2 — this example's app (graph + checkpointer + callback)
 cd examples/langgraph-ts
 npm install
-export AWAITHUMANS_PAYLOAD_KEY=$(cat /tmp/<your-dev-cwd>/.awaithumans/payload.key)
+
+# AWAITHUMANS_PAYLOAD_KEY lives at .awaithumans/payload.key relative to wherever
+# you ran `awaithumans dev`. Easiest way to find it:
+#   cd <that-directory> && pwd && ls .awaithumans/payload.key
+# Then point this export at it:
+export AWAITHUMANS_PAYLOAD_KEY=$(cat /path/to/awaithumans-dev-cwd/.awaithumans/payload.key)
 # Demo-only: pre-assign every human-review task to your dashboard
 # login so the Approve / Reject form renders immediately. Leave
 # unset in production — operators claim tasks from the dashboard.

--- a/examples/slack-native/README.md
+++ b/examples/slack-native/README.md
@@ -101,7 +101,10 @@ export AWAITHUMANS_SLACK_BOT_TOKEN=xoxb-...
 export AWAITHUMANS_SLACK_SIGNING_SECRET=...
 export AWAITHUMANS_PUBLIC_URL=https://YOUR-NGROK-URL.ngrok.io  # so dashboard URLs match the tunnel
 
-# Optional — enables NL-thread-reply parsing
+# Optional — enables NL-thread-reply parsing.
+# The verifier runs server-side (BYOK), so the key lives on this server's env, not the agent's.
+# Also requires the Claude verifier extra:
+#   pip install "awaithumans[verifier-claude]"
 export ANTHROPIC_API_KEY=sk-ant-...
 
 awaithumans dev

--- a/examples/temporal-ts/README.md
+++ b/examples/temporal-ts/README.md
@@ -4,6 +4,14 @@ A real Temporal workflow that pauses for a human approval through awaithumans, t
 
 This is the canonical durable-HITL pattern: the workflow's `awaitHuman()` call gives Temporal back to the scheduler ("park me until a signal arrives"), the human reviews via the awaithumans dashboard / Slack / email, and a webhook from the awaithumans server signals the workflow back to life. Zero compute consumed while waiting; full Temporal durability if the worker restarts mid-await.
 
+## Prerequisites
+
+- Node 20+
+- [uv](https://docs.astral.sh/uv/) — `npx awaithumans dev` (and `awaithumans dev` directly) uses it under the hood to run the Python server. Install with `curl -LsSf https://astral.sh/uv/install.sh | sh`.
+- The Temporal CLI — `brew install temporal` on macOS; see [temporal.io/setup-cli](https://docs.temporal.io/cli) for Linux / Windows.
+- `awaithumans dev` running locally (step 2 below). The SDK auto-discovers it via `~/.awaithumans-dev.json`.
+- The Temporal adapter has peer deps on `@temporalio/workflow` and `@temporalio/client`. This example's `package.json` already lists them. If you're copying this code into your own project, run `npm install awaithumans @temporalio/workflow @temporalio/client`.
+
 ## Architecture
 
 ```

--- a/examples/temporal/README.md
+++ b/examples/temporal/README.md
@@ -4,6 +4,13 @@ A real Temporal workflow that pauses for a human approval through awaithumans, t
 
 This is the canonical durable-HITL pattern: the workflow's `await_human()` call gives Temporal back to the scheduler ("park me until a signal arrives"), the human reviews via the awaithumans dashboard / Slack / email, and a webhook from the awaithumans server signals the workflow back to life. Zero compute consumed while waiting; full Temporal durability if the worker restarts mid-await.
 
+## Prerequisites
+
+- Python 3.10+
+- The Temporal CLI — `brew install temporal` on macOS; see [temporal.io/setup-cli](https://docs.temporal.io/cli) for Linux / Windows.
+- `awaithumans dev` running locally (covered in step 2 below). The SDK auto-discovers the URL + admin token via `~/.awaithumans-dev.json` so you don't have to set env vars in your agent process.
+- The Temporal adapter extra. This example's `requirements.txt` installs `awaithumans[temporal]` for you. If you're copying this code into your own project, run `pip install "awaithumans[temporal]"` — without the extra, the workflow fails to import `dispatch_signal`.
+
 ## Architecture
 
 ```

--- a/examples/verifier-py/README.md
+++ b/examples/verifier-py/README.md
@@ -10,11 +10,24 @@ submission.
 
 Mirrors [`../verifier/`](../verifier/) (TypeScript).
 
+> **BYOK — bring your own key.** awaithumans has no inference layer
+> of its own; every verifier call goes from the server directly to
+> Anthropic on your account at provider list price. The agent
+> process never sees the key. Forget to export it on the server and
+> the first submission returns `HTTP 500 VERIFIER_API_KEY_MISSING`
+> ([docs](https://awaithumans.dev/docs/troubleshooting#verifier-api-key-missing)) —
+> the human can resubmit once you've fixed it; the verifier didn't
+> burn an attempt.
+
 ## Prerequisites
 
 - Python 3.10+
 - A Claude API key exported in the **server's** shell as
-  `ANTHROPIC_API_KEY` — the verifier runs server-side.
+  `ANTHROPIC_API_KEY`. The agent process doesn't need it.
+- The server has the verifier extra installed:
+  `pip install "awaithumans[server,verifier-claude]"`. Without the
+  extra, submissions return `VERIFIER_PROVIDER_UNAVAILABLE` instead
+  of running the check.
 
 ## Run
 

--- a/examples/verifier/README.md
+++ b/examples/verifier/README.md
@@ -10,11 +10,28 @@ submission.
 
 Mirrors [`../verifier-py/`](../verifier-py/) (Python).
 
+> **BYOK — bring your own key.** awaithumans has no inference layer
+> of its own; every verifier call goes from the server directly to
+> Anthropic on your account at provider list price. The agent
+> process never sees the key. Forget to export it on the server and
+> the first submission returns `HTTP 500 VERIFIER_API_KEY_MISSING`
+> ([docs](https://awaithumans.dev/docs/troubleshooting#verifier-api-key-missing)) —
+> the human can resubmit once you've fixed it; the verifier didn't
+> burn an attempt.
+
 ## Prerequisites
 
 - Node 20+
 - A Claude API key exported in the **server's** shell as
-  `ANTHROPIC_API_KEY` — the verifier runs server-side.
+  `ANTHROPIC_API_KEY`. The agent process (this Node script) doesn't
+  need it — the verifier LLM call runs on the awaithumans Python
+  server.
+- The server has the verifier extra installed. `npx awaithumans dev`
+  uses `uv` to run a Python venv under the hood; the first time you
+  add a new provider extra it's:
+  `uv tool install "awaithumans[verifier-claude]" --force`.
+  Without it, submissions return `VERIFIER_PROVIDER_UNAVAILABLE`
+  instead of running the check.
 
 ## Run
 


### PR DESCRIPTION
## Summary

Two prerequisites that the quickstart implied but never spelled out — both reported by users hitting silent failures.

## Problem

**Verifier** — the snippet \`verifier=claude_verifier(instructions=..., max_attempts=3)\` looks self-contained, but the LLM call runs server-side and needs:

1. \`ANTHROPIC_API_KEY\` (or equivalent) exported on the **server's** environment, not the agent's.
2. The matching SDK extra installed (\`pip install \"awaithumans[verifier-claude]\"\`).

Without either, the first verifier-gated submission returns \`HTTP 500 VERIFIER_API_KEY_MISSING\` or \`VERIFIER_PROVIDER_UNAVAILABLE\`. The original quickstart doc had no signal pointing the reader to either prereq.

**Slack** — \`notify=[\"slack:#approvals\"]\` looks like it self-configures the channel. It doesn't — it's a routing string. Slack delivery still requires:

1. A Slack app installed in the workspace with the right scopes.
2. \`AWAITHUMANS_SLACK_BOT_TOKEN\` + \`AWAITHUMANS_SLACK_SIGNING_SECRET\` on the server.
3. The bot invited to the target channel.

Without setup, the SDK call succeeds silently — the task lands in the dashboard but no Slack post happens. The failure is logged server-side but the agent never knows.

## Changes

### \`docs/quickstart.mdx\`

- **Add a notification channel** section now has a \`<Warning>\` callout listing the three Slack prerequisites and pointing at \`/channels/slack#1-create-a-slack-app\` for the full setup. Same shape for email pointing at \`/channels/email\`.
- **Add AI verification** section now has a \`<Note>\` callout explaining the BYOK / server-side model. Includes a \`<CodeGroup>\` with the export commands for all four built-in providers, plus the SDK-extra install step. Code block stays the same (still copy-paste-runnable).

### \`docs/adapters/verifier.mdx\`

- New **BYOK — bring your own key** section placed before the providers table. Flags two things: (a) the LLM call runs server-side, key lives on the server; (b) billing goes direct to the LLM provider — no awaithumans inference layer, no markup.
- Providers table now includes the **Required env var** column per-provider.
- Quickstart code block gets a one-liner reminder that \`claude_verifier(...)\` declares config but doesn't ship an API key — the server reads the key from its own env.

## Test plan

- [ ] \`mintlify dev\` — both pages render with the new callouts in the right styling
- [ ] Cross-links resolve: \`/channels/slack#1-create-a-slack-app\`, \`/channels/email\`, \`/troubleshooting#verifier-api-key-missing\`, \`/adapters/verifier\` from the quickstart
- [ ] CodeGroup tabs for the four providers show in the quickstart

🤖 Generated with [Claude Code](https://claude.com/claude-code)