### PR TITLE
chore(deps): override protobufjs to ^7.5.8 to clear Dependabot alerts

### DIFF
--- a/examples/temporal-ts/package-lock.json
+++ b/examples/temporal-ts/package-lock.json
@@ -25,8 +25,8 @@
     },
     "../../packages/typescript-sdk": {
       "name": "awaithumans",
-      "version": "0.0.1",
-      "license": "MIT",
+      "version": "0.1.2",
+      "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.0",
         "zod-to-json-schema": "^3.23.0"
@@ -35,14 +35,14 @@
         "awaithumans": "bin/awaithumans.mjs"
       },
       "devDependencies": {
-        "@langchain/langgraph": "^0.2.0",
+        "@langchain/langgraph": "^0.2.0 || ^1.0.0",
         "@temporalio/client": "^1.0.0",
         "@temporalio/workflow": "^1.0.0",
         "typescript": "^5.7.0",
-        "vitest": "^2.1.0"
+        "vitest": "^4.1.5"
       },
       "peerDependencies": {
-        "@langchain/langgraph": "^0.2.0",
+        "@langchain/langgraph": "^0.2.0 || ^1.0.0",
         "@temporalio/client": "^1.0.0",
         "@temporalio/workflow": "^1.0.0"
       },
@@ -1407,30 +1407,6 @@
         "node": ">= 20.0.0"
       }
     },
-    "node_modules/@temporalio/proto/node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/@temporalio/worker": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/@temporalio/worker/-/worker-1.17.0.tgz",
@@ -2335,9 +2311,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
-      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/examples/temporal-ts/package.json
+++ b/examples/temporal-ts/package.json
@@ -22,5 +22,8 @@
     "@types/node": "^20.0.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0"
+  },
+  "overrides": {
+    "protobufjs": "^7.5.8"
   }
 }

--- a/packages/typescript-sdk/package-lock.json
+++ b/packages/typescript-sdk/package-lock.json
@@ -689,31 +689,6 @@
         "node": ">= 20.0.0"
       }
     },
-    "node_modules/@temporalio/proto/node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/@temporalio/workflow": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/@temporalio/workflow/-/workflow-1.17.0.tgz",
@@ -1678,9 +1653,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
-      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",

--- a/packages/typescript-sdk/package.json
+++ b/packages/typescript-sdk/package.json
@@ -57,7 +57,8 @@
     "@langchain/langgraph": "^0.2.0 || ^1.0.0"
   },
   "overrides": {
-    "langsmith": ">=0.6.0"
+    "langsmith": ">=0.6.0",
+    "protobufjs": "^7.5.8"
   },
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

Closes the 13 protobufjs Dependabot alerts (#25–#38) by forcing every node in the dep tree onto the latest patched protobufjs via npm `overrides`. After this change, both lockfiles collapse onto a single hoisted `protobufjs@7.5.8` and `npm audit` reports **0 vulnerabilities**.

## Why the fixes kept coming back

`@temporalio/proto@1.17.x` (current latest) hardcodes:

```
"protobufjs": "7.5.5"   ← exact pin, not a range
```

That creates a nested `node_modules/@temporalio/proto/node_modules/protobufjs` copy in our lockfiles which survives every top-level `npm install`. Every new CVE disclosed against protobufjs (and they ship steadily — see the 13 alerts opened today against the same nested 7.5.5 copy) re-opens fresh alerts. The user's previous "fixes" updated the top-level copy, never the nested pin.

## How `overrides` fix it

```jsonc
// packages/typescript-sdk/package.json
"overrides": {
  "langsmith": ">=0.6.0",
  "protobufjs": "^7.5.8"   // ← new
}

// examples/temporal-ts/package.json
"overrides": {
  "protobufjs": "^7.5.8"
}
```

npm overrides apply to **every** node in the dep tree, even hardcoded pins inside upstream packages. After `npm install --package-lock-only` regenerates the lockfiles:

```diff
- node_modules/@temporalio/proto/node_modules/protobufjs (7.5.5)  ← gone
- node_modules/protobufjs (7.5.6)                                 ← bumped
+ node_modules/protobufjs (7.5.8)                                 ← single copy
```

Diff stat: **-45 lines net** in the lockfiles (duplicate copy eliminated).

## No package republish needed

The TS SDK on npm and the Python wheel on PyPI both ship **zero** protobufjs:

| Artifact | protobufjs files | Why |
|---|---|---|
| `awaithumans-0.1.2.tgz` (npm) | 0 | Tarball only includes `dist/` + `bin/`. Runtime deps: `zod`, `zod-to-json-schema`. |
| `awaithumans-0.1.2-py3-none-any.whl` (PyPI) | 0 | JS dep — Python wheel can't carry it. |
| Dashboard lockfile | 0 | No Temporal dep. |

`@temporalio/*` is a `peerDependency` on the SDK (optional, opt-in); end users supply their own copy. Additionally, npm `overrides` only apply at the install root, not when our package is a transitive dep — so even republishing the SDK wouldn't change downstream behavior. The alerts are about our repo's lockfiles (dev + example reproducibility), nothing else.

## Verification

- [x] `cd packages/typescript-sdk && npm audit` → **found 0 vulnerabilities**
- [x] `cd examples/temporal-ts && npm audit` → **found 0 vulnerabilities**
- [x] `grep "node_modules/protobufjs" packages/typescript-sdk/package-lock.json` shows a single entry at `7.5.8`; no nested copy
- [x] `grep "node_modules/protobufjs" examples/temporal-ts/package-lock.json` same — single entry at `7.5.8`
- [x] No `dependencies` / `peerDependencies` / `files` changed → published artifacts unaffected

## Going forward

When protobufjs ships a new patch (7.5.9, etc.), bump the override version. Same maintenance pattern as the existing `langsmith` override. The structural fix is gated on upstream `@temporalio/proto` widening its hardcoded `protobufjs: "7.5.5"` to a range — until then, the override stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)