### PR TITLE
fix(config): ignore unknown AWAITHUMANS_* env keys, warn instead of crashing

### DIFF
--- a/docs/self-hosting/configuration.mdx
+++ b/docs/self-hosting/configuration.mdx
@@ -5,6 +5,20 @@ description: "Every environment variable the awaithumans server reads."
 
 All configuration is via environment variables prefixed `AWAITHUMANS_`. The server reads these once at startup; restart the process to pick up changes.
 
+## Two namespaces under one prefix
+
+The `AWAITHUMANS_` prefix is shared by two unrelated consumers — pay attention when filling a `.env` file:
+
+| Variable | Read by | Used for |
+|---|---|---|
+| `AWAITHUMANS_URL` | **SDK only** | Tells `await_human()` where the server lives. |
+| `AWAITHUMANS_ADMIN_API_TOKEN` | **Both** | Server gates admin routes with it; SDK sends it as bearer. |
+| Every other `AWAITHUMANS_*` on this page | **Server only** | Not read by the SDK. |
+
+The server silently ignores any `AWAITHUMANS_*` key in `.env` that it doesn't recognize — so a shared `.env` containing `AWAITHUMANS_URL=…` for the agent and `AWAITHUMANS_PAYLOAD_KEY=…` for the server boots cleanly. If a key looks like a typo (no matching server field), the server emits a `WARNING` at startup listing every unrecognized `AWAITHUMANS_*` key — check that line if you suspect a misconfigured server var was silently dropped.
+
+Prior to v0.1.3 the server would crash on boot with a pydantic `extra_forbidden` error if any SDK-side key was present in `.env`. If you're hitting that, upgrade.
+
 ## Required
 
 | Variable | Description |

--- a/packages/python/awaithumans/server/app.py
+++ b/packages/python/awaithumans/server/app.py
@@ -20,7 +20,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from awaithumans.server.core.auth import DashboardAuthMiddleware
-from awaithumans.server.core.config import settings
+from awaithumans.server.core.config import settings, unknown_env_keys
 from awaithumans.server.core.dashboard_static import DashboardStaticFiles
 from awaithumans.server.core.embed_auth import EmbedAuthMiddleware
 from awaithumans.server.core.exceptions import exception_handlers
@@ -169,6 +169,24 @@ def create_app(*, serve_dashboard: bool = True) -> FastAPI:
     """
     # ── Logging ──────────────────────────────────────────────────────
     setup_logging(settings.LOG_LEVEL)
+
+    # ── .env hygiene ────────────────────────────────────────────────
+    # SDK-side vars (AWAITHUMANS_URL, etc.) live under the same prefix
+    # as server vars and used to crash the server on boot when present
+    # in a shared `.env`. We now silently ignore them — but a typo like
+    # `AWAITHUMANS_SLAK_BOT_TOKEN` would be ignored too, so we surface
+    # any unrecognized `AWAITHUMANS_*` keys as a WARNING. Cheap to scan,
+    # only runs once at app creation.
+    _unknown = unknown_env_keys()
+    if _unknown:
+        logger.warning(
+            "Found %d AWAITHUMANS_* key(s) in .env that the server does not "
+            "consume: %s. These are ignored. Likely cause: SDK-side vars in a "
+            "shared .env (see docs/self-hosting/configuration#two-namespaces). "
+            "If one is a typo of a real server var, fix it and restart.",
+            len(_unknown),
+            ", ".join(sorted(_unknown)),
+        )
 
     # ── Production safety checks ─────────────────────────────────────
     # HTTPS is required in production because the server handles Slack OAuth

--- a/packages/python/awaithumans/server/core/config.py
+++ b/packages/python/awaithumans/server/core/config.py
@@ -8,9 +8,12 @@ All config is read from env vars with sensible defaults for development.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 from pydantic_settings import BaseSettings
+
+logger = logging.getLogger("awaithumans.server.core.config")
 
 
 class Settings(BaseSettings):
@@ -149,6 +152,17 @@ class Settings(BaseSettings):
         "env_file": ".env",
         "env_file_encoding": "utf-8",
         "case_sensitive": False,
+        # Two namespaces share the `AWAITHUMANS_` prefix: server-side
+        # (this Settings class) and SDK-side (`AWAITHUMANS_URL`,
+        # `AWAITHUMANS_ADMIN_API_TOKEN` when used purely as a client
+        # bearer, etc.). Without `extra="ignore"`, pydantic-settings'
+        # dotenv source treats any unknown prefixed key as a
+        # validation error and crashes Settings() at boot — so a
+        # shared `.env` with an SDK-only key like `AWAITHUMANS_URL`
+        # would kill `awaithumans dev`. We ignore unknown keys here
+        # and emit a startup WARNING via `unknown_env_keys()` so the
+        # operator still gets a heads-up if a key is actually a typo.
+        "extra": "ignore",
     }
 
     @property
@@ -190,3 +204,42 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
+
+
+def unknown_env_keys(env_path: Path | None = None) -> list[str]:
+    """Return AWAITHUMANS_* keys present in `.env` that this Settings ignores.
+
+    Pydantic-settings (with our `extra="ignore"`) silently drops keys it
+    doesn't recognize. That's the right default — keeps a shared `.env`
+    with SDK vars like `AWAITHUMANS_URL` from crashing the server — but
+    silent ignore can hide typos. This helper scans the `.env` file and
+    returns every `AWAITHUMANS_*` key that didn't map to a declared
+    server field, so the caller can WARN at boot.
+
+    Returns `[]` when the env file is absent or has no unknown keys.
+    """
+    if env_path is None:
+        # Mirror the Settings model_config value. Hardcoded to `.env`
+        # because pydantic types `env_file` broadly enough (Path |
+        # Sequence[Path | str]) that the .get() chain isn't worth
+        # narrowing — we only ever set a single relative-cwd path.
+        env_path = Path(".env")
+
+    if not env_path.is_file():
+        return []
+
+    known = {f"AWAITHUMANS_{name.upper()}" for name in Settings.model_fields}
+    unknown: list[str] = []
+    try:
+        contents = env_path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+
+    for raw_line in contents.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key = line.split("=", 1)[0].strip().upper()
+        if key.startswith("AWAITHUMANS_") and key not in known:
+            unknown.append(key)
+    return unknown

--- a/packages/python/tests/core/test_config_unknown_env_keys.py
+++ b/packages/python/tests/core/test_config_unknown_env_keys.py
@@ -1,0 +1,102 @@
+"""Regression tests for the dual-namespace `.env` issue.
+
+Before the fix, pydantic-settings' dotenv source enforced
+`extra="forbid"` by default on unknown keys. Any `AWAITHUMANS_*` key
+in a project's `.env` that wasn't a declared server field would crash
+`Settings()` at module-import — including SDK-side vars like
+`AWAITHUMANS_URL` that the SDK reads but the server has no field for.
+
+These tests pin three things:
+  1. Settings() instantiation does not crash when `.env` contains an
+     unrecognized AWAITHUMANS_* key.
+  2. `unknown_env_keys()` returns the unrecognized keys so the caller
+     (`app.create_app`) can emit a startup warning.
+  3. Known server keys are NOT in the unknown list.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from awaithumans.server.core.config import Settings, unknown_env_keys
+
+
+def test_settings_does_not_crash_on_unknown_awaithumans_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The bug-was-here case: an SDK-side var in a shared .env."""
+    env = tmp_path / ".env"
+    env.write_text(
+        "AWAITHUMANS_URL=http://localhost:3001\n"
+        "AWAITHUMANS_EMAIL_TRANSPORT=smtp\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    # Pydantic-settings reads `.env` from cwd by default.
+    Settings()  # MUST not raise
+
+
+def test_unknown_env_keys_reports_sdk_only_var(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    env.write_text(
+        "AWAITHUMANS_URL=http://localhost:3001\n"
+        "AWAITHUMANS_EMAIL_TRANSPORT=smtp\n",
+        encoding="utf-8",
+    )
+    unknown = unknown_env_keys(env_path=env)
+    assert unknown == ["AWAITHUMANS_URL"], (
+        "Expected AWAITHUMANS_URL flagged as unknown (SDK-side), "
+        f"AWAITHUMANS_EMAIL_TRANSPORT silently accepted. Got: {unknown}"
+    )
+
+
+def test_unknown_env_keys_ignores_known_server_vars(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    env.write_text(
+        "AWAITHUMANS_PAYLOAD_KEY=abc123\n"
+        "AWAITHUMANS_PUBLIC_URL=https://example.com\n"
+        "AWAITHUMANS_EMAIL_TRANSPORT=smtp\n",
+        encoding="utf-8",
+    )
+    assert unknown_env_keys(env_path=env) == []
+
+
+def test_unknown_env_keys_handles_comments_and_blanks(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    env.write_text(
+        "# top comment\n"
+        "\n"
+        "AWAITHUMANS_URL=http://x\n"
+        "   # indented comment\n"
+        "AWAITHUMANS_FAKE_VAR=oops\n",
+        encoding="utf-8",
+    )
+    assert sorted(unknown_env_keys(env_path=env)) == [
+        "AWAITHUMANS_FAKE_VAR",
+        "AWAITHUMANS_URL",
+    ]
+
+
+def test_unknown_env_keys_ignores_non_awaithumans_keys(tmp_path: Path) -> None:
+    """Other env vars (DATABASE_URL, PATH, etc.) are not our concern."""
+    env = tmp_path / ".env"
+    env.write_text(
+        "DATABASE_URL=postgresql://...\n"
+        "SOME_OTHER_KEY=value\n",
+        encoding="utf-8",
+    )
+    assert unknown_env_keys(env_path=env) == []
+
+
+def test_unknown_env_keys_returns_empty_when_no_env_file(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist.env"
+    assert unknown_env_keys(env_path=missing) == []
+
+
+def test_unknown_env_keys_is_case_insensitive(tmp_path: Path) -> None:
+    """`.env` lines can use lowercase; we normalize to uppercase."""
+    env = tmp_path / ".env"
+    env.write_text("awaithumans_url=http://x\n", encoding="utf-8")
+    assert unknown_env_keys(env_path=env) == ["AWAITHUMANS_URL"]


### PR DESCRIPTION
## Summary

Beta tester reported `awaithumans dev` crashing on boot with a pydantic `extra_forbidden` validation error after they added an SDK-side var (`AWAITHUMANS_URL=...`) to a project `.env`.

**Root cause:** pydantic-settings' dotenv source enforces `extra="forbid"` by default on unrecognized keys, while the env-var source filters silently on prefix match. Two different code paths, asymmetric behavior. The `AWAITHUMANS_` prefix is shared between the server (this Settings class) and the SDK (`AWAITHUMANS_URL`, etc.) — a `.env` with any SDK-side key crashed the server.

## Changes

- `core/config.py`: set `extra="ignore"` in `Settings.model_config` so the dotenv source matches the env-var source (silent ignore). Preserves the deliberate "two namespaces, one prefix" design.
- `core/config.py`: add `unknown_env_keys()` helper that scans `.env` for `AWAITHUMANS_*` keys not declared on Settings — surfaces typos without crashing.
- `server/app.py`: after `setup_logging`, call the helper and emit a single WARNING listing unknown keys with a pointer to the new docs section. Cheap one-shot scan at app creation.
- `docs/self-hosting/configuration.mdx`: new "Two namespaces under one prefix" section at the top of the page.
- `tests/core/test_config_unknown_env_keys.py`: 7 regression tests covering silent-ignore, helper output, comments/blanks/case-insensitivity, missing `.env`.

## Test plan

- [ ] `pytest tests/core/test_config_unknown_env_keys.py` — 7 new tests pass.
- [ ] Full Python test suite green (631 → 638 passing after this and PR #107).
- [ ] Manual: `.env` with `AWAITHUMANS_URL=…` no longer crashes server boot.
- [ ] Manual: same `.env` emits a single WARNING line naming the unrecognized key.
- [ ] Manual: typo like `AWAITHUMANS_SLAK_BOT_TOKEN=…` is also surfaced as a WARNING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)