### PR TITLE
chore(release): v0.1.1 — widen @langchain/langgraph peer-dep range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ _Nothing yet — open the next change here._
 
 ---
 
+## [0.1.1] — 2026-05-11
+
+### Fixed
+
+- **TypeScript SDK: widen `@langchain/langgraph` peer-dep range** to
+  `"^0.2.0 || ^1.0.0"` (was `"^0.2.0"`). Users on a fresh
+  `npm install awaithumans @langchain/langgraph` would get the
+  current upstream (`1.x`) and hit `ERESOLVE` against the old
+  pinned range. Verified the `interrupt(...)` API surface the
+  adapter uses is signature-identical across both majors. No
+  runtime code changed; this is purely a peer-range fix.
+
+---
+
 ## [0.1.0] — 2026-05-11
 
 First tagged release. Everything below is in the shipped package.

--- a/packages/typescript-sdk/package.json
+++ b/packages/typescript-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awaithumans",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "The human layer for AI agents. Your agents already await promises. Now they can await humans.",
   "type": "module",
   "sideEffects": false,
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@temporalio/client": "^1.0.0",
     "@temporalio/workflow": "^1.0.0",
-    "@langchain/langgraph": "^0.2.0"
+    "@langchain/langgraph": "^0.2.0 || ^1.0.0"
   },
   "peerDependenciesMeta": {
     "@temporalio/client": { "optional": true },
@@ -54,7 +54,7 @@
     "typescript": "^5.7.0",
     "@temporalio/workflow": "^1.0.0",
     "@temporalio/client": "^1.0.0",
-    "@langchain/langgraph": "^0.2.0"
+    "@langchain/langgraph": "^0.2.0 || ^1.0.0"
   },
   "overrides": {
     "langsmith": ">=0.6.0"


### PR DESCRIPTION
## Summary

Patch release fixing the only real issue caught in the v0.1.0 launch-day smoke test.

## The bug

\`\`\`bash
npm install awaithumans @langchain/langgraph
# → installs current upstream (@langchain/langgraph@1.3.0)
# → ERESOLVE: awaithumans's peer wants "^0.2.0"
# → user must retry with --legacy-peer-deps
\`\`\`

Half of new TS users (anyone following modern LangGraph docs) would hit this.

## The fix

\`packages/typescript-sdk/package.json\`:

- \`version\`: \`0.1.0\` → \`0.1.1\`
- \`peerDependencies["@langchain/langgraph"]\`: \`"^0.2.0"\` → \`"^0.2.0 || ^1.0.0"\`
- \`devDependencies["@langchain/langgraph"]\`: same widen for parity

\`CHANGELOG.md\`: new \`[0.1.1]\` entry under "Fixed".

## Safety verification

Before widening, I verified:

1. **Only one symbol used.** \`grep -r "@langchain/langgraph" packages/typescript-sdk/src\` shows the adapter imports exactly one runtime symbol: \`interrupt\`. \`Command\` is only referenced in comments — the user constructs it themselves.

2. **Signature identical across both majors.**
   - \`@langchain/langgraph@^0.2.0\`'s \`interrupt.d.ts\`: \`function interrupt<I = unknown, R = any>(value: I): R\`
   - \`@langchain/langgraph@1.3.0\`'s \`interrupt.d.ts\`: \`function interrupt<I = unknown, R = any>(value: I): R\`

3. **Smoke-tested both ranges.** Installed \`awaithumans + @langchain/langgraph@^0.2.0\` and separately \`awaithumans + @langchain/langgraph@1.3.0\` (with \`--legacy-peer-deps\` to bypass the very issue this PR fixes). Both ran \`import { awaitHuman } from "awaithumans/langgraph"\` successfully.

## What's NOT changing

- Zero runtime code changes. The adapter logic is unchanged.
- The 0.3.x / 0.4.x intermediate releases exist but weren't tested. Users on those versions can override with \`--legacy-peer-deps\`. Conservative range only covers what's verified.

## Test plan

- [ ] After merge: tag \`v0.1.1\`, publish to npm
- [ ] Re-run TS smoke test against current upstream LangGraph (\`npm install awaithumans @langchain/langgraph\` with no version pin) — should succeed without \`--legacy-peer-deps\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)