### PR TITLE
chore(release): bump python and typescript SDKs to 0.1.4

### DIFF
--- a/.github/RELEASE_NOTES_v0.1.4.md
+++ b/.github/RELEASE_NOTES_v0.1.4.md
@@ -1,0 +1,80 @@
+# awaithumans v0.1.4 — eight bug-fix / DX PRs + a full marketing refresh
+
+Three days after [v0.1.3](https://github.com/awaithumans/awaithumans/releases/tag/v0.1.3). Eight server / dashboard PRs from beta-tester feedback, plus the full GitHub / PyPI / npm README refresh. No API-breaking changes; safe drop-in upgrade.
+
+## Highlights
+
+- 🔔 **`notification_failed` audit + banner** — when an email or Slack send can't deliver, the task page now shows an amber banner with the failure reason and the inline audit timeline gets a matching row. Email surfaces 4 failure modes; Slack surfaces 3. Operators no longer have to grep the server log to find out why a human never got pinged. ([#111](https://github.com/awaithumans/awaithumans/pull/111))
+- 🌍 **East-of-UTC handoff URLs work again** — SQLite stores `task.timeout_at` tz-naive, and the email notifier was calling `.timestamp()` on it which treats the value as local time. UTC+1 users were getting links that expired 3,000 seconds before they were issued. Fix extracted to a shared `to_utc_unix` helper used by both email + Slack handoffs. ([#113](https://github.com/awaithumans/awaithumans/pull/113))
+- 🔁 **No more duplicate notification emails on retries.** The create-task route was firing notify tasks unconditionally; a retry with the same idempotency key re-emailed the reviewer for an already-running task. Now gated on `was_newly_created`. ([#114](https://github.com/awaithumans/awaithumans/pull/114))
+- 🪪 **`GET /api/version`** — new public endpoint for ops monitoring + pre-auth SDK compatibility probes. Returns `{"name":"awaithumans","version":"0.1.4"}`. ([#117](https://github.com/awaithumans/awaithumans/pull/117))
+- 🏷 **`Idempotent-Replayed: true` header** on `POST /api/tasks` when an existing task is returned via idempotency key. Stripe-style — status stays `201`, the header is the signal. Documented in `docs/api/overview.mdx`. ([#118](https://github.com/awaithumans/awaithumans/pull/118))
+- 📍 **OpenAPI docs moved to `/api/docs`** to match the docs page contract — the FastAPI defaults at root `/docs` were a framework leak. Auth-bypass updated; FastAPI's `info.version` field now reads from `awaithumans.__version__`. ([#115](https://github.com/awaithumans/awaithumans/pull/115))
+- 🎨 **Brand-styled HTML error page** on email/Slack handoff link failure. Recipients clicking stale links no longer see raw FastAPI JSON in their browser. ([#116](https://github.com/awaithumans/awaithumans/pull/116))
+- ⚠️ **Boot-time channel-config validator** — `EMAIL_TRANSPORT=smtp` set without `SMTP_HOST`? Warning fires at server start naming the missing env var. Same for resend / Slack OAuth / single-workspace Slack. ([#112](https://github.com/awaithumans/awaithumans/pull/112))
+- 🤝 **Python and TypeScript stay mono-versioned at `0.1.4`** — TS SDK source unchanged this release (all new behaviour rides the existing wire protocol), but the version number tracks Python.
+
+Plus a full GitHub / PyPI / npm README refresh: hero block with brand logo, "Why awaithumans" comparison table (capturing "humanlayer alternative" search traffic), copy-pasteable Quick start, "What you can build with it" use-case list, prominent adoption badges, 10 new GitHub repo topics, keyword expansion across PyPI + npm. ([#119](https://github.com/awaithumans/awaithumans/pull/119), [#120](https://github.com/awaithumans/awaithumans/pull/120), [#121](https://github.com/awaithumans/awaithumans/pull/121), [#122](https://github.com/awaithumans/awaithumans/pull/122))
+
+## Upgrade
+
+### Python
+
+```bash
+pip install --upgrade "awaithumans[server]==0.1.4"
+# or whichever extras you use:
+#   pip install --upgrade "awaithumans[temporal]==0.1.4"
+#   pip install --upgrade "awaithumans[langgraph]==0.1.4"
+#   pip install --upgrade "awaithumans[verifier-claude]==0.1.4"
+```
+
+### TypeScript
+
+```bash
+npm install awaithumans@0.1.4
+# Or with peers if you're using the adapters:
+#   npm install awaithumans@0.1.4 @temporalio/workflow @temporalio/client
+#   npm install awaithumans@0.1.4 @langchain/langgraph
+```
+
+### Docker
+
+```bash
+docker pull ghcr.io/awaithumans/awaithumans:0.1.4
+docker pull ghcr.io/awaithumans/awaithumans:latest
+```
+
+## What didn't change
+
+- **No API changes** — every function in v0.1.3 still works identically in v0.1.4.
+- **No breaking changes** — `pip install --upgrade` and `npm install awaithumans@latest` are safe drop-ins.
+- **TypeScript SDK source unchanged** — version bump is mono-version sync only. All new server behaviour (Idempotent-Replayed header, /api/version, /api/docs path, friendly error pages) is observable from TS without any client-side changes.
+
+## Verify the upgrade landed
+
+```bash
+python -c "import awaithumans; print(awaithumans.__version__)"
+# → 0.1.4
+
+awaithumans dev
+# Boot logs should now include a "channel-config" WARNING line if any
+# email/slack channel is half-configured, instead of silently failing
+# at first send.
+
+# Hit the new version endpoint:
+curl http://localhost:3001/api/version
+# → {"name":"awaithumans","version":"0.1.4"}
+```
+
+```bash
+node -e "console.log(require('awaithumans/package.json').version)"
+# → 0.1.4
+```
+
+## Links
+
+- 📚 [Documentation](https://docs.awaithumans.dev)
+- 🆕 [What's new](https://docs.awaithumans.dev/changelog)
+- 🔒 Security disclosures: **security@awaithumans.dev**
+- 💬 [Discord](https://discord.gg/Kewdh7vjdc) · [GitHub Discussions](https://github.com/awaithumans/awaithumans/discussions)
+- 🐛 [v0.1.3 → v0.1.4 full diff](https://github.com/awaithumans/awaithumans/compare/v0.1.3...v0.1.4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,113 @@ _Nothing yet — open the next change here._
 
 ---
 
+## [0.1.4] — 2026-05-17
+
+Eight PRs of bug fixes and DX improvements caught by beta-tester
+feedback over the 0.1.3 → 0.1.4 window, plus the full marketing
+README refresh.
+
+### Added
+
+- **`GET /api/version`** — public endpoint returning `{"name":
+  "awaithumans", "version": "..."}`. Useful for ops monitoring,
+  pre-auth SDK compatibility probes, and reverse-proxy
+  misconfig debugging. Auth-bypass entry added so it works without
+  a session. ([#117](https://github.com/awaithumans/awaithumans/pull/117))
+- **`Idempotent-Replayed: true` response header** on
+  `POST /api/tasks` when the call returns an existing task via the
+  idempotency key. Status stays `201` (matches Stripe's
+  contract — flipping to `200` would break clients that check
+  the specific code). Documented in `docs/api/overview.mdx`.
+  ([#118](https://github.com/awaithumans/awaithumans/pull/118))
+- **`notification_failed` audit entries + banner** on the task
+  detail page when an email or Slack send couldn't deliver. The
+  previous silent-drop behaviour left operators wondering why
+  a human never got pinged. Email surfaces all four failure
+  modes (no transport configured, no From: address, transport
+  error, internal error); Slack surfaces three (no client, target
+  not found, post-message error). ([#111](https://github.com/awaithumans/awaithumans/pull/111))
+- **Startup channel-config validator** warns at boot if a channel
+  is half-configured (e.g. `EMAIL_TRANSPORT=smtp` set but
+  `SMTP_HOST` missing). Catches the misconfig before the first
+  send silently fails. ([#112](https://github.com/awaithumans/awaithumans/pull/112))
+- **Brand-styled HTML page** on email- / Slack-handoff link
+  failure. Recipients clicking a stale link in a browser used to
+  see raw FastAPI JSON; now they get a friendly card on the same
+  dark surface as the existing confirmation / completed pages.
+  ([#116](https://github.com/awaithumans/awaithumans/pull/116))
+
+### Fixed
+
+- **Email-handoff URL no longer expires instantly for east-of-UTC
+  users.** SQLite stores `task.timeout_at` tz-naive; the email
+  notifier was calling `.timestamp()` on it which treats the
+  value as local time. For UTC+1 users a fresh 10-minute task
+  issued a link born 3,000 seconds expired. Fix extracted to a
+  shared `awaithumans.utils.time.to_utc_unix` helper used by both
+  the email and Slack handoff paths. ([#113](https://github.com/awaithumans/awaithumans/pull/113))
+- **Duplicate notifications on idempotent retries.** The
+  `POST /api/tasks` route was firing `notify_task_*` background
+  tasks unconditionally; a retry with the same idempotency key
+  re-emailed / re-Slacked the reviewer for already-in-flight
+  work. `create_task` now returns `(task, was_newly_created)` and
+  the route gates notify on the flag. ([#114](https://github.com/awaithumans/awaithumans/pull/114))
+- **OpenAPI docs now at `/api/docs`** to match the docs page
+  contract (which had been promising that path while the actual
+  routes lived at `/docs`). Auth-bypass updated; `version=` in
+  the FastAPI constructor reads from `awaithumans.__version__`
+  instead of the hardcoded `0.1.1`. ([#115](https://github.com/awaithumans/awaithumans/pull/115))
+- **CopyButton on the dashboard** works in all contexts now —
+  previously, a parent row's `onClick` could preempt the
+  clipboard write, and the `navigator.clipboard` failure path
+  was silent. Adds `stopPropagation`, a legacy
+  `document.execCommand("copy")` fallback, and `console.warn`
+  on hard failure. Plus copy buttons added to the audit-log list
+  rows next to each task ID. ([#112](https://github.com/awaithumans/awaithumans/pull/112))
+- **All docs URLs** point at the real subdomain
+  `docs.awaithumans.dev` instead of the dead `awaithumans.dev/docs`
+  path. 13 files updated; verified each previously-broken URL
+  returns 200. ([#113](https://github.com/awaithumans/awaithumans/pull/113))
+
+### Docs / Marketing
+
+- **Hero structure + brand logo + comparison table** on the
+  GitHub README, plus matching hero blocks on the PyPI and npm
+  package READMEs. New "Why awaithumans" comparison table
+  positioned between the problem statement and the quick start
+  — captures "humanlayer alternative" search traffic, the
+  strongest single positioning lever. ([#119](https://github.com/awaithumans/awaithumans/pull/119)
+  / [#120](https://github.com/awaithumans/awaithumans/pull/120))
+- **Copy-pasteable Quick start** rewritten as a single bash
+  heredoc block. New "What you can build with it" section with
+  six concrete production patterns (high-value approvals, KYC,
+  content moderation, agent-PR review, customer-success
+  escalation, scrape-and-CAPTCHA fallback). ([#121](https://github.com/awaithumans/awaithumans/pull/121))
+- **Adoption badges** (PyPI installs, npm installs, GitHub stars)
+  promoted to a prominent for-the-badge row in the hero, above
+  the small flat metadata row. PyPI install badge switched to
+  pepy.tech to fix the "rate limited by upstream service" error
+  that was showing in production. ([#122](https://github.com/awaithumans/awaithumans/pull/122))
+- **Keyword expansion** on both PyPI (10 → 33) and npm (8 → 32),
+  covering problem terms, framework names (LangChain / LangGraph /
+  CrewAI / AutoGen / Pydantic AI / Temporal / MCP), model
+  provider names (Claude / Anthropic / OpenAI / GPT / Gemini),
+  use cases (KYC / content-moderation / agent-safety), and
+  competitor-capture (`human-layer` for the abandoned humanlayer
+  package).
+- **GitHub repo topics** expanded to the full 20-slot maximum
+  with the same strategic mix.
+
+### Versions
+
+- Python `awaithumans`: `0.1.3` → `0.1.4`
+- TypeScript `awaithumans`: `0.1.3` → `0.1.4` (mono-version sync;
+  the package source is unchanged this release — the SDK is a
+  thin HTTP client and all the new server endpoints / behaviour
+  ride on the existing wire protocol)
+
+---
+
 ## [0.1.3] — 2026-05-14
 
 ### Fixed

--- a/packages/python/awaithumans/__init__.py
+++ b/packages/python/awaithumans/__init__.py
@@ -21,7 +21,7 @@ Usage (sync):
 """
 from __future__ import annotations
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 from awaithumans.client import await_human, await_human_sync
 from awaithumans.embed import EmbedTokenResult, embed_token, embed_token_sync

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -20,7 +20,7 @@ packages = ["awaithumans"]
 
 [project]
 name = "awaithumans"
-version = "0.1.3"
+version = "0.1.4"
 description = "HITL infrastructure for AI agents. Your agent calls await_human(), a human reviews via Slack/email/dashboard, agent resumes with a typed response."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/typescript-sdk/package-lock.json
+++ b/packages/typescript-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "awaithumans",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "awaithumans",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.0",

--- a/packages/typescript-sdk/package.json
+++ b/packages/typescript-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awaithumans",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "HITL infrastructure for AI agents. Your agent calls awaitHuman(), a human reviews via Slack/email/dashboard, agent resumes with a typed response.",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary

Three days of merged work (twelve PRs) shipped together as v0.1.4:

**Server / dashboard fixes** (8 PRs):
- #111 — `notification_failed` audit entries + amber banner on task page
- #112 — channel-config validator + CopyButton fix on dashboard
- #113 — east-of-UTC handoff URL tz fix + docs URL cleanup
- #114 — no duplicate notifications on idempotent retries
- #115 — OpenAPI docs at `/api/docs` (matches docs page contract)
- #116 — brand-styled HTML error page on handoff failure
- #117 — `GET /api/version` public endpoint
- #118 — `Idempotent-Replayed: true` response header on replay

**README / marketing refresh** (4 PRs):
- #119 — Tier 1 hook + badges + keywords + hyperlinks + demo images
- #120 — Tier 2 viral-OSS hero + Why-awaithumans comparison
- #121 — Tier 2 copy-pasteable quickstart + use-case list
- #122 — install-count badge fix + prominent adoption row

No API changes; safe drop-in upgrade.

## TypeScript SDK

Source unchanged this release — all new server behaviour (Idempotent-Replayed header, /api/version, /api/docs path, friendly handoff error pages) is observable from the TS SDK without any client-side changes since they ride the existing wire protocol. The version bump is mono-version sync per the convention from v0.1.1.

## Files

- `packages/python/pyproject.toml` — `0.1.3` → `0.1.4`
- `packages/python/awaithumans/__init__.py` — `__version__` → `0.1.4`
- `packages/typescript-sdk/package.json` — `0.1.3` → `0.1.4`
- `packages/typescript-sdk/package-lock.json` — both `version` fields → `0.1.4`
- `CHANGELOG.md` — new `[0.1.4]` block
- `.github/RELEASE_NOTES_v0.1.4.md` — new file (Highlights, Upgrade, Verify, Links sections)

## After-merge release checklist

- [ ] `git tag v0.1.4 main && git push origin v0.1.4`
- [ ] `cd packages/python && python -m build`
- [ ] `twine upload packages/python/dist/awaithumans-0.1.4*`
- [ ] `cd packages/typescript-sdk && npm publish`
- [ ] Docker `docker.yml` auto-builds on tag push
- [ ] `gh release create v0.1.4 --title "v0.1.4 — bug fixes + marketing refresh" --notes-file .github/RELEASE_NOTES_v0.1.4.md`
- [ ] Sanity test: `pip install --upgrade "awaithumans[server]==0.1.4"` then `python -c "import awaithumans; print(awaithumans.__version__)"` → `0.1.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)