### PR TITLE
docs(install,cli): lead quickstart with [server] extras + polish CLI error

### DIFF
--- a/docs/sdk/python.mdx
+++ b/docs/sdk/python.mdx
@@ -3,18 +3,41 @@ title: "Python SDK"
 description: "Reference for the awaithumans Python package."
 ---
 
+## Install
+
+Pick one of two starting points based on what you're doing:
+
 ```bash
-pip install awaithumans                  # SDK only (httpx + pydantic)
-pip install "awaithumans[server]"        # SDK + server + CLI + dashboard
-pip install "awaithumans[temporal]"      # + Temporal adapter peer dep
-pip install "awaithumans[langgraph]"     # + LangGraph adapter peer dep
-pip install "awaithumans[verifier-claude]"   # + Anthropic SDK
-pip install "awaithumans[verifier-openai]"   # + OpenAI SDK
-pip install "awaithumans[verifier-gemini]"   # + Google SDK
-pip install "awaithumans[verifier-azure]"    # + Azure OpenAI
+pip install "awaithumans[server]"   # to RUN the server + dashboard locally
+pip install awaithumans              # to CALL a server (slim SDK, 2 deps)
 ```
 
-Python 3.10+. The base SDK (`pip install awaithumans`) has only two runtime deps: `httpx` and `pydantic`.
+Most people want the first. Use the bare SDK install only when your agent runs in a lambda, edge runtime, or container where you just need an HTTP client talking to a server hosted elsewhere — bare install is `httpx` + `pydantic` and nothing else.
+
+### Adapters and verifiers compose with either base
+
+Extras stack. Comma-separate them in one bracket to install in a single command:
+
+```bash
+pip install "awaithumans[server,temporal]"            # server + Temporal
+pip install "awaithumans[server,verifier-claude]"     # server + Claude verifier
+pip install "awaithumans[temporal,verifier-claude]"   # SDK + Temporal + Claude
+pip install "awaithumans[server,temporal,verifier-claude]"  # all three
+```
+
+### All extras
+
+| Extra              | Adds                                       |
+| ------------------ | ------------------------------------------ |
+| `server`           | FastAPI server, CLI, bundled dashboard     |
+| `temporal`         | Temporal workflow adapter                  |
+| `langgraph`        | LangGraph interrupt/resume adapter         |
+| `verifier-claude`  | Anthropic SDK (for Claude verification)    |
+| `verifier-openai`  | OpenAI SDK                                 |
+| `verifier-gemini`  | Google Generative AI SDK                   |
+| `verifier-azure`   | OpenAI SDK (used against Azure endpoints)  |
+
+Python 3.10+ required.
 
 ## await_human / await_human_sync
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -230,6 +230,31 @@ Email action token was already used.
 
 **Fix:** This is by design — single-use prevents replay. Use the dashboard to update the response.
 
+## CLI errors
+
+### cli-missing-server-extra
+
+`awaithumans` (the CLI binary) exits immediately with a message like:
+
+```
+awaithumans CLI: server extras not installed.
+```
+
+**Why:** `pip install awaithumans` (no extras) installs only the lightweight SDK — `httpx` + `pydantic`. That's enough for a Python agent calling a remote awaithumans server, but the CLI commands (`awaithumans dev`, `awaithumans add-user`, etc.) need FastAPI, SQLModel, slack-sdk, etc., which ship behind the `[server]` extra.
+
+**Fix:** install the server extras and re-run the same command.
+
+```bash
+pip install "awaithumans[server]"
+awaithumans dev
+```
+
+If you also need adapters or verifiers, stack them in one install:
+
+```bash
+pip install "awaithumans[server,temporal,verifier-claude]"
+```
+
 ## Still stuck?
 
 - Check the [GitHub Discussions](https://github.com/awaithumans/awaithumans/discussions) — most issues have been seen before.

--- a/packages/python/awaithumans/cli/main.py
+++ b/packages/python/awaithumans/cli/main.py
@@ -9,8 +9,16 @@ try:
     import typer
 except ImportError:
     raise SystemExit(
-        "The awaithumans CLI requires the [server] extra.\n"
-        'Install with: pip install "awaithumans[server]"'
+        "awaithumans CLI: server extras not installed.\n"
+        "\n"
+        "You have the lightweight SDK (httpx + pydantic) installed — fine for\n"
+        "calling a remote awaithumans server, but the CLI (`awaithumans dev`,\n"
+        "`awaithumans add-user`, etc.) needs FastAPI, SQLModel, and other\n"
+        "server deps that ship in the [server] extra.\n"
+        "\n"
+        'Fix: pip install "awaithumans[server]"\n'
+        "\n"
+        "Docs: https://awaithumans.dev/docs/troubleshooting#cli-missing-server-extra"
     ) from None
 
 from awaithumans.cli.commands.add_user import add_user


### PR DESCRIPTION
## Summary

First-time users running bare `pip install awaithumans` then `awaithumans dev` got a stack trace instead of a working server. The bare install is the lightweight SDK (`httpx` + `pydantic` only); the CLI commands need FastAPI, SQLModel, etc. from the `[server]` extra. Reported by a beta tester.

- **CLI:** polish the existing `ImportError` handler in `cli/main.py` to follow the project's `what → why → fix → docs` pattern with an actionable docs URL.
- **Docs (SDK):** restructure `docs/sdk/python.mdx` to lead with two clear install paths and explain how extras stack (e.g. `[server,temporal,verifier-claude]`).
- **Docs (troubleshooting):** add `## CLI errors` → `### cli-missing-server-extra` so the URL emitted by the polished error message resolves to a real anchor.

## Test plan

- [ ] In a fresh venv with only `httpx + pydantic` installed, running `awaithumans dev` exits cleanly with the new helpful message (no traceback).
- [ ] After `pip install "awaithumans[server]"`, `awaithumans dev` boots normally.
- [ ] `docs/troubleshooting.mdx#cli-missing-server-extra` renders correctly in Mintlify preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)