### PR TITLE
chore: replace broken Discord invite + land v0.1.1 release notes

### DIFF
--- a/.github/RELEASE_NOTES_v0.1.0.md
+++ b/.github/RELEASE_NOTES_v0.1.0.md
@@ -110,7 +110,7 @@ If you were running off `main` before tagging:
 - 📚 [Documentation](https://awaithumans.dev/docs)
 - 🚀 [Quickstart](https://awaithumans.dev/docs/quickstart)
 - 🐛 [Report an issue](https://github.com/awaithumans/awaithumans/issues)
-- 💬 [Discord](https://discord.gg/awaithumans)
+- 💬 [Discord](https://discord.gg/Kewdh7vjdc)
 - 🔒 Security disclosures: **security@awaithumans.dev**
 
 ## Thanks

--- a/.github/RELEASE_NOTES_v0.1.1.md
+++ b/.github/RELEASE_NOTES_v0.1.1.md
@@ -1,0 +1,83 @@
+# awaithumans v0.1.1 — patch release
+
+First patch on top of [v0.1.0](https://github.com/awaithumans/awaithumans/releases/tag/v0.1.0). Two fixes from real-world install issues caught in the launch-day smoke test, plus a bundled-dependency security update. No API changes.
+
+## Highlights
+
+- 🔒 **Bundled Next.js bumped `16.2.3` → `16.2.6`** in the dashboard, clearing 13 GHSA advisories. Ships in the Python wheel; PyPI users get the fix on `pip install --upgrade awaithumans`.
+- 📦 **TypeScript SDK peer-dep range widened** so `npm install awaithumans @langchain/langgraph` works against current upstream LangGraph (`1.x`), not just the older `0.2.x` line.
+- 🤝 **Python and TypeScript now mono-version** at `0.1.1` — single version number across the stack.
+
+## Upgrade
+
+### Python
+
+```bash
+pip install --upgrade "awaithumans[server]==0.1.1"
+# or whichever extras you use:
+#   pip install --upgrade "awaithumans[temporal]==0.1.1"
+#   pip install --upgrade "awaithumans[langgraph]==0.1.1"
+#   pip install --upgrade "awaithumans[verifier-claude]==0.1.1"
+```
+
+### TypeScript
+
+```bash
+npm install awaithumans@0.1.1
+# Or with peers if you're using the adapters:
+#   npm install awaithumans@0.1.1 @temporalio/workflow @temporalio/client
+#   npm install awaithumans@0.1.1 @langchain/langgraph
+```
+
+### Docker
+
+```bash
+docker pull ghcr.io/awaithumans/awaithumans:0.1.1
+# Or use the floating tag:
+docker pull ghcr.io/awaithumans/awaithumans:latest
+```
+
+## What changed
+
+### Security
+
+- **Dashboard: Next.js `16.2.3` → `16.2.6`** (PR #94). Clears 13 GHSA-tracked advisories in the bundled dashboard. The dashboard ships statically built inside the Python wheel, so this fix only reaches PyPI users via a republish — the Python bump in this release is the delivery vehicle.
+
+### Fixed
+
+- **TypeScript SDK: `@langchain/langgraph` peer-dep range widened** to `"^0.2.0 || ^1.0.0"` (was `"^0.2.0"`) (PR #93). Users on a fresh `npm install awaithumans @langchain/langgraph` would get current upstream (`1.x`) and hit `ERESOLVE` against the old pinned range. Verified the `interrupt(...)` API surface the adapter uses is signature-identical across both majors. No runtime code changed.
+
+- **Python package version bumped `0.1.0` → `0.1.1`** (PR #95) so the bundled-Next.js security fix can be republished to PyPI. Mono-version with the TypeScript SDK.
+
+## What didn't change
+
+- **No API changes** — every public function signature in v0.1.0 still works identically in v0.1.1.
+- **No breaking changes** — `pip install --upgrade` and `npm install awaithumans@latest` are safe drop-in upgrades.
+- **No infrastructure changes** — same Docker image shape, same server boot sequence, same dashboard URL.
+
+## Verify the upgrade landed
+
+After upgrading the Python package:
+
+```bash
+python -c "import awaithumans; print(awaithumans.__version__)"
+# → 0.1.1
+
+awaithumans dev
+# open http://localhost:3001 — the dashboard loads with the patched Next.js
+```
+
+After upgrading the TS package:
+
+```bash
+node -e "console.log(require('awaithumans/package.json').version)"
+# → 0.1.1
+```
+
+## Links
+
+- 📚 [Documentation](https://awaithumans.dev/docs)
+- 🆕 [What's new](https://awaithumans.dev/docs/changelog)
+- 🔒 Security disclosures: **security@awaithumans.dev**
+- 💬 [Discord](https://discord.gg/Kewdh7vjdc) · [GitHub Discussions](https://github.com/awaithumans/awaithumans/discussions)
+- 🐛 [v0.1.0 → 0.1.1 full diff](https://github.com/awaithumans/awaithumans/compare/v0.1.0...v0.1.1)

--- a/README.md
+++ b/README.md
@@ -276,6 +276,6 @@ the project's trademarks without permission.
 
 The full primitive, all three channels (dashboard / Slack / email), both durable adapters (Temporal / LangGraph), AI verification across four providers, and one-command self-hosting are all live in this release.
 
-This is a young project — APIs are stable for v0.x, but expect rough edges in the long tail. File issues, open PRs, drop questions in [Discussions](https://github.com/awaithumans/awaithumans/discussions) or [Discord](https://discord.gg/awaithumans). Every reproducible bug report shipped with a fix in v0.2.
+This is a young project — APIs are stable for v0.x, but expect rough edges in the long tail. File issues, open PRs, drop questions in [Discussions](https://github.com/awaithumans/awaithumans/discussions) or [Discord](https://discord.gg/Kewdh7vjdc). Every reproducible bug report shipped with a fix in v0.2.
 
 For the post-launch roadmap — local task book for runtimes without an orchestrator, custom router strategies, post-launch hardening — see [Roadmap & help wanted](https://awaithumans.dev/docs/community/roadmap).

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -114,7 +114,7 @@
         },
         {
           "anchor": "Discord",
-          "href": "https://discord.gg/awaithumans",
+          "href": "https://discord.gg/Kewdh7vjdc",
           "icon": "discord"
         },
         {
@@ -241,7 +241,7 @@
           },
           {
             "label": "Discord",
-            "href": "https://discord.gg/awaithumans"
+            "href": "https://discord.gg/Kewdh7vjdc"
           },
           {
             "label": "Roadmap & help wanted",


### PR DESCRIPTION
## Summary

Two fixes that needed to land before tomorrow's Show HN, consolidated into one PR.

### 1. Discord invite was dead

\`https://discord.gg/awaithumans\` returned \`10006: Unknown Invite\` from Discord's API. Replaced with the real invite \`https://discord.gg/Kewdh7vjdc\` which points at the **awaithumans** server. Set to never expire.

The bad invite was referenced in:
- \`README.md\` — Status section (post-launch link)
- \`docs/docs.json\` — sidebar Discord anchor + footer link (renders on every docs page)
- \`.github/RELEASE_NOTES_v0.1.0.md\` — historical, but matters because the live GitHub Release body shows it

### 2. v0.1.1 release notes file

The v0.1.1 release notes were authored on PR #95's branch after the merge — orphaned commit. The GitHub Release was already published from the orphaned content. This PR:

- Lands the corrected notes file on main (with the right Discord invite this time)
- Closes #96, which carried the older version of the file
- After merge, the live GitHub Release v0.1.1 body will be re-uploaded via \`gh release edit --notes-file\` so the published Release also points at the working invite

## Files changed

| File | Change |
|---|---|
| \`README.md\` | Status section Discord link |
| \`docs/docs.json\` | Sidebar anchor + footer link (renders on every docs page) |
| \`.github/RELEASE_NOTES_v0.1.0.md\` | One historical link in the v0.1.0 notes |
| \`.github/RELEASE_NOTES_v0.1.1.md\` | **new** — v0.1.1 notes with the correct invite baked in |

## Verification

\`\`\`bash
$ git grep -nI "discord.gg/awaithumans"
(no output)

$ curl -s "https://discord.com/api/v10/invites/Kewdh7vjdc" | jq .guild.name
"awaithumans"
\`\`\`

## Post-merge follow-up

After this merges I'll run:

\`\`\`bash
gh release edit v0.1.0 --notes-file .github/RELEASE_NOTES_v0.1.0.md
gh release edit v0.1.1 --notes-file .github/RELEASE_NOTES_v0.1.1.md
\`\`\`

To re-upload the live Release bodies on github.com so the working invite shows in the Releases tab too.

Closes #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)