### PR TITLE
fix(readme): serve PyPI/npm README images via cdn.jsdelivr.net for correct MIME

### DIFF
--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-<img alt="awaithumans" src="https://raw.githubusercontent.com/awaithumans/awaithumans/main/docs/logo/light.svg" width="520">
+<img alt="awaithumans" src="https://cdn.jsdelivr.net/gh/awaithumans/awaithumans@main/docs/logo/light.svg" width="520">
 
 <br>
 
@@ -46,9 +46,9 @@ if decision.approved:
     process_refund(...)
 ```
 
-![awaithumans demo — an agent creates a task, a human reviews it, the agent resumes with the typed response](https://raw.githubusercontent.com/awaithumans/awaithumans/main/docs/images/hero-demo.gif)
+![awaithumans demo — an agent creates a task, a human reviews it, the agent resumes with the typed response](https://cdn.jsdelivr.net/gh/awaithumans/awaithumans@main/docs/images/hero-demo.gif)
 
-![The awaithumans dashboard — pending tasks queued for human review](https://raw.githubusercontent.com/awaithumans/awaithumans/main/docs/images/hero-dashboard.png)
+![The awaithumans dashboard — pending tasks queued for human review](https://cdn.jsdelivr.net/gh/awaithumans/awaithumans@main/docs/images/hero-dashboard.png)
 
 ---
 
@@ -147,7 +147,7 @@ Slack channel broadcasts post a "Claim this task" button; first
 clicker atomically wins. Direct messages and emails go straight to
 the recipient.
 
-![Slack broadcast — a task posted to a channel with a Claim button](https://raw.githubusercontent.com/awaithumans/awaithumans/main/docs/images/slack-broadcast.png)
+![Slack broadcast — a task posted to a channel with a Claim button](https://cdn.jsdelivr.net/gh/awaithumans/awaithumans@main/docs/images/slack-broadcast.png)
 
 ---
 

--- a/packages/typescript-sdk/README.md
+++ b/packages/typescript-sdk/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-<img alt="awaithumans" src="https://raw.githubusercontent.com/awaithumans/awaithumans/main/docs/logo/light.svg" width="520">
+<img alt="awaithumans" src="https://cdn.jsdelivr.net/gh/awaithumans/awaithumans@main/docs/logo/light.svg" width="520">
 
 <br>
 
@@ -53,9 +53,9 @@ if (decision.approved) {
 }
 ```
 
-![awaithumans demo — an agent creates a task, a human reviews it, the agent resumes with the typed response](https://raw.githubusercontent.com/awaithumans/awaithumans/main/docs/images/hero-demo.gif)
+![awaithumans demo — an agent creates a task, a human reviews it, the agent resumes with the typed response](https://cdn.jsdelivr.net/gh/awaithumans/awaithumans@main/docs/images/hero-demo.gif)
 
-![The awaithumans dashboard — pending tasks queued for human review](https://raw.githubusercontent.com/awaithumans/awaithumans/main/docs/images/hero-dashboard.png)
+![The awaithumans dashboard — pending tasks queued for human review](https://cdn.jsdelivr.net/gh/awaithumans/awaithumans@main/docs/images/hero-dashboard.png)
 
 ---
 
@@ -100,7 +100,7 @@ Prefer Docker? `docker run -p 3001:3001 ghcr.io/awaithumans/awaithumans:latest`.
 
 Tasks can be delivered to Slack channels with a "Claim this task" button — first clicker atomically wins, response form opens as a modal, agent unblocks when they submit. Add `notify: ["slack:#ops"]` to the `awaitHuman()` call:
 
-![Slack broadcast — a task posted to a channel with a Claim button](https://raw.githubusercontent.com/awaithumans/awaithumans/main/docs/images/slack-broadcast.png)
+![Slack broadcast — a task posted to a channel with a Claim button](https://cdn.jsdelivr.net/gh/awaithumans/awaithumans@main/docs/images/slack-broadcast.png)
 
 ---
 


### PR DESCRIPTION
## Summary

Reported by user: the demo GIF doesn't render on the **PyPI package page** (v0.1.4 just published).

**Root cause:** `raw.githubusercontent.com` serves files with `Content-Type: application/octet-stream` — GitHub's security policy to prevent browsers from executing arbitrary content. PyPI's `readme-renderer` is strict about MIME types; it rejects anything that doesn't carry `image/*`. The image silently disappears from the rendered page.

Confirmed with `curl -I`:

```
HTTP/2 200
content-type: application/octet-stream    ← PyPI rejects this
```

vs jsdelivr's proxy:

```
HTTP/2 200
content-type: image/gif                    ← PyPI accepts this
```

## Fix

Swap `raw.githubusercontent.com/.../docs/` → `cdn.jsdelivr.net/gh/.../docs/` in both package READMEs. jsdelivr proxies GitHub content and serves with correct MIME types (image/gif, image/png, image/svg+xml). Same content, real CDN, no rate limits.

## Files

- `packages/python/README.md` — 4 image URLs (logo + hero GIF + dashboard PNG + Slack PNG)
- `packages/typescript-sdk/README.md` — same 4 image URLs

**Root `README.md` intentionally not touched** — github.com renders raw URLs from its own infrastructure fine on the GitHub repo page, and the canonical link form there is the raw URL.

## ⚠️ Forward-only fix

PyPI / npm READMEs are captured at publish time and bound to that version. **v0.1.4 on PyPI will keep the broken GIF forever** — this fix only ships on the next release (v0.1.5+).

So the sequence to actually surface the fix to users:
1. Merge this PR
2. Cut v0.1.5 (next release, can batch with other fixes)
3. Publish to PyPI + npm
4. PyPI page for v0.1.5 will then render the GIF correctly

## Test plan

- [ ] All 8 jsdelivr URLs verified rendering with correct MIME headers (`image/gif`, `image/png`, `image/svg+xml`)
- [ ] Local preview of `packages/python/README.md` and `packages/typescript-sdk/README.md` on a Markdown renderer that respects MIME types
- [ ] After publishing v0.1.5: check `pypi.org/project/awaithumans/0.1.5/` — GIF + PNGs should display

🤖 Generated with [Claude Code](https://claude.com/claude-code)