### PR TITLE
docs: remove ellipsis placeholders, make every example fully runnable

### DIFF
--- a/docs/adapters/verifier.mdx
+++ b/docs/adapters/verifier.mdx
@@ -127,11 +127,37 @@ A reviewer can now reply to the Slack DM with "approve, looks legit" and the ver
 If the task's `redact_payload=True`, the verifier is **skipped entirely**. The operator marked the payload sensitive; we don't ship it to a third-party LLM regardless of verifier config.
 
 ```python
+from pydantic import BaseModel
+from awaithumans import await_human_sync
+from awaithumans.verifiers.claude import claude_verifier
+
+
+class KYCPayload(BaseModel):
+    ssn: str
+    legal_name: str
+    country: str
+
+
+class KYCDecision(BaseModel):
+    approved: bool
+    notes: str | None = None
+
+
 decision = await_human_sync(
-    # ...
-    payload=KYCPayload(ssn="123-45-6789", ...),
+    task="Approve KYC for new account",
+    payload_schema=KYCPayload,
+    payload=KYCPayload(
+        ssn="123-45-6789",
+        legal_name="Priya Iyer",
+        country="IN",
+    ),
+    response_schema=KYCDecision,
+    timeout_seconds=3600,
     redact_payload=True,    # never sent to the verifier
-    verifier=claude_verifier(...),   # silently ignored
+    verifier=claude_verifier(
+        instructions="Reject if notes contradict the decision.",
+        max_attempts=3,
+    ),    # silently ignored because redact_payload=True
 )
 ```
 

--- a/docs/channels/email.mdx
+++ b/docs/channels/email.mdx
@@ -43,15 +43,47 @@ Restart `awaithumans dev`.
 
 ### 3. Send
 
+Save as `email_test.py` and run with `python email_test.py`:
+
 ```python
-await_human_sync(
-    task="Approve $250 refund?",
-    # ...
-    notify=["email:reviewer@acme.com"],
-)
+from pydantic import BaseModel
+from awaithumans import await_human_sync
+
+
+class RefundRequest(BaseModel):
+    order_id: str
+    customer_email: str
+    amount_usd: int
+    reason: str
+
+
+class RefundDecision(BaseModel):
+    approved: bool
+    notes: str | None = None
+
+
+def main() -> None:
+    decision = await_human_sync(
+        task="Approve $250 refund?",
+        payload_schema=RefundRequest,
+        payload=RefundRequest(
+            order_id="A-4721",
+            customer_email="alex@example.com",
+            amount_usd=250,
+            reason="Duplicate charge",
+        ),
+        response_schema=RefundDecision,
+        timeout_seconds=900,
+        notify=["email:reviewer@acme.com"],
+    )
+    print(f"approved={decision.approved} · notes={decision.notes}")
+
+
+if __name__ == "__main__":
+    main()
 ```
 
-The recipient gets an email; clicking through completes the task.
+The recipient gets an email; clicking through completes the task and the script prints the typed `RefundDecision`.
 
 ## SMTP — env-var path
 

--- a/docs/channels/overview.mdx
+++ b/docs/channels/overview.mdx
@@ -14,9 +14,25 @@ A channel is "where does the human find out about the task and respond?" awaithu
 You activate channels per-task via `notify=`:
 
 ```python
-await_human_sync(
+from pydantic import BaseModel
+from awaithumans import await_human_sync
+
+
+class RefundRequest(BaseModel):
+    order_id: str
+    amount_usd: int
+
+
+class RefundDecision(BaseModel):
+    approved: bool
+
+
+decision = await_human_sync(
     task="Approve refund?",
-    # ...
+    payload_schema=RefundRequest,
+    payload=RefundRequest(order_id="A-4721", amount_usd=250),
+    response_schema=RefundDecision,
+    timeout_seconds=900,
     notify=[
         "slack:#approvals",            # post to a channel
         "email:reviews@acme.com",      # email a person

--- a/docs/concepts/idempotency.mdx
+++ b/docs/concepts/idempotency.mdx
@@ -49,10 +49,28 @@ The Temporal and LangGraph adapters use prefixed defaults:
 ## When to pass an explicit key
 
 ```python
+from pydantic import BaseModel
+from awaithumans import await_human_sync
+
+
+class RefundRequest(BaseModel):
+    order_id: str
+    amount_usd: int
+
+
+class RefundDecision(BaseModel):
+    approved: bool
+
+
+order_id = "A-4721"
+
 # RECOMMENDED: bake your application's natural ID into the key
 decision = await_human_sync(
     task=f"Approve refund for order {order_id}?",
-    # ...
+    payload_schema=RefundRequest,
+    payload=RefundRequest(order_id=order_id, amount_usd=250),
+    response_schema=RefundDecision,
+    timeout_seconds=900,
     idempotency_key=f"refund:{order_id}",
 )
 ```
@@ -73,7 +91,10 @@ When you genuinely want to start a *fresh* review for the same logical event —
 attempt = 1
 decision = await_human_sync(
     task=f"Approve refund for {order_id}?",
-    # ...
+    payload_schema=RefundRequest,
+    payload=RefundRequest(order_id=order_id, amount_usd=250),
+    response_schema=RefundDecision,
+    timeout_seconds=900,
     idempotency_key=f"refund:{order_id}:retry-{attempt}",
 )
 ```
@@ -99,13 +120,53 @@ If the verifier exhausts attempts → `VERIFICATION_EXHAUSTED` (terminal). Subse
 ## Example: a refund pipeline
 
 ```python
-async def process_refund(order):
+from dataclasses import dataclass
+
+from pydantic import BaseModel
+from awaithumans import await_human_sync
+
+
+class RefundApprovalPayload(BaseModel):
+    order_id: str
+    customer_id: str
+    amount_usd: int
+
+
+class RefundApprovalDecision(BaseModel):
+    approved: bool
+    notes: str | None = None
+
+
+class RefundConfirmationPayload(BaseModel):
+    refund_id: str
+    order_id: str
+
+
+class RefundConfirmation(BaseModel):
+    correct: bool
+
+
+@dataclass
+class Order:
+    id: str
+    amount: int
+    customer_id: str
+
+
+async def process_refund(order: Order):
     # First HITL: approval. If we ever retry this whole function,
     # the same order_id maps to the same task — including the stored
     # decision if the human completed it during a previous outage.
     decision = await_human_sync(
         task=f"Approve ${order.amount} refund for {order.customer_id}?",
-        # ...
+        payload_schema=RefundApprovalPayload,
+        payload=RefundApprovalPayload(
+            order_id=order.id,
+            customer_id=order.customer_id,
+            amount_usd=order.amount,
+        ),
+        response_schema=RefundApprovalDecision,
+        timeout_seconds=900,
         idempotency_key=f"refund-approval:{order.id}",
     )
     if not decision.approved:
@@ -117,7 +178,13 @@ async def process_refund(order):
     # Second HITL: post-refund review. Different key, different task.
     confirmation = await_human_sync(
         task=f"Confirm refund {refund_id} processed correctly?",
-        # ...
+        payload_schema=RefundConfirmationPayload,
+        payload=RefundConfirmationPayload(
+            refund_id=refund_id,
+            order_id=order.id,
+        ),
+        response_schema=RefundConfirmation,
+        timeout_seconds=900,
         idempotency_key=f"refund-confirmation:{order.id}",
     )
 

--- a/docs/routing/overview.mdx
+++ b/docs/routing/overview.mdx
@@ -98,25 +98,49 @@ This is one of the [four buckets](/concepts/four-buckets) — extension points b
 ## Example: KYC review queue
 
 ```python
+from pydantic import BaseModel
+from awaithumans import await_human_sync
+
+
+class KYCPayload(BaseModel):
+    applicant_id: str
+    amount_usd: int
+    country: str
+
+
+class KYCDecision(BaseModel):
+    approved: bool
+    notes: str | None = None
+
+
 # Fast lane: senior reviewers handle anything over $10k
-async def review_high_value(amount: int):
+async def review_high_value(applicant_id: str, amount: int, country: str):
     return await_human_sync(
         task=f"KYC review for ${amount} transaction",
-        # ...
+        payload_schema=KYCPayload,
+        payload=KYCPayload(applicant_id=applicant_id, amount_usd=amount, country=country),
+        response_schema=KYCDecision,
+        timeout_seconds=3600,
         assign_to={"role": "kyc-reviewer", "access_level": "senior"},
         notify=["slack:#kyc-senior"],
     )
 
+
 # Default lane: junior pool
-async def review_standard(amount: int):
+async def review_standard(applicant_id: str, amount: int, country: str):
     return await_human_sync(
         task=f"KYC review for ${amount} transaction",
-        # ...
+        payload_schema=KYCPayload,
+        payload=KYCPayload(applicant_id=applicant_id, amount_usd=amount, country=country),
+        response_schema=KYCDecision,
+        timeout_seconds=3600,
         assign_to={"role": "kyc-reviewer"},
         notify=["slack:#kyc"],
     )
 
+
 # Pick the lane in your agent code
+amount = 12_500
 review = review_high_value if amount > 10_000 else review_standard
 ```
 

--- a/docs/testing.mdx
+++ b/docs/testing.mdx
@@ -59,16 +59,22 @@ requests.post(
 )
 
 # 2. Kick off await_human (in a thread so we can drive the response)
+class WirePayload(BaseModel):
+    vendor: str
+    amount_usd: int
+
+
 class Decision(BaseModel):
     approved: bool
+
 
 import threading
 result_box = {}
 def run_agent():
     result_box["v"] = await_human_sync(
         task="Approve wire?",
-        payload_schema=...,
-        payload=...,
+        payload_schema=WirePayload,
+        payload=WirePayload(vendor="Atlas Logistics", amount_usd=48200),
         response_schema=Decision,
         timeout_seconds=120,
         notify=["email+smoke:reviewer@example.test"],
@@ -148,12 +154,29 @@ For tests that should not call a real LLM, set the verifier's `model` to a deplo
 If your test suite creates tasks in parallel, pin every test's `idempotency_key` to its test name so a flaky run doesn't accidentally pick up a sibling test's task:
 
 ```python
+from pydantic import BaseModel
+from awaithumans import await_human_sync
+
+
+class RefundRequest(BaseModel):
+    order_id: str
+    amount_usd: int
+
+
+class RefundDecision(BaseModel):
+    approved: bool
+
+
 def test_refund_approval():
     decision = await_human_sync(
-        task="...",
+        task="Approve refund for test order",
+        payload_schema=RefundRequest,
+        payload=RefundRequest(order_id="test-A-4721", amount_usd=250),
+        response_schema=RefundDecision,
+        timeout_seconds=60,
         idempotency_key="test:refund-approval",   # ← stable per-test
-        # ...
     )
+    assert decision.approved is True
 ```
 
 Re-running the same test re-uses the same task (Stripe-style idempotency). To force a fresh task between runs, suffix with a UUID:


### PR DESCRIPTION
## Why

Project rule: every code example in the docs has to be copy-paste runnable. Sweep found 11 `# ...` / `payload=...` / `payload_schema=...` placeholders. 8 are real code gaps (this PR). 3 are intentionally kept.

## Fixed (8 sites across 6 files)

| File | Section |
|---|---|
| `docs/channels/overview.mdx` | Multi-channel notify example |
| `docs/channels/email.mdx` | Step 3 'Send' example |
| `docs/adapters/verifier.mdx` | `redact_payload=True` example |
| `docs/concepts/idempotency.mdx` | When-to-pass-an-explicit-key + re-triggering + full refund pipeline |
| `docs/routing/overview.mdx` | KYC queue example (two lanes) |
| `docs/testing.mdx` | File-transport email smoke template + idempotency-key test fixture |

## Pattern across all 8 fixes

Every `# ...` placeholder replaced with explicit `payload_schema` / `payload` / `response_schema` / `timeout_seconds`, plus inline Pydantic model definitions so the snippet is genuinely runnable.

Example before/after — `docs/channels/overview.mdx`:

**Before:**
```python
await_human_sync(
    task="Approve refund?",
    # ...
    notify=[
        "slack:#approvals",
        "email:reviews@acme.com",
    ],
)
```

**After:**
```python
from pydantic import BaseModel
from awaithumans import await_human_sync


class RefundRequest(BaseModel):
    order_id: str
    amount_usd: int


class RefundDecision(BaseModel):
    approved: bool


decision = await_human_sync(
    task="Approve refund?",
    payload_schema=RefundRequest,
    payload=RefundRequest(order_id="A-4721", amount_usd=250),
    response_schema=RefundDecision,
    timeout_seconds=900,
    notify=[
        "slack:#approvals",
        "email:reviews@acme.com",
    ],
)
```

## Intentionally KEPT (3 sites)

- `docs/webhooks.mdx:65` — `# ... do work, return 2xx ...` is narrative inside an otherwise-complete receiver handler. The receiver itself is fully runnable; the placeholder marks 'your handler logic differs per use case'.
- `docs/sdk/python.mdx:35` — `# ...and the shape of the response form they fill in.` is the continuation of a sentence comment, not a code gap.
- `docs/channels/slack.mdx:67` — being fixed in #98 (same conversion to a runnable example).

## Files touched

6 docs files, +212 / -24 lines. Zero runtime code changes.

## Relationship to other PRs

- **PR #98** — handles `docs/channels/slack.mdx` the same way. The two PRs touch different files; merge order doesn't matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)