### PR TITLE
docs(readme): add CI badge + 'Built with awaithumans?' powered-by section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/awaithumans?label=pypi&color=3775A9&logo=pypi&logoColor=white)](https://pypi.org/project/awaithumans/)
 [![npm](https://img.shields.io/npm/v/awaithumans?label=npm&color=CB3837&logo=npm&logoColor=white)](https://www.npmjs.com/package/awaithumans)
+[![CI](https://img.shields.io/github/actions/workflow/status/awaithumans/awaithumans/test.yml?label=tests&logo=github&logoColor=white)](https://github.com/awaithumans/awaithumans/actions/workflows/test.yml)
 [![License](https://img.shields.io/badge/license-Apache_2.0-blue)](https://github.com/awaithumans/awaithumans/blob/main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
 [![Discord](https://img.shields.io/badge/discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/Kewdh7vjdc)
@@ -315,6 +316,24 @@ the entire extension surface.
 - **Full docs:** [docs.awaithumans.dev](https://docs.awaithumans.dev)
 - **Contributing:** [`CONTRIBUTING.md`](./CONTRIBUTING.md)
 - **Security policy:** [`SECURITY.md`](./SECURITY.md)
+
+---
+
+## Built with awaithumans?
+
+Drop this badge in your project's README so folks know where the HITL primitive came from:
+
+[![Powered by awaithumans](https://raw.githubusercontent.com/awaithumans/awaithumans/main/docs/images/badges/powered-by-awaithumans.svg)](https://github.com/awaithumans/awaithumans)
+
+```markdown
+[![Powered by awaithumans](https://raw.githubusercontent.com/awaithumans/awaithumans/main/docs/images/badges/powered-by-awaithumans.svg)](https://github.com/awaithumans/awaithumans)
+```
+
+Or generate a generic variant via [shields.io](https://shields.io):
+
+```markdown
+[![Powered by awaithumans](https://img.shields.io/badge/Powered_by-awaithumans-00E676)](https://github.com/awaithumans/awaithumans)
+```
 
 ---
 

--- a/docs/images/badges/powered-by-awaithumans.svg
+++ b/docs/images/badges/powered-by-awaithumans.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="28" viewBox="0 0 200 28" role="img" aria-label="Powered by awaithumans">
+  <title>Powered by awaithumans</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#fff" stop-opacity=".06"/>
+    <stop offset="1" stop-opacity=".10"/>
+  </linearGradient>
+  <clipPath id="r"><rect width="200" height="28" rx="4" fill="#fff"/></clipPath>
+  <g clip-path="url(#r)">
+    <rect width="78" height="28" fill="#0A0A0A"/>
+    <rect x="78" width="122" height="28" fill="#00E676"/>
+    <rect width="200" height="28" fill="url(#s)"/>
+  </g>
+  <g fill="#F5F5F5" font-family="ui-monospace, 'SF Mono', Menlo, Monaco, 'Cascadia Mono', 'Roboto Mono', Consolas, monospace" font-size="11">
+    <text x="39" y="17.5" text-anchor="middle" font-weight="500">Powered by</text>
+  </g>
+  <g fill="#0A0A0A" font-family="ui-monospace, 'SF Mono', Menlo, Monaco, 'Cascadia Mono', 'Roboto Mono', Consolas, monospace" font-size="11">
+    <text x="139" y="17.5" text-anchor="middle" font-weight="600">awaithumans</text>
+  </g>
+</svg>


### PR DESCRIPTION
Two small adds:

1. **CI badge** linking to test.yml workflow status — completes the row alongside PyPI, npm, License, Python, Discord.

2. **'Built with awaithumans?' section** before Packages — brand-styled SVG badge (dark + brand-green halves, monospace wordmark) plus a shields.io fallback for anyone who prefers the generic style.

The SVG lives at `docs/images/badges/powered-by-awaithumans.svg` so it serves both the docs site (Mintlify auto-routes /docs/*) and the README via raw.githubusercontent.com.

## Preview

![Powered by awaithumans](https://raw.githubusercontent.com/awaithumans/awaithumans/chore/week-1-bootstrap-badges/docs/images/badges/powered-by-awaithumans.svg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)