### PR TITLE
chore(release): bump Python to 0.1.1 to ship Next.js security fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ _Nothing yet — open the next change here._
 
 ## [0.1.1] — 2026-05-11
 
+### Security
+
+- **Bumped bundled Next.js `16.2.3` → `16.2.6`** in the dashboard,
+  clearing 13 GHSA advisories. The dashboard ships statically built
+  into the Python wheel, so this fix only reaches PyPI users via a
+  republish — bump the Python version accordingly.
+
 ### Fixed
 
 - **TypeScript SDK: widen `@langchain/langgraph` peer-dep range** to
@@ -27,6 +34,10 @@ _Nothing yet — open the next change here._
   pinned range. Verified the `interrupt(...)` API surface the
   adapter uses is signature-identical across both majors. No
   runtime code changed; this is purely a peer-range fix.
+
+- **Python package version bumped 0.1.0 → 0.1.1** so the bundled-Next.js
+  security fix above can be republished to PyPI. Mono-version with the
+  TypeScript SDK at 0.1.1.
 
 ---
 

--- a/packages/python/awaithumans/__init__.py
+++ b/packages/python/awaithumans/__init__.py
@@ -21,7 +21,7 @@ Usage (sync):
 """
 from __future__ import annotations
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 from awaithumans.client import await_human, await_human_sync
 from awaithumans.embed import EmbedTokenResult, embed_token, embed_token_sync

--- a/packages/python/awaithumans/server/app.py
+++ b/packages/python/awaithumans/server/app.py
@@ -228,7 +228,7 @@ def create_app(*, serve_dashboard: bool = True) -> FastAPI:
     app = FastAPI(
         title="awaithumans",
         description="The human layer for AI agents.",
-        version="0.1.0",
+        version="0.1.1",
         lifespan=lifespan,
     )
 

--- a/packages/python/awaithumans/server/routes/status.py
+++ b/packages/python/awaithumans/server/routes/status.py
@@ -32,7 +32,7 @@ async def get_status() -> SystemStatus:
     # but is always True now — we left it in place so the dashboard
     # doesn't need redeployment just to drop a field.
     return SystemStatus(
-        version="0.1.0",
+        version="0.1.1",
         environment=settings.ENVIRONMENT,
         public_url=settings.PUBLIC_URL,
         auth_enabled=True,

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -20,7 +20,7 @@ packages = ["awaithumans"]
 
 [project]
 name = "awaithumans"
-version = "0.1.0"
+version = "0.1.1"
 description = "The human layer for AI agents. Your agents already await promises. Now they can await humans."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Why this PR exists

PR #94 bumped the dashboard's Next.js \`16.2.3\` → \`16.2.6\`, clearing 13 GHSA advisories. But the fix doesn't reach PyPI users until we republish — because:

- The dashboard ships as a static build **bundled inside the Python wheel** (see \`scripts/build-bundled.sh\` → \`packages/python/awaithumans/dashboard_dist/\`).
- \`dashboard_dist/\` is **gitignored** — it materializes only at wheel-build time.
- PyPI users on \`awaithumans[server]==0.1.0\` are still running the vulnerable Next.js until the next Python release.

So: bump Python from \`0.1.0\` → \`0.1.1\` to authorize a republish. Now mono-version with the TypeScript SDK at \`0.1.1\` from #93.

## Changes

- \`packages/python/pyproject.toml\` — \`version = "0.1.1"\`
- \`packages/python/awaithumans/__init__.py\` — \`__version__ = "0.1.1"\`
- \`packages/python/awaithumans/server/app.py\` — FastAPI metadata \`version="0.1.1"\` (so \`/api/openapi.json\` and Swagger UI show the right version)
- \`packages/python/awaithumans/server/routes/status.py\` — \`/api/status\` response version
- \`CHANGELOG.md\` — added \`### Security\` section to \`[0.1.1]\` for the Next.js bump

## Release runbook (after merge)

\`\`\`bash
# 1. Rebuild the dashboard with the new Next.js
make bundle-dashboard

# 2. Rebuild the Python wheel (picks up fresh dashboard_dist)
make wheel

# 3. Publish to PyPI
twine upload packages/python/dist/*
\`\`\`

**Critical order:** \`make bundle-dashboard\` MUST run before \`make wheel\`, otherwise the wheel ships the stale dashboard_dist sitting in the working tree.

## Test plan

- [ ] After merge: tag \`v0.1.1\` (covers both TS @ 0.1.1 from #93 and Python @ 0.1.1 from this PR)
- [ ] Publish both packages
- [ ] On a fresh box: \`pip install "awaithumans[server]==0.1.1"\` + \`awaithumans dev\` + open dashboard → inspect served Next.js version header (\`X-Powered-By: Next.js\`) or check the bundled chunks for the \`16.2.6\` marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)