### PR TITLE
fix(server): defer transport_config when listing email identities

### DIFF
--- a/packages/python/awaithumans/server/services/email_identity_service.py
+++ b/packages/python/awaithumans/server/services/email_identity_service.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import defer
 
 from awaithumans.server.db.models import EmailSenderIdentity
 
@@ -70,9 +71,7 @@ async def upsert_identity(
     return existing
 
 
-async def get_identity(
-    session: AsyncSession, identity_id: str
-) -> EmailSenderIdentity | None:
+async def get_identity(session: AsyncSession, identity_id: str) -> EmailSenderIdentity | None:
     result = await session.execute(
         select(EmailSenderIdentity).where(EmailSenderIdentity.id == identity_id)
     )
@@ -80,7 +79,27 @@ async def get_identity(
 
 
 async def list_identities(session: AsyncSession) -> list[EmailSenderIdentity]:
-    result = await session.execute(select(EmailSenderIdentity))
+    """List all identities WITHOUT loading the encrypted transport_config.
+
+    Listing is a public-fields-only view (see route's `_to_public`). If we
+    let SQLAlchemy materialize `transport_config`, EncryptedString runs
+    AES-GCM decrypt on every row — a single row encrypted under a rotated
+    or stale PAYLOAD_KEY then raises InvalidTag and kills the whole
+    endpoint with a 500. Deferring the column means listing keeps working;
+    per-row ops that genuinely need the secret (upsert, get_identity,
+    transport resolution) load it through `get_identity` and surface
+    decrypt failures loudly at use-time.
+
+    `raiseload=True`: any accidental read of `.transport_config` on a
+    listed row raises immediately instead of silently lazy-loading inside
+    async context (which would either fail with MissingGreenlet or
+    re-trigger the InvalidTag bug). Forces callers to use `get_identity`.
+    """
+    result = await session.execute(
+        select(EmailSenderIdentity).options(
+            defer(EmailSenderIdentity.transport_config, raiseload=True)
+        )
+    )
     return list(result.scalars().all())
 
 

--- a/packages/python/tests/email/test_identity_service.py
+++ b/packages/python/tests/email/test_identity_service.py
@@ -6,9 +6,15 @@ provider credentials (like an API key) never land on disk in plaintext.
 
 from __future__ import annotations
 
-import pytest
-from sqlalchemy import text
+import secrets
 
+import pytest
+from cryptography.exceptions import InvalidTag
+from sqlalchemy import text
+from sqlalchemy.exc import InvalidRequestError
+
+from awaithumans.server.core import encryption
+from awaithumans.server.core.config import settings
 from awaithumans.server.services.email_identity_service import (
     delete_identity,
     get_identity,
@@ -46,9 +52,7 @@ async def test_transport_config_encrypted_on_disk(session) -> None:
         transport_config={"api_key": "re_prod_SENSITIVE"},
     )
     result = await session.execute(
-        text(
-            "SELECT transport_config FROM email_sender_identities WHERE id = 'acme-prod'"
-        )
+        text("SELECT transport_config FROM email_sender_identities WHERE id = 'acme-prod'")
     )
     raw = result.scalar_one()
     assert "re_prod_SENSITIVE" not in raw
@@ -105,3 +109,71 @@ async def test_list_and_delete(session) -> None:
 @pytest.mark.asyncio
 async def test_get_missing_returns_none(session) -> None:
     assert await get_identity(session, "nope") is None
+
+
+@pytest.mark.asyncio
+async def test_list_survives_undecryptable_row(session) -> None:
+    """A row whose transport_config was encrypted under a rotated/stale
+    PAYLOAD_KEY must not crash the listing endpoint.
+
+    Repro of the dashboard 500 on /api/channels/email/identities: one
+    smoke-test row was left over from an earlier key, EncryptedString
+    raised InvalidTag at row materialization, and the whole listing
+    endpoint 500'd. After the fix, listing defers transport_config so
+    the column is never decrypted; per-row ops that need the secret
+    still fail loudly.
+    """
+    await upsert_identity(
+        session,
+        identity_id="good",
+        display_name="Good",
+        from_email="good@x.com",
+        transport="noop",
+        transport_config={"ok": True},
+    )
+    await upsert_identity(
+        session,
+        identity_id="stale-key",
+        display_name="Stale Key",
+        from_email="stale@x.com",
+        transport="noop",
+        transport_config={"will_be_overwritten": True},
+    )
+
+    # Re-encrypt one row's transport_config under a different key,
+    # then restore the original so subsequent reads of the "good" row
+    # still succeed. This mirrors the real-world rotation scenario.
+    original_key = settings.PAYLOAD_KEY
+    settings.PAYLOAD_KEY = secrets.token_urlsafe(32)
+    encryption.reset_key_cache()
+    rotated_blob = encryption.encrypt_str('{"rotated":true}')
+    settings.PAYLOAD_KEY = original_key
+    encryption.reset_key_cache()
+
+    await session.execute(
+        text("UPDATE email_sender_identities SET transport_config = :blob WHERE id = 'stale-key'"),
+        {"blob": rotated_blob},
+    )
+    await session.commit()
+
+    rows = await list_identities(session)
+    ids = {r.id for r in rows}
+    assert ids == {"good", "stale-key"}
+
+    # The deferred column must not be accessible — touching it should
+    # raise rather than silently lazy-load. This enforces the contract
+    # that listing is a public-fields-only view.
+    stale_row = next(r for r in rows if r.id == "stale-key")
+    with pytest.raises(InvalidRequestError):
+        _ = stale_row.transport_config
+
+    # Per-row fetch still loads transport_config and surfaces the
+    # decryption failure loudly — callers that need the secret learn
+    # immediately that this row is unusable.
+    with pytest.raises(InvalidTag):
+        await get_identity(session, "stale-key")
+
+    # The healthy row still round-trips through get_identity unaffected.
+    good = await get_identity(session, "good")
+    assert good is not None
+    assert identity_config(good) == {"ok": True}


### PR DESCRIPTION
## Summary

- One row whose `transport_config` was encrypted under a rotated/stale `PAYLOAD_KEY` was 500'ing the entire `GET /api/channels/email/identities` endpoint — `EncryptedString.process_result_value` runs AES-GCM decrypt during row materialization, the first `InvalidTag` propagates up, the global handler shapes it as `INTERNAL_ERROR`, and the dashboard's Email sender identities panel renders "An unexpected error occurred." Adding a new identity didn't help (the new row wrote fine, but the subsequent list still had to decrypt the broken one).
- Listing is a public-fields-only view — the route's `_to_public` never reads `transport_config`. Now `list_identities` defers the column with `raiseload=True`, so a stale-key row no longer participates in decryption at list time. Per-row ops (`get_identity`, `upsert_identity` reading the existing row) still load the secret and fail loudly at use-time when it's genuinely unreadable — no silent fallback at the EncryptedString layer.
- New test `test_list_survives_undecryptable_row` reproduces the rotated-key scenario end-to-end: list returns both rows, accessing the deferred column on the broken row raises `InvalidRequestError`, `get_identity` on it raises `InvalidTag`, and the healthy row still round-trips through `identity_config`.

## Reproduction (before this PR)

```
GET /api/channels/email/identities
→ 500
{"error":"INTERNAL_ERROR","message":"An unexpected error occurred.","docs":"https://awaithumans.dev/docs/troubleshooting#internal-error"}
```

Hit when any single existing `email_sender_identities` row was written under a prior `AWAITHUMANS_PAYLOAD_KEY` (rotation, dev DB carried across key resets, smoke-test residue).

## Test plan

- [x] `pytest tests/email/test_identity_service.py tests/email/test_admin_and_action_routes.py` — 17/17 pass, including the new rotated-key test
- [x] Full `pytest tests/email/` — 80/80 pass
- [x] `ruff check` + `ruff format --check` clean on touched files
- [ ] Manually verify the dashboard Email sender identities panel loads when a stale-key row exists (reproduce locally by writing a row, rotating `AWAITHUMANS_PAYLOAD_KEY`, restarting, opening Settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)