### PR TITLE
fix(dashboard): two embed-page bugs surfaced during E2E

### DIFF
--- a/packages/dashboard/app/embed/page.tsx
+++ b/packages/dashboard/app/embed/page.tsx
@@ -31,6 +31,11 @@ function EmbedTaskInner() {
 	const [submitting, setSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const parentOriginRef = useRef<string>("");
+	// `submitting` is React state, which doesn't update synchronously —
+	// a fast double-click fires `onSubmit` twice before the button's
+	// `disabled` prop flips. The ref flips on the same tick so the
+	// second call returns early.
+	const inFlightRef = useRef(false);
 
 	useEffect(() => {
 		if (!taskId) {
@@ -102,6 +107,8 @@ function EmbedTaskInner() {
 
 	const onSubmit = async () => {
 		if (!token || !task) return;
+		if (inFlightRef.current) return;
+		inFlightRef.current = true;
 		setSubmitting(true);
 		setError(null);
 		try {
@@ -135,6 +142,7 @@ function EmbedTaskInner() {
 			});
 		} finally {
 			setSubmitting(false);
+			inFlightRef.current = false;
 		}
 	};
 

--- a/packages/dashboard/lib/embed/post-message.ts
+++ b/packages/dashboard/lib/embed/post-message.ts
@@ -29,5 +29,10 @@ const SOURCE = "awaithumans" as const;
 export function postEmbed(parentOrigin: string, event: EmbedEvent): void {
 	if (typeof window === "undefined" || !window.parent) return;
 	if (!parentOrigin) return;
+	// Top-level page (opened directly, not iframed) — `window.parent`
+	// IS `window`, and posting to the JWT's parent_origin would throw
+	// because that origin doesn't match the page's own origin. There's
+	// nobody to notify anyway, so skip silently.
+	if (window.parent === window) return;
 	window.parent.postMessage({ source: SOURCE, ...event }, parentOrigin);
 }


### PR DESCRIPTION
## Summary

Two real bugs surfaced when manually walking through the embed flow end-to-end.

1. **Double-submit slipped past the disabled button.** `submitting` is React state — doesn't flip synchronously, so a fast second click fires `onSubmit` again before the button's `disabled` prop updates. The first request completes; the second hits a 409 from the first-writer-wins guard and the user sees an "Error Conflict" message after their actually-successful submit. Add a ref-based re-entrancy guard that flips on the same tick.

2. **postMessage origin-mismatch errors flood the console** when the embed URL is opened directly (not iframed). The page's `parentOriginRef` is set from the JWT's `parent_origin` claim; when there's no real parent, `window.parent === window`, the page's own origin doesn't match, and every postMessage throws. The ResizeObserver fires repeatedly so errors pile up. Skip silently when top-level — nobody to notify anyway. The strict `targetOrigin` still applies in the iframed case.

## Test plan

- [x] pytest: 613 passed (no behavior change in Python)
- [x] Manual: opened embed URL directly (no iframe), no console errors. Iframed it via `parent.html`, postMessage events still fire. Double-clicked Submit, only one request lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)