### PR TITLE
chore(release): bump python and typescript SDKs to 0.1.3

### DIFF
--- a/.github/RELEASE_NOTES_v0.1.3.md
+++ b/.github/RELEASE_NOTES_v0.1.3.md
@@ -1,0 +1,91 @@
+# awaithumans v0.1.3 — patch release
+
+Three bug-fix PRs reported by early testers, landing two days after [v0.1.2](https://github.com/awaithumans/awaithumans/releases/tag/v0.1.2). No API changes; safe drop-in upgrade.
+
+## Highlights
+
+- 🌍 **Email-handoff URLs no longer expire instantly for East-of-UTC users.** A naive-datetime → local-time conversion was shifting URL expiries by the local-UTC offset. A UTC+1 user saw a fresh 10-minute task issue a link born 50 minutes expired. ([#107](https://github.com/awaithumans/awaithumans/pull/107))
+- 🧩 **`AWAITHUMANS_URL` in a shared `.env` no longer crashes the server on boot.** The SDK-side and server-side namespaces share a prefix; pydantic-settings' dotenv source used to enforce `extra="forbid"` by default. Now silently ignored, with a startup `WARNING` listing unknown keys so typos still get caught. ([#108](https://github.com/awaithumans/awaithumans/pull/108))
+- 📝 **First-touch DX: clearer install + CLI error.** Bare `pip install awaithumans` followed by `awaithumans dev` now exits with a what → why → fix → docs message pointing at the `[server]` extra, instead of a raw `ImportError` traceback. ([#106](https://github.com/awaithumans/awaithumans/pull/106))
+- 🤝 **Python and TypeScript stay mono-versioned at `0.1.3`** — even though the TypeScript SDK has no code changes this round, the version number tracks Python.
+
+## Upgrade
+
+### Python
+
+```bash
+pip install --upgrade "awaithumans[server]==0.1.3"
+# or whichever extras you use:
+#   pip install --upgrade "awaithumans[temporal]==0.1.3"
+#   pip install --upgrade "awaithumans[langgraph]==0.1.3"
+#   pip install --upgrade "awaithumans[verifier-claude]==0.1.3"
+```
+
+### TypeScript
+
+```bash
+npm install awaithumans@0.1.3
+# Or with peers if you're using the adapters:
+#   npm install awaithumans@0.1.3 @temporalio/workflow @temporalio/client
+#   npm install awaithumans@0.1.3 @langchain/langgraph
+```
+
+### Docker
+
+```bash
+docker pull ghcr.io/awaithumans/awaithumans:0.1.3
+# Or use the floating tag:
+docker pull ghcr.io/awaithumans/awaithumans:latest
+```
+
+## What changed
+
+### Fixed
+
+- **Email-handoff URL `e` parameter coerced to UTC before signing.** SQLite + SQLModel stores `task.timeout_at` tz-naive; `int(task.timeout_at.timestamp())` was treating the naive value as local time, shifting the expiry by the local-UTC offset. For users east of UTC this killed every freshly-issued email link. Fix extracted to a shared `awaithumans.utils.time.to_utc_unix` helper used by both the email and Slack handoff paths. Regression test runs under `TZ=Africa/Lagos`. ([#107](https://github.com/awaithumans/awaithumans/pull/107))
+
+- **`Settings()` ignores unknown `AWAITHUMANS_*` env keys** instead of raising `extra_forbidden`. Pydantic-settings' dotenv source enforced `extra="forbid"` by default; the env-var source did not. Asymmetric crash behavior killed any `awaithumans dev` whose `.env` contained an SDK-side key like `AWAITHUMANS_URL`. Now silently ignored with a one-shot startup `WARNING` listing unrecognized keys, so typos still surface. ([#108](https://github.com/awaithumans/awaithumans/pull/108))
+
+- **CLI bare-install error rewritten** to follow the what → why → fix → docs pattern with an actionable docs URL, instead of the previous one-liner. ([#106](https://github.com/awaithumans/awaithumans/pull/106))
+
+### Docs
+
+- **`docs/sdk/python.mdx` install matrix restructured** to lead with the two main paths (run a server vs call a server) and explain how to stack extras like `[server,temporal,verifier-claude]`. ([#106](https://github.com/awaithumans/awaithumans/pull/106))
+- **`docs/troubleshooting.mdx`** gains a `### cli-missing-server-extra` section so the new CLI error message links to a real anchor. ([#106](https://github.com/awaithumans/awaithumans/pull/106))
+- **`docs/self-hosting/configuration.mdx`** opens with a new "Two namespaces under one prefix" section documenting the SDK/server split and the new silent-ignore + warning policy. ([#108](https://github.com/awaithumans/awaithumans/pull/108))
+
+## What didn't change
+
+- **No API changes** — every public function signature in v0.1.2 still works identically in v0.1.3.
+- **No breaking changes** — `pip install --upgrade` and `npm install awaithumans@latest` are safe drop-in upgrades.
+- **No TypeScript SDK source changes** — TS bump is mono-version sync only.
+
+## Verify the upgrade landed
+
+After upgrading the Python package:
+
+```bash
+python -c "import awaithumans; print(awaithumans.__version__)"
+# → 0.1.3
+
+awaithumans dev
+# In another terminal, on a UTC+ machine: create a task with
+# timeout_seconds=600 and click the "Open task" link in the email.
+# You should land on the task page, not a 400 "Sign-in link is
+# invalid or expired" error.
+```
+
+After upgrading the TS package:
+
+```bash
+node -e "console.log(require('awaithumans/package.json').version)"
+# → 0.1.3
+```
+
+## Links
+
+- 📚 [Documentation](https://awaithumans.dev/docs)
+- 🆕 [What's new](https://awaithumans.dev/docs/changelog)
+- 🔒 Security disclosures: **security@awaithumans.dev**
+- 💬 [Discord](https://discord.gg/Kewdh7vjdc) · [GitHub Discussions](https://github.com/awaithumans/awaithumans/discussions)
+- 🐛 [v0.1.2 → v0.1.3 full diff](https://github.com/awaithumans/awaithumans/compare/v0.1.2...v0.1.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,58 @@ _Nothing yet — open the next change here._
 
 ---
 
+## [0.1.3] — 2026-05-14
+
+### Fixed
+
+- **Email-handoff URLs no longer expire instantly for East-of-UTC users.**
+  SQLite + SQLModel stores `task.timeout_at` tz-naive;
+  `int(task.timeout_at.timestamp())` was interpreting the naive value as
+  local time, shifting the URL's `e` parameter by the local-UTC offset.
+  For users east of UTC, a fresh 10-minute task was issued a link born
+  already expired by the offset (e.g. UTC+1 → 50 minutes past expiry at
+  creation time). Fix extracted to a shared
+  `awaithumans.utils.time.to_utc_unix` helper used by both the email
+  and Slack handoff paths. Regression tests run under
+  `TZ=Africa/Lagos`. ([#107](https://github.com/awaithumans/awaithumans/pull/107))
+
+- **Unknown `AWAITHUMANS_*` keys in `.env` are silently ignored**
+  (with a one-shot startup `WARNING` listing them) instead of crashing
+  `Settings()` on boot with a pydantic `extra_forbidden` error.
+  The `AWAITHUMANS_` prefix is shared by the SDK (`AWAITHUMANS_URL`,
+  etc.) and the server; pydantic-settings' dotenv source previously
+  enforced `extra="forbid"` by default, killing the server whenever a
+  shared `.env` carried any SDK-side key. Typos still surface via the
+  warning. ([#108](https://github.com/awaithumans/awaithumans/pull/108))
+
+- **CLI `awaithumans dev` error message rewritten** when the bare SDK
+  is installed without the `[server]` extras. Now follows the
+  what → why → fix → docs pattern with an actionable docs URL,
+  instead of a one-line `SystemExit`. ([#106](https://github.com/awaithumans/awaithumans/pull/106))
+
+### Docs
+
+- **`docs/sdk/python.mdx` install section restructured** to lead with
+  the two main install paths (run a server vs call a server) and
+  explain how to stack extras like `[server,temporal,verifier-claude]`.
+  ([#106](https://github.com/awaithumans/awaithumans/pull/106))
+- **`docs/troubleshooting.mdx`** gains a new
+  `### cli-missing-server-extra` section so the URL in the new CLI
+  error message resolves to a real anchor.
+  ([#106](https://github.com/awaithumans/awaithumans/pull/106))
+- **`docs/self-hosting/configuration.mdx`** opens with a new
+  "Two namespaces under one prefix" section documenting the
+  SDK/server split and the silent-ignore + warning policy.
+  ([#108](https://github.com/awaithumans/awaithumans/pull/108))
+
+### Versions
+
+- Python `awaithumans`: `0.1.2` → `0.1.3`
+- TypeScript `awaithumans`: `0.1.2` → `0.1.3` (mono-version sync; no
+  TypeScript SDK source changes this release)
+
+---
+
 ## [0.1.2] — 2026-05-12
 
 ### Fixed

--- a/packages/python/awaithumans/__init__.py
+++ b/packages/python/awaithumans/__init__.py
@@ -21,7 +21,7 @@ Usage (sync):
 """
 from __future__ import annotations
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 from awaithumans.client import await_human, await_human_sync
 from awaithumans.embed import EmbedTokenResult, embed_token, embed_token_sync

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -20,7 +20,7 @@ packages = ["awaithumans"]
 
 [project]
 name = "awaithumans"
-version = "0.1.2"
+version = "0.1.3"
 description = "The human layer for AI agents. Your agents already await promises. Now they can await humans."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/typescript-sdk/package-lock.json
+++ b/packages/typescript-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "awaithumans",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "awaithumans",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.0",

--- a/packages/typescript-sdk/package.json
+++ b/packages/typescript-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awaithumans",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "The human layer for AI agents. Your agents already await promises. Now they can await humans.",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary

Roll up the three patch fixes merged on top of v0.1.2 into a release-ready version bump:

- **#106** — install/CLI/docs DX: lead quickstart with `[server]` extras + polish the bare-install CLI error
- **#107** — email-handoff URL tz fix for East-of-UTC users (the one breaking your Nigeria-based tester)
- **#108** — silent-ignore unknown `AWAITHUMANS_*` env keys instead of crashing on `.env` load

No API changes; safe drop-in upgrade.

## Why TS also bumps

TypeScript SDK has no source changes this round but mono-versions with Python per the convention established in [v0.1.1's release notes](.github/RELEASE_NOTES_v0.1.1.md). If you'd rather let TS stay at `0.1.2` for this release, drop the two TS version lines from this PR before merging — the rest still publishes cleanly.

## Files

- `packages/python/pyproject.toml` — `0.1.2` → `0.1.3`
- `packages/python/awaithumans/__init__.py` — `__version__` → `0.1.3`
- `packages/typescript-sdk/package.json` — `0.1.2` → `0.1.3`
- `packages/typescript-sdk/package-lock.json` — `0.1.2` → `0.1.3` (both occurrences)
- `CHANGELOG.md` — new `[0.1.3]` block documenting the three fixes + version sync
- `.github/RELEASE_NOTES_v0.1.3.md` — new file, mirrors the v0.1.1 format

## After merge — release checklist

- [ ] Tag `v0.1.3` on the merge commit
- [ ] Build the Python wheel (`cd packages/python && uv build` or `python -m build`)
- [ ] Upload to PyPI (`twine upload packages/python/dist/awaithumans-0.1.3*`)
- [ ] Build + publish the TS package (`cd packages/typescript-sdk && npm publish`)
- [ ] Docker image — `docker.yml` workflow auto-builds on tag push
- [ ] Verify `pip install --upgrade awaithumans[server]==0.1.3` and `npm install awaithumans@0.1.3` resolve
- [ ] Sanity test: bare-install → `awaithumans dev` should now exit with the polished error; full install → boot + create a task on a UTC+ machine and click the email link

🤖 Generated with [Claude Code](https://claude.com/claude-code)