### PR TITLE
chore(release): roll CHANGELOG to v0.1.0, bump TS + dashboard to 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,17 @@ into a versioned release when tagged.
 
 ## [Unreleased]
 
+_Nothing yet — open the next change here._
+
+---
+
+## [0.1.0] — 2026-05-11
+
+First tagged release. Everything below is in the shipped package.
+
 ### Changed (BREAKING)
 
-- **Idempotency keys now follow strict Stripe semantics.** A task's
+- **Idempotency keys follow strict Stripe semantics.** A task's
   `idempotency_key` always returns the same task, regardless of
   status. Previously a terminal task's key was released, allowing a
   fresh task with the same key — convenient for "re-trigger a
@@ -28,11 +36,12 @@ into a versioned release when tagged.
   `VERIFICATION_EXHAUSTED`). Aligns the implementation with the
   Stripe model the docs already claimed.
 
----
-
-## [0.1.0] — Pre-launch (planned for 2026-05-12)
-
-First tagged release. Everything below is in the shipped package.
+- **Repo and packages are now Apache 2.0** across the whole stack
+  (SDK, server, dashboard, adapters, channels). Pre-tag the README
+  claimed a dual-license (MIT SDK + ELv2 server) that was never
+  realized in pyproject.toml or package.json. The explicit patent
+  grant in Apache 2.0 matters more for AI infra than the brevity of
+  MIT.
 
 ### Added
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awaithumans/dashboard",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Self-hosted HITL review dashboard — Next.js 16 + React 19",
   "type": "module",
   "private": true,

--- a/packages/typescript-sdk/package.json
+++ b/packages/typescript-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awaithumans",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "The human layer for AI agents. Your agents already await promises. Now they can await humans.",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary

Pre-launch release prep — last gate before tagging \`v0.1.0\` and publishing.

## Changes

### \`CHANGELOG.md\`

- Moved the BREAKING idempotency-semantics entry from \`[Unreleased]\` into \`[0.1.0]\`.
- Added the Apache 2.0 license switch as a second BREAKING entry under \`[0.1.0]\` (PR #89 is the implementation).
- Reset \`[Unreleased]\` to an empty placeholder ("Nothing yet — open the next change here.").
- Dated \`[0.1.0]\` as **2026-05-11** (tag day; public Show HN announcement is 2026-05-12).

### \`packages/typescript-sdk/package.json\`

\`0.0.1\` (placeholder) → \`0.1.0\`. The Python package, \`__version__\`, and the server's OpenAPI spec are already at 0.1.0; the TS package was lagging behind the npm placeholder publish.

### \`packages/dashboard/package.json\`

\`0.0.1\` → \`0.1.0\` for monorepo consistency. Dashboard is private (bundled into the Python wheel as static files), not published independently, but the version should match.

## Test plan

- [ ] \`packages/python/pyproject.toml\` still at \`version = "0.1.0"\` (no change needed)
- [ ] \`packages/python/awaithumans/__init__.py\` \`__version__\` still \`"0.1.0"\` (no change needed)
- [ ] After merge: tag \`v0.1.0\` from \`main\`, then publish to npm + PyPI, then create the GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)