### PR TITLE
chore(release): bump python and ts SDK lockfile to 0.1.5

### DIFF
--- a/.github/RELEASE_NOTES_v0.1.5.md
+++ b/.github/RELEASE_NOTES_v0.1.5.md
@@ -1,0 +1,52 @@
+# awaithumans v0.1.5 — PyPI rendering fix, tests CI, and a 224-keyword npm discovery push
+
+Two days after [v0.1.4](https://github.com/awaithumans/awaithumans/releases/tag/v0.1.4). Maintenance + discovery release: a PyPI-rendering bug fix from beta-tester feedback, the GitHub Actions tests workflow that the repo had been missing, three follow-up cleanups CI surfaced on its first run, and a deliberate npm-keyword expansion. No API changes; safe drop-in upgrade.
+
+## Highlights
+
+- 🖼 **PyPI README images render again.** v0.1.4's README pointed at `raw.githubusercontent.com`, which serves `application/octet-stream` — PyPI's strict MIME check rejects non-image types and the demo GIF + logo silently didn't appear. Switched both to `cdn.jsdelivr.net/gh/`, which proxies GitHub content with the correct `image/gif` / `image/png` headers. npm rendered fine on 0.1.4; the fix is PyPI-specific. ([#124](https://github.com/awaithumans/awaithumans/pull/124))
+- 🧪 **Tests CI.** New `.github/workflows/test.yml` runs three parallel jobs on every PR and every push to `main`: Python 3.11 + 3.13 matrix (pytest), TypeScript SDK (vitest + tsc), dashboard (vitest + tsc). Concurrency group cancels superseded runs. The existing `migrations.yml` continues to cover Alembic separately. ([#125](https://github.com/awaithumans/awaithumans/pull/125))
+- 🐍 **Python 3.10 support is real again.** Two production modules + one test file imported `datetime.UTC`, which only exists in 3.11+. pyproject claimed 3.10 as the floor but the package crashed on import there. Swapped to the long-form `datetime.timezone.utc`. ([#126](https://github.com/awaithumans/awaithumans/pull/126))
+- 🧹 **Temporal adapter test fixed.** `tests/adapters/test_temporal_adapter.py` still imported `_create_task_activity`, the pre-refactor name; the public symbol is now `awaithumans_create_task`. Updated four call sites. ([#127](https://github.com/awaithumans/awaithumans/pull/127))
+- 🎨 **Ruff cleanup pass across the Python package.** 165 lint findings had accumulated on `main` (mostly import-sort + trailing-comma drift). `ruff check --fix` + `ruff format` handled 154; 14 manual edits cleaned up the rest. `ruff check .` is now green. ([#128](https://github.com/awaithumans/awaithumans/pull/128))
+- 🔒 **TypeScript strictness up a notch.** Enabled `noUnusedLocals` + `noUnusedParameters` in `tsconfig.base.json`, then fixed the five real unused locals that surfaced (four in the dashboard, one duplicate `ZodType` import in the temporal adapter). Future regressions now fail `npm run typecheck` instead of slipping past the build. ([#129](https://github.com/awaithumans/awaithumans/pull/129))
+- 🔍 **npm keyword expansion: 33 → 224.** A deliberate discovery experiment — npm is treated as a discovery surface rather than a one-liner index. The README, not the keyword list, judges fit. Pure metadata; no code change. ([#130](https://github.com/awaithumans/awaithumans/pull/130))
+- 🤝 **Python and TypeScript stay mono-versioned at `0.1.5`** — TS SDK had been bumped solo for the keyword expansion; this release re-syncs Python alongside.
+
+## Upgrade
+
+### Python
+
+```bash
+pip install --upgrade "awaithumans[server]==0.1.5"
+# or whichever extras you use:
+#   pip install --upgrade "awaithumans[temporal]==0.1.5"
+#   pip install --upgrade "awaithumans[langgraph]==0.1.5"
+#   pip install --upgrade "awaithumans[verifier-claude]==0.1.5"
+```
+
+### TypeScript
+
+```bash
+npm install awaithumans@0.1.5
+```
+
+### Docker
+
+```bash
+docker pull ghcr.io/awaithumans/awaithumans:0.1.5
+```
+
+No migrations, no env var changes, no config changes.
+
+## Compatibility
+
+- **Python:** 3.10+ (`datetime.UTC` removal restores the declared floor).
+- **Node:** 18+.
+- **Database:** No new migrations.
+
+## What's not in this release
+
+- **mypy in CI** — pyproject opts in to `strict = true` but enforcing it in CI needs its own cleanup pass.
+- **Re-enabling `ruff check .` in the tests workflow** — the lint findings are gone after #128; the CI step itself rolls into the next release.
+- **Re-including the temporal adapter test** — the `--ignore=` flag in `test.yml` stays until the workflow update follows it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,29 @@ _Nothing yet — open the next change here._
 
 ---
 
+## [0.1.5] — 2026-05-19
+
+Two days after [v0.1.4](https://github.com/awaithumans/awaithumans/releases/tag/v0.1.4). Maintenance + discovery release: one PyPI-rendering bug fix from beta-tester feedback, the test-CI infrastructure that was missing, follow-up cleanups CI surfaced on first run, and a deliberate npm-keyword expansion as a discovery experiment. No API changes; safe drop-in upgrade.
+
+### Fixed
+
+- **PyPI README images render again.** v0.1.4's README pointed at `raw.githubusercontent.com`, which serves `application/octet-stream` — PyPI's strict MIME check rejects that and just doesn't render the image. Switched the demo GIF + logo to `cdn.jsdelivr.net/gh/`, which proxies GitHub content with the correct `image/gif` / `image/png` headers. npm rendered fine on 0.1.4; this fix is PyPI-specific. ([#124](https://github.com/awaithumans/awaithumans/pull/124))
+- **Python 3.10 support is real again.** Two production modules (`server/routes/embed.py`, `server/services/service_key_service.py`) plus one test file imported `datetime.UTC`, which only exists in 3.11+. pyproject declared 3.10 as the floor but the package crashed on import. Swapped to the long-form `datetime.timezone.utc`. ([#126](https://github.com/awaithumans/awaithumans/pull/126))
+- **Temporal adapter test collection no longer breaks the suite.** `tests/adapters/test_temporal_adapter.py` still imported `_create_task_activity`, the pre-refactor name; the public symbol is now `awaithumans_create_task`. Updated four call sites. ([#127](https://github.com/awaithumans/awaithumans/pull/127))
+- **Dashboard had four real unused locals** (`cn` import + `DEFAULT_FILTERS` const, in both the task queue and audit pages) — surfaced once strict tsconfig flags went in. ([#129](https://github.com/awaithumans/awaithumans/pull/129))
+
+### Added
+
+- **GitHub Actions tests workflow.** Three parallel jobs run on every PR and every push to `main`: Python 3.11 + 3.13 matrix (pytest), TypeScript SDK (vitest + tsc), dashboard (vitest + tsc). Concurrency group cancels superseded runs. The existing `migrations.yml` continues to cover Alembic separately. ([#125](https://github.com/awaithumans/awaithumans/pull/125))
+- **`noUnusedLocals` + `noUnusedParameters` in `tsconfig.base.json`** — future regressions now fail `npm run typecheck` instead of slipping through. ([#129](https://github.com/awaithumans/awaithumans/pull/129))
+
+### Changed
+
+- **Ruff cleanup pass across the Python package.** Lint drift had accumulated to 165 findings (mostly import-sort + trailing-comma); `ruff check --fix` + `ruff format` resolved 154 of them, 14 manual edits cleaned up the rest. `ruff check .` is now green; CI re-enabling the lint step is queued as a follow-up. No behavior change. ([#128](https://github.com/awaithumans/awaithumans/pull/128))
+- **TypeScript SDK npm keywords: 33 → 224** as a deliberate discovery experiment. npm is treated as a discovery surface rather than a one-liner index — the README, not the keyword list, judges fit. No code change; metadata only. ([#130](https://github.com/awaithumans/awaithumans/pull/130))
+
+---
+
 ## [0.1.4] — 2026-05-17
 
 Eight PRs of bug fixes and DX improvements caught by beta-tester

--- a/packages/python/awaithumans/__init__.py
+++ b/packages/python/awaithumans/__init__.py
@@ -22,7 +22,7 @@ Usage (sync):
 
 from __future__ import annotations
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 from awaithumans.client import await_human, await_human_sync
 from awaithumans.embed import EmbedTokenResult, embed_token, embed_token_sync

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -20,7 +20,7 @@ packages = ["awaithumans"]
 
 [project]
 name = "awaithumans"
-version = "0.1.4"
+version = "0.1.5"
 description = "HITL infrastructure for AI agents. Your agent calls await_human(), a human reviews via Slack/email/dashboard, agent resumes with a typed response."
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/typescript-sdk/package-lock.json
+++ b/packages/typescript-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "awaithumans",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "awaithumans",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.0",


### PR DESCRIPTION
## Summary
#130 bumped the TS SDK's \`package.json\` to 0.1.5 for the npm-keyword expansion but left Python at 0.1.4 and \`packages/typescript-sdk/package-lock.json\` out of sync. This re-syncs everything to restore the mono-versioning convention.

| File | Change |
|------|--------|
| \`packages/python/pyproject.toml\` | \`version = "0.1.4"\` → \`"0.1.5"\` |
| \`packages/python/awaithumans/__init__.py\` | \`__version__ = "0.1.4"\` → \`"0.1.5"\` |
| \`packages/typescript-sdk/package-lock.json\` | regenerated at 0.1.5 |
| \`CHANGELOG.md\` | new \`[0.1.5] — 2026-05-19\` section |
| \`.github/RELEASE_NOTES_v0.1.5.md\` | new — GitHub Release body |

## What v0.1.5 covers (7 PRs since 0.1.4)
- **#124** — PyPI README images render again (jsdelivr CDN swap)
- **#125** — tests CI workflow (Python 3.11+3.13, TS SDK, dashboard)
- **#126** — Python 3.10 \`datetime.UTC\` → \`timezone.utc\` fix
- **#127** — temporal adapter test rename
- **#128** — ruff cleanup pass (165 lint findings → green)
- **#129** — TS strict-unused: \`noUnusedLocals\` + 5 real fixes
- **#130** — npm keywords 33 → 224 (discovery experiment)

No API changes; safe drop-in upgrade.

## Test plan
- [ ] All CI checks green
- [ ] After merge: tag \`v0.1.5\` triggers Docker workflow; PyPI + npm publishes happen manually from this commit