### PR TITLE
chore(release): bump Python + TypeScript SDK to 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,61 @@ _Nothing yet — open the next change here._
 
 ---
 
+## [0.1.2] — 2026-05-12
+
+### Fixed
+
+- **Bare `notify=["email:user@x"]` now routes through a single configured
+  DB identity** when `AWAITHUMANS_EMAIL_TRANSPORT` is unset. Operators
+  who set email up through the dashboard saw the docs quickstart example
+  silently skip because nothing pointed at their identity — now it
+  "just works" when exactly one identity is configured. Multi-identity
+  deployments still require explicit `email+<id>:...` (no arbitrary
+  pick). Existing env-configured deployments unchanged. ([#101](https://github.com/awaithumans/awaithumans/pull/101))
+
+- **SMTP factory accepts `user` as an alias for `username`.** The
+  dashboard form hint advertised `user`, Python's stdlib `smtplib`
+  uses `user` too, but the factory only read `username` — credentials
+  were silently dropped, producing opaque auth failures. Explicit
+  `username` still wins when both keys are present. ([#101](https://github.com/awaithumans/awaithumans/pull/101))
+
+- **SMTP factory defaults `use_tls=True` on port 465.** Port 465 is
+  implicit-TLS by convention; the previous default of `use_tls=False,
+  start_tls=True` attempted STARTTLS on an implicit-TLS port and failed
+  the handshake — the exact trap operators hit with Hostinger, Zoho,
+  Fastmail, and most managed SMTP providers. Explicit overrides are
+  still respected. ([#101](https://github.com/awaithumans/awaithumans/pull/101))
+
+- **Listing email identities tolerates rows encrypted under a rotated
+  or stale `PAYLOAD_KEY`.** A single undecryptable row used to 500 the
+  entire `GET /api/channels/email/identities` endpoint (the Settings
+  page showed "An unexpected error occurred."). The list view now
+  defers the encrypted `transport_config` column so a single bad row
+  doesn't poison the response; per-row ops that actually need the
+  secret still surface decryption failures loudly at use-time. ([#100](https://github.com/awaithumans/awaithumans/pull/100))
+
+- **Dashboard SMTP form hint shows a port-465 example** and uses the
+  canonical `username` key. The Email-sender-identities panel
+  description now also mentions the bare-`email:` solo-identity
+  shortcut so the UI matches the docs. ([#101](https://github.com/awaithumans/awaithumans/pull/101))
+
+### Docs
+
+- **`docs/channels/email.mdx`** documents the solo-identity shortcut
+  in both "Two ways to configure" and "Route to a specific identity"
+  so the quickstart example is honest for operators who configure
+  through the dashboard.
+
+### Version note
+
+The **TypeScript SDK has no functional changes** — `awaithumans@0.1.2`
+on npm is byte-equivalent to `0.1.1` at the source level. The bump is
+purely to keep the Python and TypeScript SDK versions in lock-step;
+pinning one and pinning the other to the same version remains the
+recommended pattern.
+
+---
+
 ## [0.1.1] — 2026-05-11
 
 ### Security

--- a/packages/python/awaithumans/__init__.py
+++ b/packages/python/awaithumans/__init__.py
@@ -21,7 +21,7 @@ Usage (sync):
 """
 from __future__ import annotations
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 from awaithumans.client import await_human, await_human_sync
 from awaithumans.embed import EmbedTokenResult, embed_token, embed_token_sync

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -20,7 +20,7 @@ packages = ["awaithumans"]
 
 [project]
 name = "awaithumans"
-version = "0.1.1"
+version = "0.1.2"
 description = "The human layer for AI agents. Your agents already await promises. Now they can await humans."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/typescript-sdk/package-lock.json
+++ b/packages/typescript-sdk/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "awaithumans",
-  "version": "0.0.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "awaithumans",
-      "version": "0.0.1",
-      "license": "MIT",
+      "version": "0.1.2",
+      "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.0",
         "zod-to-json-schema": "^3.23.0"
@@ -16,14 +16,14 @@
         "awaithumans": "bin/awaithumans.mjs"
       },
       "devDependencies": {
-        "@langchain/langgraph": "^0.2.0",
+        "@langchain/langgraph": "^0.2.0 || ^1.0.0",
         "@temporalio/client": "^1.0.0",
         "@temporalio/workflow": "^1.0.0",
         "typescript": "^5.7.0",
         "vitest": "^4.1.5"
       },
       "peerDependencies": {
-        "@langchain/langgraph": "^0.2.0",
+        "@langchain/langgraph": "^0.2.0 || ^1.0.0",
         "@temporalio/client": "^1.0.0",
         "@temporalio/workflow": "^1.0.0"
       },

--- a/packages/typescript-sdk/package.json
+++ b/packages/typescript-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awaithumans",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "The human layer for AI agents. Your agents already await promises. Now they can await humans.",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary

Releases the email-channel hardening from #100 and #101 to PyPI and (for lock-step versioning) npm. Patch bump — bug fixes only, no API changes.

| Package | Version | Reason |
|---|---|---|
| `awaithumans` (PyPI, Python) | 0.1.1 → 0.1.2 | Server fixes + bundled dashboard hint update |
| `awaithumans` (npm, TypeScript SDK) | 0.1.1 → 0.1.2 | Lock-step (no functional changes) |

## What ships in this release

### Python (#100, #101)

- **Bare `notify=["email:user@x"]`** routes through a single configured DB identity when no `AWAITHUMANS_EMAIL_TRANSPORT` env var is set. Operators who configured email through the dashboard saw the docs quickstart example silently skip; now it works as advertised. Multi-identity deployments still require explicit `email+<id>:...`.
- **SMTP factory** now accepts `user` as an alias for `username` (dashboard form hint and Python `smtplib` both use `user`; the factory previously dropped credentials silently).
- **SMTP factory** defaults `use_tls=True` when port is 465 and the key isn't explicitly set (implicit-TLS convention; was failing the handshake on Hostinger/Zoho/Fastmail).
- **Listing email identities** tolerates rows encrypted under a rotated or stale `PAYLOAD_KEY` — the encrypted column is now deferred during list, so one bad row doesn't 500 the whole endpoint. Per-row ops still surface decryption failures loudly at use-time.
- **Dashboard form hint + Settings panel description** updated to match. The dashboard ships statically built into the Python wheel, so these strings reach end users via the Python republish.

### TypeScript SDK

No functional changes. Bumped purely to keep the npm and PyPI versions aligned — `awaithumans@0.1.2` on npm is source-identical to `0.1.1`.

## Release sequence

1. **Merge this PR** to main.
2. **PyPI** (Tunde runs `twine upload` — has the token): `packages/python/dist/awaithumans-0.1.2-py3-none-any.whl` + `awaithumans-0.1.2.tar.gz` are already built and verified in a clean venv (`awaithumans version` reports 0.1.2; the new factory behavior is confirmed in the wheel).
3. **npm** (Claude runs after PyPI is up, pending confirmation): `npm publish` from `packages/typescript-sdk/` — tarball already built at `awaithumans-0.1.2.tgz`, verified to import cleanly.
4. **Tag** v0.1.2 on the merge commit + push.
5. **GitHub release** with notes pulled from CHANGELOG [0.1.2].

## Verification done locally

- [x] Python wheel builds, version reports 0.1.2, dashboard_dist bundled, `587/STARTTLS` form hint present in chunks
- [x] Fresh-venv install of `awaithumans[server]==0.1.2` imports cleanly; factory smoke test confirms port-465 default + user-alias both behave as expected
- [x] TS SDK tarball builds, version 0.1.2, ESM import works, top-level exports unchanged
- [x] CHANGELOG follows project format (Keep a Changelog, ISO-8601 dates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)