### PR TITLE
fix(dashboard): drop "You can close this window" from embed done view

### DIFF
--- a/packages/dashboard/app/embed/page.tsx
+++ b/packages/dashboard/app/embed/page.tsx
@@ -174,9 +174,7 @@ function EmbedTaskInner() {
 				<h1 className="mb-4 font-mono text-lg font-medium">{task.task}</h1>
 				<div className="rounded-md border border-brand/40 bg-brand/10 p-4 font-mono text-sm">
 					<p className="mb-1 text-brand">Submitted</p>
-					<p className="text-fg-2">
-						Your response has been recorded. You can close this window.
-					</p>
+					<p className="text-fg-2">Your response has been recorded.</p>
 				</div>
 			</div>
 		);


### PR DESCRIPTION
## Summary

That sentence presumes a close-on-done UX. Partners may want to keep the iframe mounted, navigate the user themselves, or swap with their own success content via the `task.completed` postMessage. The embed page shouldn't dictate what happens after submit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)