### PR TITLE
fix(docker): install all verifier extras in the published image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,8 +80,16 @@ COPY --from=wheel-builder /src/packages/python/dist /tmp/dist
 # globs `[...]` as a character class — `*.whl[server]` would expand
 # to nothing. Resolve the wheel path first, then concat the extras.
 RUN WHEEL=$(ls /tmp/dist/*.whl | head -1) \
- && pip install --no-cache-dir "${WHEEL}[server]" \
+ && pip install --no-cache-dir \
+      "${WHEEL}[server,verifier-claude,verifier-openai,verifier-gemini,verifier-azure]" \
  && rm -rf /tmp/dist
+# Why all verifier extras? Without them, sending a verifier config to the
+# server fails with "Verifier provider 'X' requires the [verifier-X]
+# extra. Install with: pip install awaithumans[verifier-X]" — which the
+# user can't do because the server lives inside an image. Shipping all
+# four extras costs ~35 MB on top of the ~200 MB base. Users who care
+# about image size can build a custom image picking only the extras
+# they actually use. See #142.
 
 # Non-root runtime user. SQLite + any writes go to /var/lib/awaithumans.
 RUN useradd --system --uid 10001 --home-dir /var/lib/awaithumans awaithumans \


### PR DESCRIPTION
Closes #142.

## Before

```
RUN WHEEL=$(ls /tmp/dist/*.whl | head -1) \
 && pip install --no-cache-dir "${WHEEL}[server]" \
 && rm -rf /tmp/dist
```

Only the `[server]` extra. The moment a user sends a task with `VerifierConfig(provider="claude" | "openai" | "gemini" | "azure_openai")` to the official Docker image, response submission fails with:

```
Verifier provider 'claude' requires the [verifier-claude] extra.
Install with: pip install "awaithumans[verifier-claude]"
```

…which the operator can't act on because the server runs inside the image. The `await_human()` call never resolves; the agent hangs until timeout.

## After

```
RUN WHEEL=$(ls /tmp/dist/*.whl | head -1) \
 && pip install --no-cache-dir \
      "${WHEEL}[server,verifier-claude,verifier-openai,verifier-gemini,verifier-azure]" \
 && rm -rf /tmp/dist
```

All four verifier providers work out of the box on `:latest` / `:v0.1.7+`.

## Image size impact

| Extra | Adds |
|---|---|
| `anthropic` (verifier-claude) | ~5 MB |
| `openai` (shared by verifier-openai + verifier-azure) | ~3 MB |
| `google-generativeai` (verifier-gemini) | ~25 MB |
| **Total** | **~35 MB** on top of ~200 MB base |

Acceptable for the OOTB experience — verifiers are headline product surface. Users who care about image size can build a custom image picking only the extras they actually use; the Dockerfile is short enough to copy.

## Test plan

- [x] `docker buildx build --check .` passes
- [x] All 4 extras are declared in `packages/python/pyproject.toml` (no typos in extras list)
- [ ] Manual: build the image, send a task with `claude_verifier(...)`, submit a response in the dashboard → response goes through, agent resumes (will verify post-merge once `:v0.1.7` publishes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
