### PR TITLE
fix(email): bare notify uses solo DB identity; SMTP user-alias + port 465 TLS

### DIFF
--- a/docs/channels/email.mdx
+++ b/docs/channels/email.mdx
@@ -22,7 +22,7 @@ The server accepts email configuration through **either**:
 1. **Environment variables** — picks one default identity, applied to every `notify=["email:..."]` entry. Best for single-tenant deployments and quickstart.
 2. **Per-identity sender records** stored in the DB — each identity has its own transport, `from_email`, and credentials. Routed via `notify=["email+<identity>:..."]`. Best for multi-tenant deployments or when you need multiple senders from one server.
 
-You can mix both: env vars provide the default, per-identity overrides for specific routes.
+You can mix both: env vars provide the default, per-identity overrides for specific routes. And as a UX shortcut, when no env transport is set and **exactly one** identity is configured in the DB, bare `notify=["email:..."]` routes through it automatically (see [Solo-identity shortcut](#solo-identity-shortcut)).
 
 ## Quickstart with Resend (env-var path)
 
@@ -163,8 +163,17 @@ POST is upsert — same `id` overwrites. Re-run to rotate credentials in place.
 ```python
 notify=["email+acme-prod:reviewer@acme.com"]    # send via the "acme-prod" identity
 notify=["email+initech:bob@initech.com"]        # send via the "initech" identity
-notify=["email:reviewer@acme.com"]              # send via the env-var default
+notify=["email:reviewer@acme.com"]              # send via the env-var default,
+                                                # or — when no env transport is set and
+                                                # exactly one DB identity is configured —
+                                                # via that identity (solo-identity shortcut)
 ```
+
+### Solo-identity shortcut
+
+When the server has **no `AWAITHUMANS_EMAIL_TRANSPORT` set** and the dashboard has **exactly one** sender identity configured, bare `notify=["email:..."]` routes through that identity. This is what makes the quickstart example honest for operators who set up email through the dashboard instead of env vars.
+
+The shortcut stops applying as soon as you add a second identity — at that point bare `email:` skips (with a clear log warning) and you must specify `email+<id>:...`. We don't pick arbitrarily.
 
 ## Action buttons vs dashboard link-out
 

--- a/packages/dashboard/components/settings/email-identities.tsx
+++ b/packages/dashboard/components/settings/email-identities.tsx
@@ -50,7 +50,9 @@ export function EmailIdentities() {
 		<SettingsSection
 			icon={Mail}
 			title="Email sender identities"
-			description={'Per-team sender profiles referenced as notify="email+<id>:user@example.com".'}
+			description={
+				'Per-team sender profiles. Reference as notify="email+<id>:user@example.com" — or bare "email:user@example.com" when this is your only identity.'
+			}
 			action={
 				!showForm && (
 					<button

--- a/packages/dashboard/components/settings/email-identity-form.tsx
+++ b/packages/dashboard/components/settings/email-identity-form.tsx
@@ -20,7 +20,7 @@ const inputClass =
 
 const TRANSPORT_CONFIG_HINT: Record<EmailTransport, string> = {
 	resend: '{"api_key": "re_…"}',
-	smtp: '{"host": "smtp.…", "port": 587, "user": "…", "password": "…"}',
+	smtp: '587/STARTTLS: {"host":"smtp.…","port":587,"username":"…","password":"…"} · 465/implicit TLS: add "use_tls": true',
 	logging: "{} for logging / noop",
 	noop: "{} for logging / noop",
 };

--- a/packages/python/awaithumans/server/channels/email/notifier.py
+++ b/packages/python/awaithumans/server/channels/email/notifier.py
@@ -31,7 +31,10 @@ from awaithumans.server.channels.routing import ChannelRoute, routes_for_channel
 from awaithumans.server.core.config import settings
 from awaithumans.server.db.connection import get_async_session_factory
 from awaithumans.server.db.models import EmailSenderIdentity
-from awaithumans.server.services.email_identity_service import get_identity
+from awaithumans.server.services.email_identity_service import (
+    get_identity,
+    list_identities,
+)
 
 logger = logging.getLogger("awaithumans.server.channels.email.notifier")
 
@@ -66,9 +69,7 @@ async def notify_task(
             logger.warning("notify_task (email): task %s missing: %s", task_id, exc)
             return
 
-        handoff_exp_unix = (
-            int(task.timeout_at.timestamp()) if task.timeout_at else None
-        )
+        handoff_exp_unix = int(task.timeout_at.timestamp()) if task.timeout_at else None
 
         for route in routes:
             try:
@@ -152,18 +153,57 @@ async def _deliver_one(
     )
 
 
-async def _resolve_identity(
-    session: Any, identity_id: str | None
-) -> EmailSenderIdentity | None:
-    if identity_id is None:
+async def _resolve_identity(session: Any, identity_id: str | None) -> EmailSenderIdentity | None:
+    """Resolve which sender identity a route should use.
+
+    Precedence:
+      1. Explicit `email+<id>:...` → that identity (None + log if missing).
+      2. Bare `email:...` AND env transport (`AWAITHUMANS_EMAIL_TRANSPORT`)
+         is set → None (caller uses env-derived transport, unchanged).
+      3. Bare `email:...` AND env transport is unset AND exactly one
+         identity is configured in the DB → use that one.
+      4. Bare `email:...` AND env transport is unset AND multiple
+         identities exist → None + log a clear "be explicit" warning.
+
+    Path 3 is the UX fix for dashboard-configured users: the docs'
+    quickstart `notify=["email:reviewer@acme.com"]` example would
+    otherwise silently skip when the operator set up email through
+    the dashboard instead of env vars. Solo identity = unambiguous
+    default; >1 identity = we don't pick arbitrarily.
+    """
+    if identity_id is not None:
+        row = await get_identity(session, identity_id)
+        if row is None:
+            logger.warning(
+                "Email identity '%s' not found; falling back to env default.",
+                identity_id,
+            )
+        return row
+
+    # Bare `email:` route. If env vars provide a default transport,
+    # honor that (existing deployments don't change behavior).
+    if settings.EMAIL_TRANSPORT:
         return None
-    row = await get_identity(session, identity_id)
-    if row is None:
+
+    rows = await list_identities(session)
+    if len(rows) == 1:
+        # list_identities defers transport_config (PR #100) so we
+        # re-fetch via get_identity to load the encrypted column.
+        full = await get_identity(session, rows[0].id)
+        if full is not None:
+            logger.info(
+                "Bare 'email:' route resolved to single configured identity '%s'.",
+                full.id,
+            )
+        return full
+    if len(rows) > 1:
         logger.warning(
-            "Email identity '%s' not found; falling back to env default.",
-            identity_id,
+            "Bare 'email:' route but %d identities configured and no "
+            "AWAITHUMANS_EMAIL_TRANSPORT set — route via 'email+<id>:...' "
+            "or set env vars. Skipping send.",
+            len(rows),
         )
-    return row
+    return None
 
 
 async def _resolve_transport_for(

--- a/packages/python/awaithumans/server/channels/email/transport/factory.py
+++ b/packages/python/awaithumans/server/channels/email/transport/factory.py
@@ -51,12 +51,23 @@ def resolve_transport(name: str, config: dict[str, Any]) -> EmailTransport:
         port = int(config.get("port") or 587)
         if not host:
             raise EmailTransportError("smtp transport: config.host is required.")
+        # Accept `user` as an alias for `username`. The dashboard's
+        # Email-identity form hint advertises `user`, Python's stdlib
+        # smtplib uses `user` too — silently dropping it on the floor
+        # left users with unauthenticated SMTP and no signal.
+        username = config.get("username") or config.get("user")
+        # Port 465 is implicit-TLS; default `use_tls` to True there
+        # unless explicitly overridden. STARTTLS on 465 fails the
+        # handshake, which is the exact trap most operators hit on
+        # the first send. Matches the convention every mature SMTP
+        # library (aiosmtplib, smtplib, Nodemailer, etc.) uses.
+        use_tls = bool(config["use_tls"]) if "use_tls" in config else port == 465
         return SMTPTransport(
             host=host,
             port=port,
-            username=config.get("username"),
+            username=username,
             password=config.get("password"),
-            use_tls=bool(config.get("use_tls", False)),
+            use_tls=use_tls,
             start_tls=bool(config.get("start_tls", True)),
         )
 
@@ -73,8 +84,7 @@ def resolve_transport(name: str, config: dict[str, Any]) -> EmailTransport:
         return FileTransport(dir=directory)
 
     raise EmailTransportError(
-        f"Unknown email transport: '{name}'. "
-        "Valid: resend, smtp, logging, noop, file."
+        f"Unknown email transport: '{name}'. Valid: resend, smtp, logging, noop, file."
     )
 
 

--- a/packages/python/tests/email/test_notifier_identity_resolution.py
+++ b/packages/python/tests/email/test_notifier_identity_resolution.py
@@ -1,0 +1,121 @@
+"""Solo-identity fallback in the email notifier.
+
+Covers the UX shortcut introduced so dashboard-configured operators don't
+silently lose sends when their code follows the quickstart `email:` form.
+The precedence under test is documented on `_resolve_identity`:
+
+  1. explicit `email+<id>:...` → that identity (or None + warn if missing)
+  2. bare `email:...` + env transport set → None (caller uses env)
+  3. bare `email:...` + env unset + 1 identity in DB → that identity
+  4. bare `email:...` + env unset + >1 identity → None (skip + warn)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from awaithumans.server.channels.email.notifier import _resolve_identity
+from awaithumans.server.core.config import settings
+from awaithumans.server.services.email_identity_service import (
+    identity_config,
+    upsert_identity,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_email_transport() -> None:
+    """Most cases want the env transport unset — set per-test when needed."""
+    original = settings.EMAIL_TRANSPORT
+    settings.EMAIL_TRANSPORT = None
+    yield
+    settings.EMAIL_TRANSPORT = original
+
+
+@pytest.mark.asyncio
+async def test_explicit_identity_id_resolves_directly(session) -> None:
+    await upsert_identity(
+        session,
+        identity_id="acme",
+        display_name="Acme",
+        from_email="a@acme.com",
+        transport="noop",
+        transport_config={"flag": "explicit"},
+    )
+    row = await _resolve_identity(session, "acme")
+    assert row is not None
+    assert row.id == "acme"
+    # transport_config is loaded (not deferred) so callers can build a transport.
+    assert identity_config(row) == {"flag": "explicit"}
+
+
+@pytest.mark.asyncio
+async def test_explicit_identity_id_missing_returns_none(session) -> None:
+    """Operator typed a bad slug — we don't silently fall through to the
+    solo fallback (that would mask config errors). Return None, log."""
+    await upsert_identity(
+        session,
+        identity_id="only-one",
+        display_name="Only",
+        from_email="o@x.com",
+        transport="noop",
+        transport_config={},
+    )
+    assert await _resolve_identity(session, "does-not-exist") is None
+
+
+@pytest.mark.asyncio
+async def test_bare_email_with_env_transport_uses_env(session) -> None:
+    """When AWAITHUMANS_EMAIL_TRANSPORT is set, bare `email:` defers to
+    env-derived config. The solo fallback must not override an explicit
+    operator-configured env default."""
+    settings.EMAIL_TRANSPORT = "noop"
+    await upsert_identity(
+        session,
+        identity_id="solo",
+        display_name="Solo",
+        from_email="s@x.com",
+        transport="noop",
+        transport_config={},
+    )
+    assert await _resolve_identity(session, None) is None
+
+
+@pytest.mark.asyncio
+async def test_bare_email_with_solo_identity_resolves_to_it(session) -> None:
+    """The UX fix: dashboard-only setup + docs quickstart code path."""
+    await upsert_identity(
+        session,
+        identity_id="awaithumans",
+        display_name="AwaitHumans",
+        from_email="hello@awaithumans.dev",
+        transport="noop",
+        transport_config={"k": "v"},
+    )
+    row = await _resolve_identity(session, None)
+    assert row is not None
+    assert row.id == "awaithumans"
+    # Re-fetched via get_identity, so transport_config is loaded
+    # (list_identities defers it; that's intentional).
+    assert identity_config(row) == {"k": "v"}
+
+
+@pytest.mark.asyncio
+async def test_bare_email_with_multiple_identities_skips(session) -> None:
+    """When >1 identity is configured and no env default is set, bare
+    `email:` is ambiguous — we don't pick arbitrarily."""
+    for i in range(2):
+        await upsert_identity(
+            session,
+            identity_id=f"team-{i}",
+            display_name=str(i),
+            from_email=f"{i}@x.com",
+            transport="noop",
+            transport_config={},
+        )
+    assert await _resolve_identity(session, None) is None
+
+
+@pytest.mark.asyncio
+async def test_bare_email_with_zero_identities_returns_none(session) -> None:
+    """No identities + no env transport = nothing to route to."""
+    assert await _resolve_identity(session, None) is None

--- a/packages/python/tests/email/test_transport.py
+++ b/packages/python/tests/email/test_transport.py
@@ -15,7 +15,6 @@ from awaithumans.server.channels.email.transport.logging import LoggingTransport
 from awaithumans.server.channels.email.transport.noop import NoopTransport
 from awaithumans.server.channels.email.transport.resend import ResendTransport
 
-
 # ─── EmailMessage header-injection defense ──────────────────────────────
 
 
@@ -91,10 +90,71 @@ def test_factory_resend_requires_api_key() -> None:
 def test_factory_smtp_requires_host() -> None:
     with pytest.raises(EmailTransportError, match="host"):
         resolve_transport("smtp", {})
-    t = resolve_transport(
-        "smtp", {"host": "smtp.example.com", "port": 587}
-    )
+    t = resolve_transport("smtp", {"host": "smtp.example.com", "port": 587})
     assert t.name == "smtp"
+
+
+def test_factory_smtp_accepts_user_alias_for_username() -> None:
+    """The dashboard form hint advertises `user`, Python stdlib smtplib
+    uses `user` too — the factory must accept either spelling. Before
+    this fix, the `user` key was silently dropped, leaving operators
+    with unauthenticated SMTP and no signal."""
+    t = resolve_transport(
+        "smtp",
+        {
+            "host": "smtp.example.com",
+            "port": 587,
+            "user": "alice@example.com",
+            "password": "secret",
+        },
+    )
+    assert t._username == "alice@example.com"  # type: ignore[attr-defined]
+    assert t._password == "secret"  # type: ignore[attr-defined]
+
+
+def test_factory_smtp_username_wins_over_user_when_both_present() -> None:
+    """Explicit `username` takes precedence over the `user` alias —
+    avoids ambiguity if a config carries both keys."""
+    t = resolve_transport(
+        "smtp",
+        {
+            "host": "smtp.example.com",
+            "port": 587,
+            "username": "canonical@x.com",
+            "user": "legacy@x.com",
+        },
+    )
+    assert t._username == "canonical@x.com"  # type: ignore[attr-defined]
+
+
+def test_factory_smtp_port_465_defaults_use_tls_true() -> None:
+    """Port 465 is implicit-TLS by convention. The factory must default
+    use_tls=True there — STARTTLS on 465 fails the handshake, which is
+    the exact trap most operators (Hostinger, Zoho, fastmail, etc.) hit
+    on the first send."""
+    t = resolve_transport("smtp", {"host": "smtp.example.com", "port": 465})
+    assert t._use_tls is True  # type: ignore[attr-defined]
+    # SMTPTransport's __init__ resolves the use_tls + start_tls
+    # conflict by clearing start_tls when use_tls is True.
+    assert t._start_tls is False  # type: ignore[attr-defined]
+
+
+def test_factory_smtp_port_587_defaults_use_tls_false() -> None:
+    """Port 587 is STARTTLS by convention; use_tls stays False so the
+    handshake upgrades after EHLO. No regression for existing setups."""
+    t = resolve_transport("smtp", {"host": "smtp.example.com", "port": 587})
+    assert t._use_tls is False  # type: ignore[attr-defined]
+    assert t._start_tls is True  # type: ignore[attr-defined]
+
+
+def test_factory_smtp_explicit_use_tls_overrides_port_default() -> None:
+    """Explicit use_tls=False on port 465 is respected — operator knows
+    something we don't (e.g. a non-standard relay)."""
+    t = resolve_transport(
+        "smtp",
+        {"host": "smtp.example.com", "port": 465, "use_tls": False},
+    )
+    assert t._use_tls is False  # type: ignore[attr-defined]
 
 
 # ─── Noop + Logging (trivial, smoke tests) ──────────────────────────────
@@ -103,9 +163,7 @@ def test_factory_smtp_requires_host() -> None:
 @pytest.mark.asyncio
 async def test_noop_send_returns_id() -> None:
     t = NoopTransport()
-    msg = EmailMessage(
-        to="a@x.com", subject="s", html="<p/>", text="t", from_email="f@x.com"
-    )
+    msg = EmailMessage(to="a@x.com", subject="s", html="<p/>", text="t", from_email="f@x.com")
     result = await t.send(msg)
     assert result.transport == "noop"
     assert result.message_id and result.message_id.startswith("noop-")
@@ -114,9 +172,7 @@ async def test_noop_send_returns_id() -> None:
 @pytest.mark.asyncio
 async def test_logging_send_returns_id() -> None:
     t = LoggingTransport()
-    msg = EmailMessage(
-        to="a@x.com", subject="s", html="<p/>", text="t", from_email="f@x.com"
-    )
+    msg = EmailMessage(to="a@x.com", subject="s", html="<p/>", text="t", from_email="f@x.com")
     result = await t.send(msg)
     assert result.transport == "logging"
 
@@ -127,9 +183,7 @@ async def test_logging_send_returns_id() -> None:
 @pytest.mark.asyncio
 async def test_resend_send_success() -> None:
     t = ResendTransport(api_key="re_test")
-    msg = EmailMessage(
-        to="a@x.com", subject="s", html="<p/>", text="t", from_email="f@x.com"
-    )
+    msg = EmailMessage(to="a@x.com", subject="s", html="<p/>", text="t", from_email="f@x.com")
 
     class FakeResp:
         status_code = 200
@@ -156,9 +210,7 @@ async def test_resend_send_success() -> None:
 @pytest.mark.asyncio
 async def test_resend_send_failure_raises() -> None:
     t = ResendTransport(api_key="re_test")
-    msg = EmailMessage(
-        to="a@x.com", subject="s", html="<p/>", text="t", from_email="f@x.com"
-    )
+    msg = EmailMessage(to="a@x.com", subject="s", html="<p/>", text="t", from_email="f@x.com")
 
     class FakeResp:
         status_code = 401


### PR DESCRIPTION
## Summary

Three independent issues caused a dashboard-configured email identity to silently drop the send when an operator's code followed the quickstart's bare `notify=["email:reviewer@acme.com"]` form. Each one alone is enough to break the flow; together they're the worst kind of trap — no error, no audit entry, no dashboard signal, just nothing arrives.

### 1. Solo-identity shortcut (UX fix)

`_resolve_identity` now follows a clear precedence chain (documented in the docstring):

| Notify | `AWAITHUMANS_EMAIL_TRANSPORT` | # of DB identities | Result |
|---|---|---|---|
| `email+<id>:...` | — | — | that identity (None + log if missing) |
| `email:...` | set | — | env-derived transport (unchanged) |
| `email:...` | unset | 1 | that identity ← **new shortcut** |
| `email:...` | unset | >1 | skip + warn ("be explicit") |
| `email:...` | unset | 0 | None |

Operators who set up email through the dashboard now get the docs quickstart code path "just working." Multi-identity deployments still require explicit `email+<id>:...` — we don't pick arbitrarily.

### 2. SMTP factory accepts `user` as alias for `username`

The dashboard form hint advertised `user` (Python stdlib `smtplib` also uses `user`), but the factory only read `username`. Credentials from a `user`-keyed config were silently dropped → unauthenticated SMTP → opaque auth failure downstream. Now: `username = config.get("username") or config.get("user")`. Explicit `username` still wins when both keys are present.

### 3. SMTP factory auto-defaults `use_tls=True` on port 465

Port 465 is implicit-TLS by convention. The previous default of `use_tls=False, start_tls=True` attempted STARTTLS on an implicit-TLS port and failed the handshake — the exact trap most operators hit with Hostinger, Zoho, Fastmail, etc. Now: when `use_tls` isn't explicitly set in config, default it from the port (`port == 465 → True`). Explicit overrides are respected.

### Surrounding surfaces

- **Dashboard form hint** (`email-identity-form.tsx`): shows a port-465 example with `use_tls`, uses canonical `username`.
- **Settings panel description** (`email-identities.tsx`): mentions the bare-`email:` shortcut.
- **Docs** (`docs/channels/email.mdx`): documents the solo-identity shortcut in both "Two ways to configure" and "Route to a specific identity", so the quickstart example is honest for dashboard users.

## Behavior diff

- **No regression** for env-configured deployments — env transport short-circuits the new fallback path.
- **No regression** for multi-identity deployments — they already used `email+<id>:...`; bare `email:` continues to skip with a clearer warning.
- **New positive behavior** for solo-identity dashboard users — bare `email:` routes through their one configured identity automatically.

## Test plan

- [x] `pytest tests/email/` — 90/90 pass (5 new factory tests, 6 new notifier tests)
- [x] `ruff check` + `ruff format --check` clean on touched files (one unrelated pre-existing SIM117 in `test_transport.py:238` not introduced here)
- [x] `tsc --noEmit` clean on the dashboard
- [ ] Manually verify in dev: with one DB identity configured and no `AWAITHUMANS_EMAIL_TRANSPORT` env var, `notify=["email:tunde@scalebrick.com"]` (no `+id`) successfully delivers via the identity's SMTP/465 config
- [ ] Manually verify the dashboard's Email-identity form shows the new hint and the section description mentions the shortcut

🤖 Generated with [Claude Code](https://claude.com/claude-code)