### PR TITLE
chore: standardize all contact emails on awaithumans.dev

### DIFF
--- a/.github/RELEASE_NOTES_v0.1.0.md
+++ b/.github/RELEASE_NOTES_v0.1.0.md
@@ -111,7 +111,7 @@ If you were running off `main` before tagging:
 - 🚀 [Quickstart](https://awaithumans.dev/docs/quickstart)
 - 🐛 [Report an issue](https://github.com/awaithumans/awaithumans/issues)
 - 💬 [Discord](https://discord.gg/awaithumans)
-- 🔒 Security disclosures: **security@awaithumans.com**
+- 🔒 Security disclosures: **security@awaithumans.dev**
 
 ## Thanks
 

--- a/docs/self-hosting/security.mdx
+++ b/docs/self-hosting/security.mdx
@@ -119,4 +119,4 @@ For multi-tenant or large-scale deployments, the Phase-2 hosted product handles 
 
 ## Reporting issues
 
-Found a security issue? Please report privately to **security@awaithumans.com** rather than opening a public GitHub issue. We aim to respond within 48 hours and ship fixes within 7 days for critical issues. See [SECURITY.md](https://github.com/awaithumans/awaithumans/blob/main/SECURITY.md) for the full disclosure policy.
+Found a security issue? Please report privately to **security@awaithumans.dev** rather than opening a public GitHub issue. We aim to respond within 48 hours and ship fixes within 7 days for critical issues. See [SECURITY.md](https://github.com/awaithumans/awaithumans/blob/main/SECURITY.md) for the full disclosure policy.

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -234,4 +234,4 @@ Email action token was already used.
 
 - Check the [GitHub Discussions](https://github.com/awaithumans/awaithumans/discussions) — most issues have been seen before.
 - Open a [GitHub Issue](https://github.com/awaithumans/awaithumans/issues) with: SDK version, Python / Node version, full error message + stack trace, minimal repro.
-- For security issues: **security@awaithumans.com** (private disclosure).
+- For security issues: **security@awaithumans.dev** (private disclosure).

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -31,7 +31,7 @@ license = "Apache-2.0"
 # require 3.10+, so no real user is left behind.
 requires-python = ">=3.10"
 authors = [
-    { name = "Await Humans", email = "hello@awaithumans.com" },
+    { name = "Await Humans", email = "hello@awaithumans.dev" },
 ]
 keywords = [
     "human-in-the-loop", "hitl", "ai-agents", "langchain", "langgraph",


### PR DESCRIPTION
## Summary

Reconcile the .com/.dev split on contact emails. Mail infrastructure is on the .dev domain, so every reference now matches what's actually deliverable.

## End state — exactly two addresses, both on .dev

| Address | Purpose | Referenced from |
|---|---|---|
| \`security@awaithumans.dev\` | Private security disclosures | \`SECURITY.md\`, \`docs/self-hosting/security.mdx\`, \`docs/troubleshooting.mdx\`, \`.github/RELEASE_NOTES_v0.1.0.md\` |
| \`hello@awaithumans.dev\` | General contact / package author | \`packages/python/pyproject.toml\` |

## Files changed

- \`.github/RELEASE_NOTES_v0.1.0.md\` — \`security@awaithumans.com\` → \`.dev\`
- \`docs/self-hosting/security.mdx\` — \`security@awaithumans.com\` → \`.dev\`
- \`docs/troubleshooting.mdx\` — \`security@awaithumans.com\` → \`.dev\`
- \`packages/python/pyproject.toml\` — author email \`hello@awaithumans.com\` → \`.dev\`

\`SECURITY.md\` already used \`.dev\` — no change needed.

## Test plan

- [x] Repo-wide grep for \`@awaithumans.com\` returns zero matches
- [x] All five \`.dev\` references confirmed
- [ ] After merge + mailbox creation: send a test email to each address and confirm delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)