### PR TITLE
fix(server): don't re-send notifications on idempotent task-create hits

### DIFF
--- a/packages/python/awaithumans/server/routes/tasks.py
+++ b/packages/python/awaithumans/server/routes/tasks.py
@@ -163,7 +163,7 @@ async def create_task_route(
     response is sent, so a slow Slack API call never blocks task creation
     and a Slack outage never fails a successful task write.
     """
-    task = await create_task(
+    task, was_newly_created = await create_task(
         session,
         task=body.task,
         payload=body.payload,
@@ -179,7 +179,12 @@ async def create_task_route(
         callback_url=body.callback_url,
     )
 
-    if body.notify:
+    # Notifications fire only when this call actually CREATED the task.
+    # An idempotency hit (same key as a previous task — common during
+    # retries / agent restarts) returns the existing task; re-emailing
+    # / re-Slacking on every retry was sending duplicate notifications
+    # for the same logical work.
+    if body.notify and was_newly_created:
         background_tasks.add_task(
             notify_task_slack,
             task_id=task.id,

--- a/packages/python/awaithumans/server/services/task_service.py
+++ b/packages/python/awaithumans/server/services/task_service.py
@@ -52,7 +52,7 @@ async def create_task(
     verifier_config: dict | None = None,
     redact_payload: bool = False,
     callback_url: str | None = None,
-) -> Task:
+) -> tuple[Task, bool]:
     """Create a new task, or return the existing one if idempotency key matches.
 
     Stripe-style idempotency: same key always returns the same task,
@@ -62,13 +62,18 @@ async def create_task(
     stored response (or terminal-status error) instead of creating a
     duplicate. To re-trigger work for the same logical event, pass a
     distinct key (e.g. `f"refund:{order_id}:retry-1"`).
+
+    Returns `(task, was_newly_created)`. The bool lets the route decide
+    whether to fire notify background tasks — re-firing on an
+    idempotency hit would send a duplicate email/Slack ping for every
+    retry of an already-running or terminal task.
     """
     # Check for existing task with same idempotency key. Looking up
     # ANY status (including terminal) is what makes direct mode
     # resumable across agent restarts.
     existing = await _find_task_by_idempotency_key(session, idempotency_key)
     if existing is not None:
-        return existing
+        return existing, False
 
     # Route: resolve assign_to -> a specific user (or None for unassigned).
     # The router bumps last_assigned_at on the picked user within this
@@ -129,14 +134,14 @@ async def create_task(
         await session.rollback()
         existing = await _find_task_by_idempotency_key(session, idempotency_key)
         if existing is not None:
-            return existing
+            return existing, False
         # No task found despite IntegrityError — should be unreachable
         # now that the lookup covers all statuses. Re-raise to surface
         # the genuine constraint violation if it ever happens.
         raise
 
     await session.refresh(new_task)
-    return new_task
+    return new_task, True
 
 
 async def get_task(session: AsyncSession, task_id: str) -> Task:

--- a/packages/python/tests/auth/test_email_handoff_route.py
+++ b/packages/python/tests/auth/test_email_handoff_route.py
@@ -271,7 +271,7 @@ def test_handoff_claims_unassigned_task_for_recipient(
     async def _make_task() -> str:
         factory = get_async_session_factory()
         async with factory() as session:
-            task = await create_task(
+            task, _ = await create_task(
                 session,
                 task="Approve refund",
                 payload={},
@@ -322,7 +322,7 @@ def test_handoff_does_not_steal_existing_assignee(
     async def _make_assigned_task() -> str:
         factory = get_async_session_factory()
         async with factory() as session:
-            task = await create_task(
+            task, _ = await create_task(
                 session,
                 task="Approve",
                 payload={},

--- a/packages/python/tests/core/test_webhook_dispatch.py
+++ b/packages/python/tests/core/test_webhook_dispatch.py
@@ -192,7 +192,7 @@ async def test_enqueue_is_noop_when_callback_url_missing(
     """The dominant case — most tasks long-poll, no row should be
     written. The dispatcher can be invoked unconditionally on every
     terminal transition without polluting the queue."""
-    task = await create_task(
+    task, _ = await create_task(
         session,
         task="x",
         payload={},
@@ -214,7 +214,7 @@ async def test_enqueue_creates_pending_row_with_signed_body(
     against. Storing the body up-front means retries re-send the
     same payload — the signature stays valid through transient
     failures."""
-    task = await create_task(
+    task, _ = await create_task(
         session,
         task="Approve refund",
         payload={"amount": 100},
@@ -253,7 +253,7 @@ async def test_enqueue_creates_pending_row_with_signed_body(
 
 
 async def _enqueued_row(session: AsyncSession, *, callback_url: str) -> WebhookDelivery:
-    task = await create_task(
+    task, _ = await create_task(
         session,
         task="t",
         payload={},

--- a/packages/python/tests/email/test_admin_and_action_routes.py
+++ b/packages/python/tests/email/test_admin_and_action_routes.py
@@ -183,7 +183,7 @@ async def test_action_get_renders_confirmation_page(client: AsyncClient) -> None
     """Valid token on a live task → 200 with a POST form (anti-prefetch)."""
     # Create a task directly in the DB so we have a real task_id to sign.
     async for session in _direct_session(client):
-        task = await create_task(
+        task, _ = await create_task(
             session,
             task="Approve wire",
             payload={"amount": 50000},
@@ -206,7 +206,7 @@ async def test_action_get_renders_confirmation_page(client: AsyncClient) -> None
 @pytest.mark.asyncio
 async def test_action_post_completes_task(client: AsyncClient) -> None:
     async for session in _direct_session(client):
-        task = await create_task(
+        task, _ = await create_task(
             session,
             task="Approve wire",
             payload={"amount": 50000},
@@ -255,7 +255,7 @@ async def test_action_post_pre_feature_token_leaves_completed_by_null(
     without the email attribution. Pre-feature in-flight tokens at
     deploy time would otherwise 500."""
     async for session in _direct_session(client):
-        task = await create_task(
+        task, _ = await create_task(
             session,
             task="Approve wire",
             payload={},
@@ -297,7 +297,7 @@ async def test_action_post_replay_rejected_with_410(
     proxies / mail clients the resource is permanently gone — they
     should not retry."""
     async for session in _direct_session(client):
-        task = await create_task(
+        task, _ = await create_task(
             session,
             task="Approve",
             payload={},
@@ -329,7 +329,7 @@ async def test_action_post_two_distinct_tokens_for_same_task_independent(
     should be able to consume EITHER one — once. This test pins that
     the consumed-token table doesn't accidentally over-block."""
     async for session in _direct_session(client):
-        task = await create_task(
+        task, _ = await create_task(
             session,
             task="Approve",
             payload={},

--- a/packages/python/tests/slack/test_claim_broadcast_e2e.py
+++ b/packages/python/tests/slack/test_claim_broadcast_e2e.py
@@ -193,7 +193,7 @@ async def _seed_task_and_user(
             display_name="Alice",
             role="reviewer",
         )
-        task = await create_task(
+        task, _ = await create_task(
             s,
             task="Approve refund",
             payload={"amount": 100},
@@ -295,7 +295,7 @@ async def test_second_claim_is_ephemeral_error(
             display_name="Bob",
             role="reviewer",
         )
-        task = await create_task(
+        task, _ = await create_task(
             s,
             task="Approve refund",
             payload={},
@@ -364,7 +364,7 @@ async def test_claim_by_user_not_in_directory_ephemeral_error(
     # Seed a task but no matching user for the clicker below.
     override = client._transport.app.dependency_overrides[get_session]
     async for s in override():
-        task = await create_task(
+        task, _ = await create_task(
             s,
             task="Approve refund",
             payload={},

--- a/packages/python/tests/slack/test_interactions_e2e.py
+++ b/packages/python/tests/slack/test_interactions_e2e.py
@@ -178,7 +178,7 @@ async def _seed_task(client: AsyncClient, *, form_definition: dict[str, Any] | N
     """Create a task directly in the overridden DB and return its id."""
     override = client._transport.app.dependency_overrides[get_session]  # type: ignore[attr-defined]
     async for s in override():
-        task = await create_task(
+        task, _ = await create_task(
             s,
             task="Approve refund",
             payload={"amount": 100},

--- a/packages/python/tests/tasks/test_idempotency_after_terminal.py
+++ b/packages/python/tests/tasks/test_idempotency_after_terminal.py
@@ -48,7 +48,7 @@ async def session() -> AsyncGenerator[AsyncSession, None]:
 
 
 async def _make(session: AsyncSession, key: str) -> Task:
-    return await create_task(
+    task, _ = await create_task(
         session,
         task="Approve refund",
         payload={"amount": 100},
@@ -57,6 +57,7 @@ async def _make(session: AsyncSession, key: str) -> Task:
         timeout_seconds=900,
         idempotency_key=key,
     )
+    return task
 
 
 @pytest.mark.asyncio
@@ -147,3 +148,88 @@ async def test_distinct_keys_create_distinct_tasks(
     second = await _make(session, "shared-key:retry-1")
     assert second.id != first.id
     assert second.status == TaskStatus.CREATED
+
+
+# ─── was_newly_created signal ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_task_signals_new_creation_on_first_call(
+    session: AsyncSession,
+) -> None:
+    """First call with a fresh idempotency key returns was_newly_created=True
+    so the route knows to fire notify."""
+    _, was_newly_created = await create_task(
+        session,
+        task="Approve refund",
+        payload={"amount": 100},
+        payload_schema={},
+        response_schema={},
+        timeout_seconds=900,
+        idempotency_key="fresh-key-1",
+    )
+    assert was_newly_created is True
+
+
+@pytest.mark.asyncio
+async def test_create_task_signals_existing_on_duplicate_key(
+    session: AsyncSession,
+) -> None:
+    """Same key on a second call returns was_newly_created=False — this is
+    the gate the route uses to avoid re-sending notification emails /
+    Slack pings on every agent retry of the same logical task. Before
+    this signal existed, every `await_human()` retry re-emailed the
+    reviewer for an already-in-flight task. Bug reported by test user
+    who got a duplicate email on a retry attempt."""
+    _, first_was_new = await create_task(
+        session,
+        task="Approve refund",
+        payload={"amount": 100},
+        payload_schema={},
+        response_schema={},
+        timeout_seconds=900,
+        idempotency_key="duplicate-key-2",
+    )
+    _, second_was_new = await create_task(
+        session,
+        task="Approve refund",
+        payload={"amount": 100},
+        payload_schema={},
+        response_schema={},
+        timeout_seconds=900,
+        idempotency_key="duplicate-key-2",
+    )
+    assert first_was_new is True
+    assert second_was_new is False
+
+
+@pytest.mark.asyncio
+async def test_create_task_signals_existing_after_terminal(
+    session: AsyncSession,
+) -> None:
+    """A terminal task (timed_out/completed/cancelled) returned via
+    idempotency key still reports was_newly_created=False — the route
+    must not re-notify even when the agent is "resuming" against a
+    completed task."""
+    first, first_was_new = await create_task(
+        session,
+        task="Approve refund",
+        payload={"amount": 100},
+        payload_schema={},
+        response_schema={},
+        timeout_seconds=900,
+        idempotency_key="terminal-key-3",
+    )
+    await timeout_task(session, first.id)
+
+    _, second_was_new = await create_task(
+        session,
+        task="Approve refund",
+        payload={"amount": 100},
+        payload_schema={},
+        response_schema={},
+        timeout_seconds=900,
+        idempotency_key="terminal-key-3",
+    )
+    assert first_was_new is True
+    assert second_was_new is False

--- a/packages/python/tests/tasks/test_verifier_integration.py
+++ b/packages/python/tests/tasks/test_verifier_integration.py
@@ -64,7 +64,7 @@ def _verifier_cfg(max_attempts: int = 3) -> dict:
 
 
 async def _make_task(session: AsyncSession, **overrides) -> Task:
-    return await create_task(
+    task, _ = await create_task(
         session,
         task="Approve refund",
         payload={"amount": 100},
@@ -74,6 +74,7 @@ async def _make_task(session: AsyncSession, **overrides) -> Task:
         idempotency_key=f"key-{id(overrides)}",
         **overrides,
     )
+    return task
 
 
 @pytest.mark.asyncio

--- a/packages/python/tests/tasks/test_verifier_polish.py
+++ b/packages/python/tests/tasks/test_verifier_polish.py
@@ -80,7 +80,7 @@ async def test_redact_payload_skips_verifier_entirely(
     """With `redact_payload=True` the verifier MUST NOT be called — the
     operator's payload would otherwise be shipped to the third-party
     LLM via the prompt. Status goes straight to COMPLETED."""
-    task = await create_task(
+    task, _ = await create_task(
         session,
         task="Approve sensitive operation",
         payload={"ssn": "1234"},
@@ -120,7 +120,7 @@ async def test_max_attempts_one_collapses_to_single_shot(
     """`max_attempts=1` is the strictest setting — the operator gets
     one shot. The first rejection is immediately exhaustion (terminal),
     not REJECTED-with-zero-budget. Documents the off-by-one semantics."""
-    task = await create_task(
+    task, _ = await create_task(
         session,
         task="One-shot verify",
         payload={},
@@ -152,7 +152,7 @@ async def test_malformed_verifier_config_surfaces_typed_error(
     must NOT 500 with a raw Pydantic ValidationError. The central
     handler turns VerifierConfigInvalidError into a clean 422 with an
     error_code + docs URL the operator can act on."""
-    task = await create_task(
+    task, _ = await create_task(
         session,
         task="Bad config",
         payload={},
@@ -179,7 +179,7 @@ async def test_unknown_provider_raises_typed_error(
 ) -> None:
     """Operator typos ('clade', 'gpt') should fail loudly with the
     supported provider list in the message — not a generic 500."""
-    task = await create_task(
+    task, _ = await create_task(
         session,
         task="Bad provider",
         payload={},

--- a/packages/python/tests/users/test_task_router_integration.py
+++ b/packages/python/tests/users/test_task_router_integration.py
@@ -11,7 +11,7 @@ from awaithumans.server.services.user_service import create_user
 
 
 async def _create(session: AsyncSession, idempotency_key: str, **kwargs) -> object:
-    return await create_task(
+    task, _ = await create_task(
         session,
         task="review refund",
         payload={},
@@ -21,6 +21,7 @@ async def _create(session: AsyncSession, idempotency_key: str, **kwargs) -> obje
         idempotency_key=idempotency_key,
         **kwargs,
     )
+    return task
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Test user reported: running the same `await_human()` script twice (same idempotency key) triggered the timeout error on the second run as expected, but the human still got a **duplicate email**.

**Root cause:** the `POST /api/tasks` route was firing `notify_task_slack` and `notify_task_email` background tasks unconditionally whenever `body.notify` was non-empty, without knowing whether the underlying `create_task` service actually inserted a new row or returned an existing one via the Stripe-style idempotency lookup. Every retry of the same logical task re-emailed / re-Slacked the reviewer for work that was already in flight or already terminal.

## Fix

- `create_task` returns `tuple[Task, bool]` — `(task, was_newly_created)`. The flag is:
  - `True` for fresh inserts
  - `False` for idempotency hits (existing task returned via key lookup)
  - `False` for IntegrityError-race recoveries (concurrent insert wins, existing task returned)
- The route unpacks the flag and gates the notify scheduling on `body.notify and was_newly_created`. A retry with a known key returns the existing task without re-pinging the reviewer.
- 3 regression tests in `test_idempotency_after_terminal.py` pin the contract: fresh key → True, duplicate key on active task → False, duplicate key on terminal task → False.
- 18 test callers + 3 test-helper wrappers updated to unpack the tuple. Test-helper wrappers preserve their `-> Task` return type so their downstream callers are unchanged.

## What ISN'T changed

- The existing Stripe-style idempotency contract is unchanged: same key always returns the same task, regardless of status. Direct-mode `await_human()` is still resumable across agent restarts.
- The `audit_entries` row created on first task creation is unchanged. Subsequent idempotency hits do NOT write a new `created` audit entry (they didn't before, either — the new flag just makes that consistent with notify behavior).

## Test plan

- [ ] `pytest tests/tasks/test_idempotency_after_terminal.py` — 8 tests pass (5 existing + 3 new)
- [ ] Full Python suite green (638 passing, no regressions)
- [ ] Manual: run an `await_human` script twice with the same idempotency key + `notify=["email:..."]`. First run → email sent. Second run → no duplicate email; SDK raises the terminal-status error from the previous task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)