### PR TITLE
fix(tests): update temporal adapter test to current activity name

### DIFF
--- a/packages/python/tests/adapters/test_temporal_adapter.py
+++ b/packages/python/tests/adapters/test_temporal_adapter.py
@@ -34,8 +34,8 @@ import pytest
 from pydantic import BaseModel
 
 from awaithumans.adapters.temporal import (
-    _create_task_activity,
     _signal_name,
+    awaithumans_create_task,
     dispatch_signal,
 )
 from awaithumans.errors import (
@@ -263,7 +263,7 @@ async def test_await_human_returns_response_after_signal(
     async def fake_create(req: adapter._CreateTaskInput) -> dict:
         return {"id": "task-stub", "idempotency_key": req.idempotency_key}
 
-    monkeypatch.setattr(adapter, "_create_task_activity", fake_create)
+    monkeypatch.setattr(adapter, "awaithumans_create_task", fake_create)
 
     async with await WorkflowEnvironment.start_local() as env:
         client = env.client
@@ -316,7 +316,7 @@ async def test_await_human_raises_typed_error_on_cancelled_status(
     async def fake_create(req: adapter._CreateTaskInput) -> dict:
         return {"id": "task-stub", "idempotency_key": req.idempotency_key}
 
-    monkeypatch.setattr(adapter, "_create_task_activity", fake_create)
+    monkeypatch.setattr(adapter, "awaithumans_create_task", fake_create)
 
     async with await WorkflowEnvironment.start_local() as env:
         client = env.client
@@ -381,7 +381,7 @@ async def test_create_task_activity_posts_with_bearer_when_api_key_set(
 
     from awaithumans.adapters.temporal import _CreateTaskInput
 
-    out = await _create_task_activity(
+    out = await awaithumans_create_task(
         _CreateTaskInput(
             server_url="http://test.example",
             api_key="test-bearer",


### PR DESCRIPTION
## Summary
- The activity in \`awaithumans.adapters.temporal\` was renamed from \`_create_task_activity\` → \`awaithumans_create_task\` so it has a stable, namespaced name on workers (Temporal looks up activities by name when they're registered).
- The test still referenced the old symbol in 4 places — one import + three call sites (two \`monkeypatch.setattr\`, one direct \`await\`) — so collection failed before any assertion ran.

## What's preserved
- The test function name \`test_create_task_activity_posts_with_bearer_when_api_key_set\` is left alone — it's a label, not a reference.

## Test plan
- [ ] After this and #126 land + #125 merges, drop the \`--ignore=tests/adapters/test_temporal_adapter.py\` from \`.github/workflows/test.yml\` and verify the file collects on CI