### PR TITLE
fix(email): coerce naive timeout_at to UTC before signing handoff URL

### DIFF
--- a/packages/python/awaithumans/server/channels/email/notifier.py
+++ b/packages/python/awaithumans/server/channels/email/notifier.py
@@ -35,6 +35,7 @@ from awaithumans.server.services.email_identity_service import (
     get_identity,
     list_identities,
 )
+from awaithumans.utils.time import to_utc_unix
 
 logger = logging.getLogger("awaithumans.server.channels.email.notifier")
 
@@ -69,7 +70,13 @@ async def notify_task(
             logger.warning("notify_task (email): task %s missing: %s", task_id, exc)
             return
 
-        handoff_exp_unix = int(task.timeout_at.timestamp()) if task.timeout_at else None
+        # `task.timeout_at` comes back from SQLite naive even though we
+        # wrote it tz-aware. `to_utc_unix` coerces; calling `.timestamp()`
+        # directly here would silently shift the URL's expiry by the
+        # local-UTC offset and kill links at birth for east-of-UTC users.
+        handoff_exp_unix = (
+            to_utc_unix(task.timeout_at) if task.timeout_at else None
+        )
 
         for route in routes:
             try:

--- a/packages/python/awaithumans/server/channels/slack/handoff_url.py
+++ b/packages/python/awaithumans/server/channels/slack/handoff_url.py
@@ -16,11 +16,12 @@ flow instead.
 from __future__ import annotations
 
 import urllib.parse
-from datetime import datetime, timezone
+from datetime import datetime
 
 from awaithumans.server.channels.slack.handoff_url_types import HandoffParams
 from awaithumans.server.core.config import settings
 from awaithumans.server.core.slack_handoff import sign_handoff
+from awaithumans.utils.time import to_utc_unix
 
 
 def _unsigned_url(task_id: str) -> str:
@@ -52,6 +53,4 @@ def task_handoff_expiry(timeout_at: datetime) -> int:
     We bind the URL's expiry to the task's own deadline so a 7-day
     approval still has a working link on day 6. Using `task.timeout_at`
     directly keeps the contract simple: link dies with the task."""
-    if timeout_at.tzinfo is None:
-        timeout_at = timeout_at.replace(tzinfo=timezone.utc)
-    return int(timeout_at.timestamp())
+    return to_utc_unix(timeout_at)

--- a/packages/python/awaithumans/utils/time.py
+++ b/packages/python/awaithumans/utils/time.py
@@ -1,0 +1,33 @@
+"""Datetime utilities that defend against the naive-datetime / local-time
+interpretation trap.
+
+SQLModel + SQLite stores `datetime` columns without tz info. A value
+written tz-aware comes back naive on read. Calling `.timestamp()`
+directly on a naive datetime makes Python interpret it as LOCAL time,
+silently shifting the resulting Unix seconds by the local-UTC offset.
+
+For users east of UTC (Lagos UTC+1, Mumbai UTC+5:30, Singapore UTC+8),
+this shifts email-handoff URL expiry into the PAST at creation time —
+a freshly issued 10-minute link is born already expired by the local
+offset. For users west of UTC, the URL lives longer than the task.
+Both are wrong.
+
+`to_utc_unix` performs the coercion every code path that hands a
+DB-loaded datetime to `.timestamp()` should use.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def to_utc_unix(dt: datetime) -> int:
+    """Return Unix seconds for `dt`, treating any naive value as UTC.
+
+    Use this anywhere a datetime loaded from the DB feeds into a Unix
+    timestamp that crosses a channel boundary (signed URL, webhook
+    payload, etc.). Already-aware datetimes round-trip unchanged.
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return int(dt.timestamp())

--- a/packages/python/tests/utils/test_time.py
+++ b/packages/python/tests/utils/test_time.py
@@ -1,0 +1,65 @@
+"""Regression tests for `awaithumans.utils.time.to_utc_unix`.
+
+The bug this defends against: `task.timeout_at` is written tz-aware
+but comes back from SQLite naive. Calling `.timestamp()` directly on
+the naive value made Python interpret it as LOCAL time and shift the
+resulting Unix seconds by the local-UTC offset. For users east of UTC
+(Lagos UTC+1, Mumbai UTC+5:30, Singapore UTC+8), this killed email-
+handoff links at birth — a 10-minute task issued a URL whose `e`
+parameter sat ~3,000+ seconds in the past on a UTC+1 machine.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from awaithumans.utils.time import to_utc_unix
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(time, "tzset"),
+    reason="time.tzset is POSIX-only; cannot force a non-UTC tz on Windows.",
+)
+
+
+@pytest.fixture
+def lagos_tz(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run the test under TZ=Africa/Lagos (UTC+1, no DST).
+
+    Same shape as the user environment where the bug was first
+    reproduced. Restored after the test.
+    """
+    monkeypatch.setenv("TZ", "Africa/Lagos")
+    time.tzset()
+    yield
+    time.tzset()
+
+
+def test_naive_datetime_is_interpreted_as_utc(lagos_tz: None) -> None:
+    """A naive datetime must round-trip to the same Unix seconds as the
+    equivalent tz-aware UTC datetime, regardless of the local tz."""
+    naive = datetime(2026, 5, 14, 22, 30, 0)  # represents UTC
+    aware = datetime(2026, 5, 14, 22, 30, 0, tzinfo=timezone.utc)
+    assert to_utc_unix(naive) == int(aware.timestamp())
+
+
+def test_aware_datetime_round_trips_unchanged(lagos_tz: None) -> None:
+    """Already-aware datetimes get the same answer as `.timestamp()`."""
+    aware = datetime(2026, 5, 14, 22, 30, 0, tzinfo=timezone.utc)
+    assert to_utc_unix(aware) == int(aware.timestamp())
+
+
+def test_url_expiry_is_in_future_for_fresh_short_task(lagos_tz: None) -> None:
+    """End-to-end shape: a 10-minute timeout produces an expiry that is
+    actually in the future of `time.time()`. Without the fix, this
+    sits ~3,000 s in the past on UTC+1 — link born expired."""
+    now_aware = datetime.now(timezone.utc)
+    # Simulate what comes back from SQLite: tz-stripped UTC.
+    timeout_at_naive = (now_aware + timedelta(seconds=600)).replace(tzinfo=None)
+    e = to_utc_unix(timeout_at_naive)
+    assert e > int(time.time()), (
+        f"Expiry {e} not after now {int(time.time())}; "
+        "URL is born expired (reproduces the email-handoff bug)."
+    )


### PR DESCRIPTION
## Summary

East-of-UTC user (Nigeria, UTC+1) reported that clicking the "Open task" button in any notification email returned `400 Sign-in link is invalid or expired` *immediately* after task creation.

**Root cause:** SQLite (via SQLModel) stores `timeout_at` tz-naive. The email notifier called `int(task.timeout_at.timestamp())` on the naive value — Python interprets that as **local** time, shifting the URL's `e` parameter into the past by the local-UTC offset. On UTC+1, a fresh 600-second task issued a URL born 3,000 seconds expired.

The Slack channel already had this fix inline (force `tzinfo=timezone.utc` before `.timestamp()`); the email channel did not. The asymmetry was the smoking gun. This PR extracts a shared `awaithumans.utils.time.to_utc_unix` helper so both channels (and any future channels) get the same defense.

## Changes

- New `awaithumans.utils.time.to_utc_unix(dt)` — single source of truth for "DB datetime → UTC unix int, treating naive as UTC".
- `channels/email/notifier.py`: use it.
- `channels/slack/handoff_url.py::task_handoff_expiry`: use it (collapses the duplicated inline guard).
- New regression tests in `tests/utils/test_time.py` running under `TZ=Africa/Lagos` — fail without this patch on any UTC+ machine.

## Test plan

- [ ] `pytest tests/utils/` — 3 new tests pass.
- [ ] Full Python test suite green (628 → 631 passing).
- [ ] Manual: on a UTC+ machine, create a task with `timeout_seconds=600`, click the email link, land on the task page (not a 400 error).
- [ ] No-op on UTC machines (tests still pass; helper is identity for tz-aware UTC datetimes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)