### PR TITLE
chore(ts): drop unused imports + enable noUnusedLocals across packages

### DIFF
--- a/packages/dashboard/app/(dashboard)/audit/page.tsx
+++ b/packages/dashboard/app/(dashboard)/audit/page.tsx
@@ -9,7 +9,7 @@ import {
 	type Task,
 	type TaskStatus,
 } from "@/lib/server";
-import { completedByLabel, cn, formatRelativeTime } from "@/lib/utils";
+import { completedByLabel, formatRelativeTime } from "@/lib/utils";
 import {
 	TASK_ID_TRUNCATE_LENGTH,
 	TASK_LIST_DEFAULT_PAGE_SIZE,
@@ -49,15 +49,6 @@ interface FilterState {
 	pageSize: number;
 	offset: number;
 }
-
-const DEFAULT_FILTERS: FilterState = {
-	status: "all",
-	assignedTo: "",
-	unassigned: false,
-	mine: false,
-	pageSize: TASK_LIST_DEFAULT_PAGE_SIZE,
-	offset: 0,
-};
 
 function readFiltersFromSearchParams(params: URLSearchParams): FilterState {
 	const rawStatus = params.get("status") ?? "all";

--- a/packages/dashboard/app/(dashboard)/page.tsx
+++ b/packages/dashboard/app/(dashboard)/page.tsx
@@ -9,7 +9,7 @@ import {
 	type Task,
 	type TaskStatus,
 } from "@/lib/server";
-import { assigneeLabel, cn, formatRelativeTime } from "@/lib/utils";
+import { assigneeLabel, formatRelativeTime } from "@/lib/utils";
 import {
 	SECONDS_PER_MINUTE,
 	TASK_ID_TRUNCATE_LENGTH,
@@ -49,15 +49,6 @@ interface FilterState {
 	pageSize: number;
 	offset: number;
 }
-
-const DEFAULT_FILTERS: FilterState = {
-	status: "all",
-	assignedTo: "",
-	unassigned: false,
-	mine: false,
-	pageSize: TASK_LIST_DEFAULT_PAGE_SIZE,
-	offset: 0,
-};
 
 /**
  * URL-synced state. Each filter knob writes through to the query

--- a/packages/typescript-sdk/src/adapters/temporal/index.ts
+++ b/packages/typescript-sdk/src/adapters/temporal/index.ts
@@ -70,7 +70,6 @@
  *    it.)
  */
 
-import type { ZodType } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
 import {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,6 +5,8 @@
     "moduleResolution": "bundler",
     "lib": ["ES2022"],
     "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary
Following up on the \`github-code-quality[bot]\` flags about unused identifiers. The bot's findings on \`alembic/versions/*.py\` and \`tests/services/conftest.py\` are **false positives** (covered below), but the dashboard had four real unused-locals that the project's current \`tsc\` flags weren't catching.

## Real findings (fixed)
Surfaced by \`tsc --noEmit --noUnusedLocals --noUnusedParameters\`:

| File | Unused |
|------|--------|
| \`packages/dashboard/app/(dashboard)/audit/page.tsx\` | \`cn\` import, \`DEFAULT_FILTERS\` const |
| \`packages/dashboard/app/(dashboard)/page.tsx\` | \`cn\` import, \`DEFAULT_FILTERS\` const |
| \`packages/typescript-sdk/src/adapters/temporal/index.ts\` | duplicate \`import type { ZodType }\` — only the aliased \`ZodTypeRef\` is referenced |

Then enabled \`noUnusedLocals\` + \`noUnusedParameters\` in \`tsconfig.base.json\` so future regressions fail \`npm run typecheck\` instead of slipping past the build. Both packages now pass \`tsc --noEmit\` clean; \`vitest\` still green (66/66 on the SDK).

## Bot false positives (not in this PR)
Two patterns the bot misreads — both already correct, no code change needed:

- **\`alembic/versions/*.py\` "unused global"** for \`revision\`, \`down_revision\`, \`branch_labels\`, \`depends_on\`. Alembic reads these at runtime via attribute access from \`env.py\`; they're required on every migration file. The bot can't see the framework's import machinery.
- **\`tests/services/conftest.py:16\` "unused import"** for \`AuditEntry\`, \`Task\`. These are side-effect imports — importing the SQLModel class registers it with \`SQLModel.metadata\` so \`create_all\` builds the schema in the test session. The file already has \`# noqa: F401\` for ruff; the bot just doesn't honor it.

Both can be resolved/dismissed once in the GitHub UI; no code change makes the bot stop flagging them.

## Test plan
- [ ] CI green on this branch (\`tsc --noEmit\` + \`vitest\` for both dashboard and typescript-sdk)
- [ ] Visual check on the dashboard pages still renders normally (no functional change)