### PR TITLE
fix(python): drop datetime.UTC for 3.10 compat

### DIFF
--- a/packages/python/awaithumans/server/routes/embed.py
+++ b/packages/python/awaithumans/server/routes/embed.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -78,5 +78,5 @@ async def mint_embed_token(
     return EmbedTokenResponse(
         embed_token=token,
         embed_url=f"{base}/embed?id={body.task_id}#token={token}",
-        expires_at=datetime.fromtimestamp(exp, tz=UTC).isoformat(),
+        expires_at=datetime.fromtimestamp(exp, tz=timezone.utc).isoformat(),
     )

--- a/packages/python/awaithumans/server/services/service_key_service.py
+++ b/packages/python/awaithumans/server/services/service_key_service.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import hashlib
 import secrets
 import time
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
@@ -73,7 +73,7 @@ async def create_service_key(
         name=name,
         key_hash=key_hash,
         key_prefix=raw[:SERVICE_KEY_DISPLAY_PREFIX_LENGTH],
-        created_at=datetime.now(UTC),
+        created_at=datetime.now(timezone.utc),
     )
     session.add(row)
     await session.commit()
@@ -96,7 +96,7 @@ async def verify_service_key(
     row = result.scalar_one_or_none()
     if row is None or row.revoked_at is not None:
         raise ServiceKeyNotFoundError()
-    row.last_used_at = datetime.now(UTC)
+    row.last_used_at = datetime.now(timezone.utc)
     session.add(row)
     await session.commit()
     await session.refresh(row)
@@ -122,7 +122,7 @@ async def revoke_service_key(
     if row is None:
         raise ServiceKeyNotFoundError()
     if row.revoked_at is None:
-        row.revoked_at = datetime.now(UTC)
+        row.revoked_at = datetime.now(timezone.utc)
         session.add(row)
         await session.commit()
         await session.refresh(row)

--- a/packages/python/tests/embed/test_service_key_model.py
+++ b/packages/python/tests/embed/test_service_key_model.py
@@ -6,7 +6,7 @@ SQLite engine.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 import pytest
 from sqlalchemy.exc import IntegrityError
@@ -24,7 +24,7 @@ def test_service_key_round_trip() -> None:
         name="acme-prod",
         key_hash="a" * 64,
         key_prefix="ah_sk_abcdef",
-        created_at=datetime.now(UTC),
+        created_at=datetime.now(timezone.utc),
     )
     with Session(engine) as session:
         session.add(row)
@@ -51,14 +51,14 @@ def test_service_key_unique_hash_constraint() -> None:
         name="alpha",
         key_hash="x" * 64,
         key_prefix="ah_sk_aaaaaa",
-        created_at=datetime.now(UTC),
+        created_at=datetime.now(timezone.utc),
     )
     second = ServiceAPIKey(
         id="01B",
         name="beta",
         key_hash="x" * 64,
         key_prefix="ah_sk_bbbbbb",
-        created_at=datetime.now(UTC),
+        created_at=datetime.now(timezone.utc),
     )
     with Session(engine) as session:
         session.add(first)


### PR DESCRIPTION
## Summary
- \`from datetime import UTC\` was added in Python 3.11, but pyproject declares 3.10 as the supported floor — so importing the \`UTC\` alias crashes the server (and any test that transitively loads it) on 3.10.
- Swap to the long-form \`from datetime import timezone\` + \`timezone.utc\`, which has been around since 3.2.
- Three files touched: two production modules (\`server/routes/embed.py\`, \`server/services/service_key_service.py\`) and one test module (\`tests/embed/test_service_key_model.py\`). Remaining "UTC" mentions are docstrings/comments only.

## Why this matters
- CI on Python 3.10 currently fails to collect 21 test files because they transitively import these two production modules. This is what surfaced the gap.
- README + PyPI advertise 3.10 support; this fix makes that claim true again.

## Test plan
- [ ] Once #125 (tests CI) merges, re-add 3.10 to the matrix and verify CI passes on both 3.10 and 3.13
- [ ] Local pytest passes against 3.10 venv