### PR TITLE
docs: wire PostHog analytics into Mintlify integrations

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -7,6 +7,12 @@
     "light": "#33EE99",
     "dark": "#00B25A"
   },
+  "integrations": {
+    "posthog": {
+      "apiKey": "phc_xHxQxFVM5onEEhuhgR6TkGNnfgvBh9XcHLrtwh5GSWbx",
+      "apiHost": "https://us.i.posthog.com"
+    }
+  },
   "favicon": "/favicon.svg",
   "logo": {
     "light": "/logo/light.svg",


### PR DESCRIPTION
## What this does

Adds the Mintlify-native PostHog integration to `docs/docs.json`:

```json
"integrations": {
  "posthog": {
    "apiKey": "phc_xHxQxFVM5onEEhuhgR6TkGNnfgvBh9XcHLrtwh5GSWbx",
    "apiHost": "https://us.i.posthog.com"
  }
}
```

Once merged, Mintlify auto-injects PostHog's capture script on every docs page within ~2 min of the rebuild.

## On committing the API key

The `phc_` key is PostHog's **public capture key** by design — it's embedded in client-side JS on every page and visible in DevTools regardless of where it lives. Hiding it gives zero security benefit. Most OSS projects (Vercel, Inngest, Trigger.dev) ship theirs visibly in their public repos for the same reason.

The actual secret PostHog gives you is the **personal API key** (used server-side for the Stats API), which we don't need here and don't commit.

## After merge — required PostHog setting

To prevent forkers of this repo from polluting analytics with their own deployments:

1. PostHog dashboard → **Project Settings** → **Authorized URLs**
2. Add `https://docs.awaithumans.dev` and `https://docs.awaithumans.dev/*`
3. PostHog will now reject capture events from any other domain (e.g., `localhost`, `my-fork.com`)

## Verify after merge (~5 min)

1. Open `https://docs.awaithumans.dev/` in an incognito window
2. Click 3-4 pages
3. PostHog → Live Events → see your visits as `$pageview` events

🤖 Generated with [Claude Code](https://claude.com/claude-code)