### PR TITLE
fix(dashboard): embed page shows a Submitted view after success

### DIFF
--- a/packages/dashboard/app/embed/page.tsx
+++ b/packages/dashboard/app/embed/page.tsx
@@ -29,6 +29,7 @@ function EmbedTaskInner() {
 	const [task, setTask] = useState<Task | null>(null);
 	const [value, setValue] = useState<FormValue>({});
 	const [submitting, setSubmitting] = useState(false);
+	const [completed, setCompleted] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const parentOriginRef = useRef<string>("");
 	// `submitting` is React state, which doesn't update synchronously —
@@ -77,6 +78,10 @@ function EmbedTaskInner() {
 				if (fetched.form_definition) {
 					setValue(initialValueFor(fetched.form_definition));
 				}
+				// Reopening an embed URL after the task already completed
+				// (e.g. partner stored the URL and the user clicks it
+				// again) — show the done view, not the form.
+				if (fetched.status === "completed") setCompleted(true);
 				postEmbed(parentOriginRef.current, {
 					type: "loaded",
 					payload: { taskId },
@@ -124,6 +129,8 @@ function EmbedTaskInner() {
 				method: "POST",
 				body: JSON.stringify(body),
 			});
+			setTask(result);
+			setCompleted(true);
 			postEmbed(parentOriginRef.current, {
 				type: "task.completed",
 				payload: {
@@ -158,6 +165,20 @@ function EmbedTaskInner() {
 	if (!task) {
 		return (
 			<div className="p-6 font-mono text-sm text-fg-2">Loading task...</div>
+		);
+	}
+
+	if (completed) {
+		return (
+			<div className="mx-auto max-w-xl p-6">
+				<h1 className="mb-4 font-mono text-lg font-medium">{task.task}</h1>
+				<div className="rounded-md border border-brand/40 bg-brand/10 p-4 font-mono text-sm">
+					<p className="mb-1 text-brand">Submitted</p>
+					<p className="text-fg-2">
+						Your response has been recorded. You can close this window.
+					</p>
+				</div>
+			</div>
 		);
 	}
 


### PR DESCRIPTION
## Summary

The embed iframe used to sit on the same form after a successful submit. The 200 came back, the `task.completed` postMessage fired, but visually nothing changed — leaving the user staring at the form they just submitted, wondering if anything happened.

Two paths now render a "Submitted" panel:

- After a successful `POST /complete` — swap the form for the panel inline.
- When the embed URL is reopened for an already-completed task (partner persisted the URL, user clicked it again) — show the same panel instead of letting them re-submit a terminal task.

The partner-side `task.completed` postMessage still fires unchanged, so partners that want to close or replace the iframe themselves can keep doing that. This is purely the inside-the-iframe feedback for the user.

## Test plan

- [x] Submit on a non-terminal task → 200, panel appears, partner gets `task.completed`.
- [x] Reopen the URL after the task is complete → panel renders directly, no form, no second submit possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)