### PR TITLE
chore(readme): Tier 2 — copy-pasteable quickstart + 'what you can build' use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,21 +66,20 @@ per project.
 
 ## Quick start
 
-**One terminal:**
+**60 seconds. Two terminals.** First-time setup needs a browser click; everything else is paste-and-run.
+
+**Terminal 1** — server + dashboard:
 
 ```bash
-pip install "awaithumans[server]"
-awaithumans dev
+pip install "awaithumans[server]" && awaithumans dev
 ```
 
-You get the API server + dashboard on `http://localhost:3001`. On first
-run it prints a setup URL; open it, create the initial operator
-account, you're in.
+Click the setup URL it prints, create your operator account. The dashboard is now at `http://localhost:3001`.
 
-**Another terminal:**
+**Terminal 2** — paste this whole block:
 
-```python
-# refund.py
+```bash
+pip install awaithumans pydantic && cat > /tmp/refund.py <<'PY'
 from awaithumans import await_human_sync
 from pydantic import BaseModel
 
@@ -91,24 +90,38 @@ class RefundRequest(BaseModel):
 class Decision(BaseModel):
     approved: bool
 
-decision = await_human_sync(
-    task="Approve refund",
+d = await_human_sync(
+    task="Approve refund of $180?",
     payload_schema=RefundRequest,
     payload=RefundRequest(order_id="A-4721", amount_usd=180),
     response_schema=Decision,
-    timeout_seconds=900,
+    timeout_seconds=300,
 )
-print("approved" if decision.approved else "rejected")
+print("approved" if d.approved else "rejected")
+PY
+python /tmp/refund.py
 ```
 
-```bash
-python refund.py
-```
+The script blocks. Open the dashboard, click the pending task, hit **Approve**. The script unblocks with the typed `Decision`.
 
-Open the dashboard, click the task, approve it. The Python script
-unblocks with `decision.approved == True`.
+That's the full loop. From here, swap the schema for your own, add `notify=["slack:#ops", "email:ops@yourco.com"]` to route the task elsewhere, or wrap the call in a Temporal / LangGraph workflow.
 
-Full walkthrough: [`examples/quickstart/`](./examples/quickstart/).
+More examples — refund, KYC, content moderation, Slack-native, Temporal, LangGraph — in [`examples/`](./examples/).
+
+---
+
+## What you can build with it
+
+Real production patterns this primitive collapses into a single function call:
+
+- **High-value approvals** — refunds above a threshold, wire transfers, plan upgrades, contract renewals. Agent prepares the case (Pydantic payload), human signs off with a typed decision (approved + reason).
+- **KYC / identity review** — agent flags borderline documents, human inspects, sends back `verified: bool` with notes. Pair with `verifier=verify_with_claude(...)` to pre-check the reviewer's reasoning.
+- **Content moderation escalation** — AI tags a borderline post; instead of hard-deciding, it calls `await_human()` with the content + AI's reasoning + a Switch for keep/remove. Reviewer's decision flows back into the moderation pipeline.
+- **Agent-generated code review** — your LLM drafts a pull request; before merge, the agent waits for a human to approve via Slack. The "Claim this task" button assigns it to whoever's on rotation.
+- **Customer-success escalation** — support agent answers FAQs; on a complex thread, it escalates to a human with the full transcript as the payload. Human writes the reply, agent posts it.
+- **Scrape-and-CAPTCHA fallback** — automation hits a CAPTCHA wall, calls `await_human()` with the screenshot, a human solves it, agent resumes the scrape.
+
+Anything where an LLM's confidence is too low, the liability too high, or the source of truth lives outside the model's reach — it's HITL-shaped, and this primitive fits.
 
 ---
 


### PR DESCRIPTION
## Summary

Two more Tier 2 items from the marketing roadmap, focused on the root README:

1. **Copy-pasteable Quick start** — rewrites the section so the agent code is a single bash heredoc that writes `/tmp/refund.py` then runs it. Previously needed three separate code blocks (Python source + bash to run). Now: paste the whole thing into Terminal 2, hit enter, the script blocks waiting for the human. 60 seconds from zero to working, the first-time setup browser click being the only manual step.
2. **New "What you can build with it" section** — six concrete production patterns positioned between Quick start and the Slack section, so the reader goes "I get the basic loop" → "here's what I'd actually use it for" → "now I want Slack / durable / verifier". Patterns cover the three HITL walls from the problem statement and each one names the actual API mapping (Pydantic payload, Switch primitive, claim-on-broadcast, etc.) so it's not just a wish list.

## What's new

```markdown
## What you can build with it

- **High-value approvals** — refunds, wires, plan upgrades…
- **KYC / identity review** — agent flags, human verifies…
- **Content moderation escalation** — AI tags, human decides…
- **Agent-generated code review** — LLM drafts PR, human approves…
- **Customer-success escalation** — agent handles FAQs, escalates complex…
- **Scrape-and-CAPTCHA fallback** — automation hits a wall, human resolves…
```

Plus a closing sentence linking the section to the philosophical "three walls" framing.

## What did NOT change

- Zero code changes
- Existing examples, code blocks, and other sections unchanged
- Python and TypeScript package READMEs untouched (they're install-and-use surface; this is the evaluate-and-decide surface)

## Tier 2 remaining

- ✅ Hero structure + logo (PR #120, awaiting merge)
- ✅ "Why awaithumans" comparison table (PR #120, awaiting merge)
- ✅ Copy-pasteable Quick start (this PR)
- ✅ Real example-agent use cases — covered as a list rather than full code blocks (this PR)
- ⏳ 30-second asciinema cast — needs you to record one (or generate from the example) before I can wire it in

## Test plan

- [ ] Paste the Terminal 2 block into a fresh shell on a clean machine, confirm it produces a working `/tmp/refund.py` and blocks waiting for the human
- [ ] GitHub preview renders the use-case list cleanly
- [ ] Python test suite still green (666 passing; one flaky test unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)