### PR TITLE
CLI: awaithumans doctor — pre-flight check #147

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,17 +86,17 @@ per project.
 
 ## Why awaithumans
 
-|                               | **awaithumans**                                                                                                                                                                                                                             | humanlayer           | DIY glue code       |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- | ------------------- |
-| **Maintained**          | ✅ Active development                                                                                                                                                                                                                             | ❌ Abandoned         | —                  |
-| **Setup time**          | One command (`awaithumans dev`)                                                                                                                                                                                                                 | Per-customer rebuild | Weeks               |
-| **Channels**            | Slack + email + built-in dashboard                                                                                                                                                                                                                | Slack only           | Build each yourself |
-| **Typed responses**     | ✅[Pydantic](https://pydantic.dev) (Python) / [Zod](https://zod.dev) (TS) — schema-validated end to end                                                                                                                                                | Partial              | Build each yourself |
-| **Restart-safe**        | ✅ Stripe-style idempotency — agent resumes across restarts                                                                                                                                                                                      | ❌                   | Build each yourself |
-| **AI pre-verification** | ✅[Claude](https://www.anthropic.com/claude) / [OpenAI](https://openai.com) / [Gemini](https://gemini.google.com) / [Azure](https://azure.microsoft.com/en-us/products/ai-services/openai-service) — pre-check the human's answer before the agent trusts it | ❌                   | Build each yourself |
-| **Workflow engines**    | ✅[Temporal](https://temporal.io) + [LangGraph](https://langchain-ai.github.io/langgraph/) adapters — hand the wait to the engine                                                                                                                      | ❌                   | Build each yourself |
-| **Self-hostable**       | ✅ Docker + Postgres in one command                                                                                                                                                                                                               | SaaS-only            | —                  |
-| **License**             | Apache 2.0 (patent grant)                                                                                                                                                                                                                         | —                   | —                  |
+|  | **awaithumans** | humanlayer | DIY glue code |
+|---|---|---|---|
+| **Maintained** | ✅ Active development | ❌ Abandoned | — |
+| **Setup time** | One command (`awaithumans dev`) | Per-customer rebuild | Weeks |
+| **Channels** | Slack + email + built-in dashboard | Slack only | Build each yourself |
+| **Typed responses** | ✅ [Pydantic](https://pydantic.dev) (Python) / [Zod](https://zod.dev) (TS) — schema-validated end to end | Partial | Build each yourself |
+| **Restart-safe** | ✅ Stripe-style idempotency — agent resumes across restarts | ❌ | Build each yourself |
+| **AI pre-verification** | ✅ [Claude](https://www.anthropic.com/claude) / [OpenAI](https://openai.com) / [Gemini](https://gemini.google.com) / [Azure](https://azure.microsoft.com/en-us/products/ai-services/openai-service) — pre-check the human's answer before the agent trusts it | ❌ | Build each yourself |
+| **Workflow engines** | ✅ [Temporal](https://temporal.io) + [LangGraph](https://langchain-ai.github.io/langgraph/) adapters — hand the wait to the engine | ❌ | Build each yourself |
+| **Self-hostable** | ✅ Docker + Postgres in one command | SaaS-only | — |
+| **License** | Apache 2.0 (patent grant) | — | — |
 
 Built by engineers who hit the HITL wall three times in production fintech and ScaleBrick agent systems — and watched the only OSS alternative get abandoned by its founder over per-customer-fork creep. The architecture has exactly four extension points (channels, verifiers, routers, task-type handlers) so no single customer can push the core into the same trap.
 
@@ -274,7 +274,8 @@ const decision = await awaitHuman({
 
 Full walkthrough: [`examples/quickstart-ts/`](./examples/quickstart-ts/).
 
-The server + dashboard are Python — TypeScript runs `npx awaithumans dev` (via [uv](https://astral.sh/uv)) so you never touch a Python env.
+The server + dashboard are Python — TypeScript runs `npx awaithumans
+dev` (via [uv](https://astral.sh/uv)) so you never touch a Python env.
 
 ---
 
@@ -336,24 +337,6 @@ Or generate a generic variant via [shields.io](https://shields.io):
 
 ---
 
-## Packages
-
-| Package                                                 | Registry | License    |
-| ------------------------------------------------------- | -------- | ---------- |
-| `awaithumans` (Python SDK + server + CLI + dashboard) | PyPI     | Apache 2.0 |
-| `awaithumans` (TypeScript SDK)                        | npm      | Apache 2.0 |
-| `ghcr.io/awaithumans/awaithumans` (container)         | GHCR     | Apache 2.0 |
-
-**License:** [Apache License 2.0](LICENSE). Permissive, OSI-approved,
-with an explicit patent grant. Use it in proprietary stacks, fork it,
-ship it inside paid products — no fee, no contact required. The only
-thing the license asks is that you preserve the notice and don't use
-the project's trademarks without permission.
-
----
-
-
-
 ## Troubleshooting
 
 If something isn't working, run the pre-flight check first:
@@ -365,12 +348,25 @@ awaithumans doctor
 It scans your environment for the most common misconfigurations —
 missing or malformed `PAYLOAD_KEY`, Slack token issues, unreachable
 database, Docker bind-mount gotchas — and prints a clear report with
-actionable fixes. This catches ~80% of first-run issues in under
-2 seconds.
+actionable fixes. Catches ~80% of first-run issues in under 2 seconds.
 
 ---
 
+## Packages
 
+| Package | Registry | License |
+|---|---|---|
+| `awaithumans` (Python SDK + server + CLI + dashboard) | PyPI | Apache 2.0 |
+| `awaithumans` (TypeScript SDK) | npm | Apache 2.0 |
+| `ghcr.io/awaithumans/awaithumans` (container) | GHCR | Apache 2.0 |
+
+**License:** [Apache License 2.0](LICENSE). Permissive, OSI-approved,
+with an explicit patent grant. Use it in proprietary stacks, fork it,
+ship it inside paid products — no fee, no contact required. The only
+thing the license asks is that you preserve the notice and don't use
+the project's trademarks without permission.
+
+---
 
 ## Status
 
@@ -380,4 +376,4 @@ The full primitive, all three channels (dashboard / Slack / email), both durable
 
 This is a young project — APIs are stable for v0.x, but expect rough edges in the long tail. File issues, open PRs, drop questions in [Discussions](https://github.com/awaithumans/awaithumans/discussions) or [Discord](https://discord.gg/Kewdh7vjdc). Every reproducible bug report shipped with a fix in v0.2.
 
-For the post-launch roadmap — local task book for runtimes without an orchestrator, custom router strategies, post-launch hardening — see [Roadmap &amp; help wanted](https://docs.awaithumans.dev/community/roadmap).
+For the post-launch roadmap — local task book for runtimes without an orchestrator, custom router strategies, post-launch hardening — see [Roadmap & help wanted](https://docs.awaithumans.dev/community/roadmap).

--- a/README.md
+++ b/README.md
@@ -86,17 +86,17 @@ per project.
 
 ## Why awaithumans
 
-|  | **awaithumans** | humanlayer | DIY glue code |
-|---|---|---|---|
-| **Maintained** | ✅ Active development | ❌ Abandoned | — |
-| **Setup time** | One command (`awaithumans dev`) | Per-customer rebuild | Weeks |
-| **Channels** | Slack + email + built-in dashboard | Slack only | Build each yourself |
-| **Typed responses** | ✅ [Pydantic](https://pydantic.dev) (Python) / [Zod](https://zod.dev) (TS) — schema-validated end to end | Partial | Build each yourself |
-| **Restart-safe** | ✅ Stripe-style idempotency — agent resumes across restarts | ❌ | Build each yourself |
-| **AI pre-verification** | ✅ [Claude](https://www.anthropic.com/claude) / [OpenAI](https://openai.com) / [Gemini](https://gemini.google.com) / [Azure](https://azure.microsoft.com/en-us/products/ai-services/openai-service) — pre-check the human's answer before the agent trusts it | ❌ | Build each yourself |
-| **Workflow engines** | ✅ [Temporal](https://temporal.io) + [LangGraph](https://langchain-ai.github.io/langgraph/) adapters — hand the wait to the engine | ❌ | Build each yourself |
-| **Self-hostable** | ✅ Docker + Postgres in one command | SaaS-only | — |
-| **License** | Apache 2.0 (patent grant) | — | — |
+|                               | **awaithumans**                                                                                                                                                                                                                             | humanlayer           | DIY glue code       |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- | ------------------- |
+| **Maintained**          | ✅ Active development                                                                                                                                                                                                                             | ❌ Abandoned         | —                  |
+| **Setup time**          | One command (`awaithumans dev`)                                                                                                                                                                                                                 | Per-customer rebuild | Weeks               |
+| **Channels**            | Slack + email + built-in dashboard                                                                                                                                                                                                                | Slack only           | Build each yourself |
+| **Typed responses**     | ✅[Pydantic](https://pydantic.dev) (Python) / [Zod](https://zod.dev) (TS) — schema-validated end to end                                                                                                                                                | Partial              | Build each yourself |
+| **Restart-safe**        | ✅ Stripe-style idempotency — agent resumes across restarts                                                                                                                                                                                      | ❌                   | Build each yourself |
+| **AI pre-verification** | ✅[Claude](https://www.anthropic.com/claude) / [OpenAI](https://openai.com) / [Gemini](https://gemini.google.com) / [Azure](https://azure.microsoft.com/en-us/products/ai-services/openai-service) — pre-check the human's answer before the agent trusts it | ❌                   | Build each yourself |
+| **Workflow engines**    | ✅[Temporal](https://temporal.io) + [LangGraph](https://langchain-ai.github.io/langgraph/) adapters — hand the wait to the engine                                                                                                                      | ❌                   | Build each yourself |
+| **Self-hostable**       | ✅ Docker + Postgres in one command                                                                                                                                                                                                               | SaaS-only            | —                  |
+| **License**             | Apache 2.0 (patent grant)                                                                                                                                                                                                                         | —                   | —                  |
 
 Built by engineers who hit the HITL wall three times in production fintech and ScaleBrick agent systems — and watched the only OSS alternative get abandoned by its founder over per-customer-fork creep. The architecture has exactly four extension points (channels, verifiers, routers, task-type handlers) so no single customer can push the core into the same trap.
 
@@ -274,8 +274,7 @@ const decision = await awaitHuman({
 
 Full walkthrough: [`examples/quickstart-ts/`](./examples/quickstart-ts/).
 
-The server + dashboard are Python — TypeScript runs `npx awaithumans
-dev` (via [uv](https://astral.sh/uv)) so you never touch a Python env.
+The server + dashboard are Python — TypeScript runs `npx awaithumans dev` (via [uv](https://astral.sh/uv)) so you never touch a Python env.
 
 ---
 
@@ -339,11 +338,11 @@ Or generate a generic variant via [shields.io](https://shields.io):
 
 ## Packages
 
-| Package | Registry | License |
-|---|---|---|
-| `awaithumans` (Python SDK + server + CLI + dashboard) | PyPI | Apache 2.0 |
-| `awaithumans` (TypeScript SDK) | npm | Apache 2.0 |
-| `ghcr.io/awaithumans/awaithumans` (container) | GHCR | Apache 2.0 |
+| Package                                                 | Registry | License    |
+| ------------------------------------------------------- | -------- | ---------- |
+| `awaithumans` (Python SDK + server + CLI + dashboard) | PyPI     | Apache 2.0 |
+| `awaithumans` (TypeScript SDK)                        | npm      | Apache 2.0 |
+| `ghcr.io/awaithumans/awaithumans` (container)         | GHCR     | Apache 2.0 |
 
 **License:** [Apache License 2.0](LICENSE). Permissive, OSI-approved,
 with an explicit patent grant. Use it in proprietary stacks, fork it,
@@ -353,6 +352,26 @@ the project's trademarks without permission.
 
 ---
 
+
+
+## Troubleshooting
+
+If something isn't working, run the pre-flight check first:
+
+```bash
+awaithumans doctor
+```
+
+It scans your environment for the most common misconfigurations —
+missing or malformed `PAYLOAD_KEY`, Slack token issues, unreachable
+database, Docker bind-mount gotchas — and prints a clear report with
+actionable fixes. This catches ~80% of first-run issues in under
+2 seconds.
+
+---
+
+
+
 ## Status
 
 **v0.1.0 — public preview.** Released 2026-05-11.
@@ -361,4 +380,4 @@ The full primitive, all three channels (dashboard / Slack / email), both durable
 
 This is a young project — APIs are stable for v0.x, but expect rough edges in the long tail. File issues, open PRs, drop questions in [Discussions](https://github.com/awaithumans/awaithumans/discussions) or [Discord](https://discord.gg/Kewdh7vjdc). Every reproducible bug report shipped with a fix in v0.2.
 
-For the post-launch roadmap — local task book for runtimes without an orchestrator, custom router strategies, post-launch hardening — see [Roadmap & help wanted](https://docs.awaithumans.dev/community/roadmap).
+For the post-launch roadmap — local task book for runtimes without an orchestrator, custom router strategies, post-launch hardening — see [Roadmap &amp; help wanted](https://docs.awaithumans.dev/community/roadmap).

--- a/packages/python/awaithumans/cli/commands/doctor.py
+++ b/packages/python/awaithumans/cli/commands/doctor.py
@@ -1,0 +1,12 @@
+"""Pre-flight checks for common misconfigurations."""
+
+from __future__ import annotations
+
+import typer
+
+
+def doctor() -> None:
+    """Run pre-flight checks against the current environment."""
+    typer.echo("awaithumans doctor — checking environment")
+    typer.echo("─" * 45)
+    typer.echo("\n0 checks defined yet.\n")

--- a/packages/python/awaithumans/cli/commands/doctor.py
+++ b/packages/python/awaithumans/cli/commands/doctor.py
@@ -60,6 +60,31 @@ def _check_database() -> tuple[str, str]:
             return ("pass", "Database connection successful")
         except Exception as e:
             return ("fail", f"DATABASE_URL unreachable: {e}")
+def _check_slack_token_shape() -> tuple[str, str]:
+    token = settings.SLACK_BOT_TOKEN
+    if not token:
+        return ("pass", "Slack: SLACK_BOT_TOKEN not configured (skipping)")
+    if not token.startswith("xoxb-"):
+        return ("warn", "Slack: SLACK_BOT_TOKEN looks malformed — expected to start with 'xoxb-'")
+    return ("pass", "Slack: SLACK_BOT_TOKEN shape looks correct")
+
+
+def _check_slack_pairing() -> tuple[str, str]:
+    has_token = bool(settings.SLACK_BOT_TOKEN)
+    has_secret = bool(settings.SLACK_SIGNING_SECRET)
+    if has_token == has_secret:
+        return ("pass", "Slack: token + signing secret both set" if has_token else "Slack: token + signing secret both unset (skipping)")
+    missing = "SLACK_SIGNING_SECRET" if has_token else "SLACK_BOT_TOKEN"
+    return ("warn", f"Slack: {missing} is missing — set both or neither")
+
+
+def _check_slack_public_url() -> tuple[str, str]:
+    slack_configured = bool(settings.SLACK_BOT_TOKEN or settings.SLACK_SIGNING_SECRET)
+    if not slack_configured:
+        return ("pass", "Slack: not configured (skipping PUBLIC_URL check)")
+    if "localhost" in settings.PUBLIC_URL or "127.0.0.1" in settings.PUBLIC_URL:
+        return ("warn", f"Slack: PUBLIC_URL is {settings.PUBLIC_URL} — Slack interactivity buttons won't work from Slack's cloud. Use ngrok or Cloudflare Tunnel, or enable Socket Mode.")
+    return ("pass", f"Slack: PUBLIC_URL is {settings.PUBLIC_URL}")
 
 
 def doctor() -> None:
@@ -68,7 +93,14 @@ def doctor() -> None:
     typer.echo("─" * 45)
     typer.echo()
 
-    checks = [_check_payload_key, _check_admin_api_token, _check_database]
+    checks = [
+        _check_payload_key,
+        _check_admin_api_token,
+        _check_database,
+        _check_slack_token_shape,
+        _check_slack_pairing,
+        _check_slack_public_url,
+    ]
     results = [check() for check in checks]
 
     for status, message in results:

--- a/packages/python/awaithumans/cli/commands/doctor.py
+++ b/packages/python/awaithumans/cli/commands/doctor.py
@@ -164,3 +164,6 @@ def doctor() -> None:
 
     if failed:
         raise typer.Exit(code=1)
+
+    typer.echo("Run `awaithumans dev` when ready.")
+    typer.echo()

--- a/packages/python/awaithumans/cli/commands/doctor.py
+++ b/packages/python/awaithumans/cli/commands/doctor.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import os
+from pathlib import Path
+
 import typer
+from rich.console import Console
+from rich.text import Text
 
 from awaithumans.server.core.config import settings
 from awaithumans.server.core.encryption import (
@@ -11,11 +16,18 @@ from awaithumans.server.core.encryption import (
     get_key,
     reset_key_cache,
 )
+from awaithumans.utils.constants import DISCOVERY_FILE_NAME
+
+console = Console()
 
 
-def _fmt(status: str, message: str) -> str:
+def _print_result(status: str, message: str) -> None:
+    color = {"pass": "green", "warn": "yellow", "fail": "red"}[status]
     icon = {"pass": "✓", "warn": "⚠", "fail": "✗"}[status]
-    return f"{icon} {message}"
+    text = Text()
+    text.append(f"{icon} ", style=f"bold {color}")
+    text.append(message)
+    console.print(text)
 
 
 def _check_payload_key() -> tuple[str, str]:
@@ -23,9 +35,16 @@ def _check_payload_key() -> tuple[str, str]:
     try:
         key = get_key()
         raw = settings.PAYLOAD_KEY or ""
-        return ("pass", f"AWAITHUMANS_PAYLOAD_KEY set ({len(raw)} chars, decodes to {len(key)} bytes)")
+        return (
+            "pass",
+            f"AWAITHUMANS_PAYLOAD_KEY set ({len(raw)} chars, decodes to {len(key)} bytes)",
+        )
     except EncryptionNotConfiguredError:
-        return ("fail", "AWAITHUMANS_PAYLOAD_KEY not set — generate with: python -c 'import secrets; print(secrets.token_urlsafe(32))'")
+        return (
+            "fail",
+            "AWAITHUMANS_PAYLOAD_KEY not set — generate with:"
+            " python -c 'import secrets; print(secrets.token_urlsafe(32))'",
+        )
     except EncryptionKeyError as e:
         return ("fail", f"AWAITHUMANS_PAYLOAD_KEY invalid: {e}")
 
@@ -37,8 +56,6 @@ def _check_admin_api_token() -> tuple[str, str]:
 
 
 def _check_database() -> tuple[str, str]:
-    from pathlib import Path
-
     url = settings.database_url_sync
     if "sqlite" in url:
         path_str = url.split("sqlite:///")[-1]
@@ -52,14 +69,18 @@ def _check_database() -> tuple[str, str]:
         except OSError as e:
             return ("fail", f"Database directory not writable: {e}")
     else:
+        # sqlalchemy kept inline — only needed on the postgres path
         try:
             import sqlalchemy as sa
+
             engine = sa.create_engine(url, connect_args={"connect_timeout": 5})
             with engine.connect():
                 pass
             return ("pass", "Database connection successful")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             return ("fail", f"DATABASE_URL unreachable: {e}")
+
+
 def _check_slack_token_shape() -> tuple[str, str]:
     token = settings.SLACK_BOT_TOKEN
     if not token:
@@ -73,7 +94,12 @@ def _check_slack_pairing() -> tuple[str, str]:
     has_token = bool(settings.SLACK_BOT_TOKEN)
     has_secret = bool(settings.SLACK_SIGNING_SECRET)
     if has_token == has_secret:
-        return ("pass", "Slack: token + signing secret both set" if has_token else "Slack: token + signing secret both unset (skipping)")
+        msg = (
+            "Slack: token + signing secret both set"
+            if has_token
+            else "Slack: token + signing secret both unset (skipping)"
+        )
+        return ("pass", msg)
     missing = "SLACK_SIGNING_SECRET" if has_token else "SLACK_BOT_TOKEN"
     return ("warn", f"Slack: {missing} is missing — set both or neither")
 
@@ -83,8 +109,30 @@ def _check_slack_public_url() -> tuple[str, str]:
     if not slack_configured:
         return ("pass", "Slack: not configured (skipping PUBLIC_URL check)")
     if "localhost" in settings.PUBLIC_URL or "127.0.0.1" in settings.PUBLIC_URL:
-        return ("warn", f"Slack: PUBLIC_URL is {settings.PUBLIC_URL} — Slack interactivity buttons won't work from Slack's cloud. Use ngrok or Cloudflare Tunnel, or enable Socket Mode.")
+        return (
+            "warn",
+            f"Slack: PUBLIC_URL is {settings.PUBLIC_URL} — Slack interactivity buttons won't"
+            " work from Slack's cloud. Use ngrok or Cloudflare Tunnel, or enable Socket Mode.",
+        )
     return ("pass", f"Slack: PUBLIC_URL is {settings.PUBLIC_URL}")
+
+
+def _check_discovery_file() -> tuple[str, str]:
+    path = Path.home() / DISCOVERY_FILE_NAME
+    if not path.exists():
+        return (
+            "pass",
+            f"Discovery file {path} not found (will be created on first `awaithumans dev`)",
+        )
+    if path.is_dir():
+        return (
+            "fail",
+            f"Discovery file {path} is a directory — Docker bind-mount gotcha."
+            f" Remove it: rm -rf {path}",
+        )
+    if not os.access(path, os.W_OK):
+        return ("fail", f"Discovery file {path} exists but is not writable")
+    return ("pass", f"Discovery file at {path} is writable")
 
 
 def doctor() -> None:
@@ -100,16 +148,17 @@ def doctor() -> None:
         _check_slack_token_shape,
         _check_slack_pairing,
         _check_slack_public_url,
+        _check_discovery_file,
     ]
     results = [check() for check in checks]
 
     for status, message in results:
-        typer.echo(_fmt(status, message))
+        _print_result(status, message)
 
-    typer.echo()
     passed = sum(1 for s, _ in results if s == "pass")
-    warned  = sum(1 for s, _ in results if s == "warn")
-    failed  = sum(1 for s, _ in results if s == "fail")
+    warned = sum(1 for s, _ in results if s == "warn")
+    failed = sum(1 for s, _ in results if s == "fail")
+    typer.echo()
     typer.echo(f"{passed} checks passed, {warned} warnings, {failed} errors.")
     typer.echo()
 

--- a/packages/python/awaithumans/cli/commands/doctor.py
+++ b/packages/python/awaithumans/cli/commands/doctor.py
@@ -4,9 +4,82 @@ from __future__ import annotations
 
 import typer
 
+from awaithumans.server.core.config import settings
+from awaithumans.server.core.encryption import (
+    EncryptionKeyError,
+    EncryptionNotConfiguredError,
+    get_key,
+    reset_key_cache,
+)
+
+
+def _fmt(status: str, message: str) -> str:
+    icon = {"pass": "✓", "warn": "⚠", "fail": "✗"}[status]
+    return f"{icon} {message}"
+
+
+def _check_payload_key() -> tuple[str, str]:
+    reset_key_cache()
+    try:
+        key = get_key()
+        raw = settings.PAYLOAD_KEY or ""
+        return ("pass", f"AWAITHUMANS_PAYLOAD_KEY set ({len(raw)} chars, decodes to {len(key)} bytes)")
+    except EncryptionNotConfiguredError:
+        return ("fail", "AWAITHUMANS_PAYLOAD_KEY not set — generate with: python -c 'import secrets; print(secrets.token_urlsafe(32))'")
+    except EncryptionKeyError as e:
+        return ("fail", f"AWAITHUMANS_PAYLOAD_KEY invalid: {e}")
+
+
+def _check_admin_api_token() -> tuple[str, str]:
+    if settings.ADMIN_API_TOKEN:
+        return ("pass", "AWAITHUMANS_ADMIN_API_TOKEN set")
+    return ("warn", "AWAITHUMANS_ADMIN_API_TOKEN not set — admin endpoints will return 503")
+
+
+def _check_database() -> tuple[str, str]:
+    from pathlib import Path
+
+    url = settings.database_url_sync
+    if "sqlite" in url:
+        path_str = url.split("sqlite:///")[-1]
+        db_dir = Path(path_str).parent
+        db_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            test_file = db_dir / ".awaithumans_doctor_test"
+            test_file.touch()
+            test_file.unlink()
+            return ("pass", f"Database at {url} is writable")
+        except OSError as e:
+            return ("fail", f"Database directory not writable: {e}")
+    else:
+        try:
+            import sqlalchemy as sa
+            engine = sa.create_engine(url, connect_args={"connect_timeout": 5})
+            with engine.connect():
+                pass
+            return ("pass", "Database connection successful")
+        except Exception as e:
+            return ("fail", f"DATABASE_URL unreachable: {e}")
+
 
 def doctor() -> None:
     """Run pre-flight checks against the current environment."""
     typer.echo("awaithumans doctor — checking environment")
     typer.echo("─" * 45)
-    typer.echo("\n0 checks defined yet.\n")
+    typer.echo()
+
+    checks = [_check_payload_key, _check_admin_api_token, _check_database]
+    results = [check() for check in checks]
+
+    for status, message in results:
+        typer.echo(_fmt(status, message))
+
+    typer.echo()
+    passed = sum(1 for s, _ in results if s == "pass")
+    warned  = sum(1 for s, _ in results if s == "warn")
+    failed  = sum(1 for s, _ in results if s == "fail")
+    typer.echo(f"{passed} checks passed, {warned} warnings, {failed} errors.")
+    typer.echo()
+
+    if failed:
+        raise typer.Exit(code=1)

--- a/packages/python/awaithumans/cli/main.py
+++ b/packages/python/awaithumans/cli/main.py
@@ -11,7 +11,7 @@ except ImportError:
     # `utils.constants` lives in the base SDK (httpx + pydantic only) —
     # importing it here is safe even when the [server] extras are missing.
     from awaithumans.utils.constants import DOCS_TROUBLESHOOTING_URL
-
+    from awaithumans.cli.commands.doctor import doctor
     raise SystemExit(
         "awaithumans CLI: server extras not installed.\n"
         "\n"
@@ -35,6 +35,7 @@ from awaithumans.cli.commands.remove_user import remove_user
 from awaithumans.cli.commands.revoke_service_key import revoke_service_key
 from awaithumans.cli.commands.set_password import set_password_cmd
 from awaithumans.cli.commands.version import version
+from awaithumans.cli.commands.doctor import doctor
 
 app = typer.Typer(
     name="awaithumans",
@@ -52,6 +53,6 @@ app.command("create-service-key")(create_service_key)
 app.command("list-service-keys")(list_service_keys)
 app.command("revoke-service-key")(revoke_service_key)
 app.command()(version)
-
+app.command()(doctor)
 if __name__ == "__main__":
     app()

--- a/packages/python/awaithumans/cli/main.py
+++ b/packages/python/awaithumans/cli/main.py
@@ -11,7 +11,7 @@ except ImportError:
     # `utils.constants` lives in the base SDK (httpx + pydantic only) —
     # importing it here is safe even when the [server] extras are missing.
     from awaithumans.utils.constants import DOCS_TROUBLESHOOTING_URL
-    from awaithumans.cli.commands.doctor import doctor
+
     raise SystemExit(
         "awaithumans CLI: server extras not installed.\n"
         "\n"
@@ -29,13 +29,13 @@ from awaithumans.cli.commands.add_user import add_user
 from awaithumans.cli.commands.bootstrap_operator import bootstrap_operator
 from awaithumans.cli.commands.create_service_key import create_service_key
 from awaithumans.cli.commands.dev import dev
+from awaithumans.cli.commands.doctor import doctor
 from awaithumans.cli.commands.list_service_keys import list_service_keys
 from awaithumans.cli.commands.list_users import list_users_cmd
 from awaithumans.cli.commands.remove_user import remove_user
 from awaithumans.cli.commands.revoke_service_key import revoke_service_key
 from awaithumans.cli.commands.set_password import set_password_cmd
 from awaithumans.cli.commands.version import version
-from awaithumans.cli.commands.doctor import doctor
 
 app = typer.Typer(
     name="awaithumans",
@@ -46,6 +46,7 @@ app = typer.Typer(
 app.command()(dev)
 app.command("bootstrap-operator")(bootstrap_operator)
 app.command("add-user")(add_user)
+app.command()(doctor)
 app.command("list-users")(list_users_cmd)
 app.command("remove-user")(remove_user)
 app.command("set-password")(set_password_cmd)
@@ -53,6 +54,6 @@ app.command("create-service-key")(create_service_key)
 app.command("list-service-keys")(list_service_keys)
 app.command("revoke-service-key")(revoke_service_key)
 app.command()(version)
-app.command()(doctor)
+
 if __name__ == "__main__":
     app()

--- a/packages/python/tests/cli/test_doctor.py
+++ b/packages/python/tests/cli/test_doctor.py
@@ -1,0 +1,213 @@
+"""Unit tests for awaithumans doctor pre-flight checks.
+
+One test per check, covering happy path + each failure mode.
+Env vars mocked via monkeypatch; no real network or Slack API calls.
+"""
+
+from __future__ import annotations
+
+import base64
+import secrets
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from awaithumans.cli.commands.doctor import (
+    _check_admin_api_token,
+    _check_database,
+    _check_discovery_file,
+    _check_payload_key,
+    _check_slack_pairing,
+    _check_slack_public_url,
+    _check_slack_token_shape,
+)
+from awaithumans.server.core.config import settings
+
+# ── PAYLOAD_KEY ───────────────────────────────────────────────────────────────
+
+
+def test_check_payload_key_valid(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "PAYLOAD_KEY", secrets.token_urlsafe(32))
+    status, msg = _check_payload_key()
+    assert status == "pass"
+    assert "32 bytes" in msg
+
+
+def test_check_payload_key_not_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "PAYLOAD_KEY", None)
+    status, msg = _check_payload_key()
+    assert status == "fail"
+    assert "not set" in msg
+
+
+def test_check_payload_key_wrong_length(monkeypatch: pytest.MonkeyPatch) -> None:
+    short = base64.urlsafe_b64encode(b"tooshort").decode()
+    monkeypatch.setattr(settings, "PAYLOAD_KEY", short)
+    status, msg = _check_payload_key()
+    assert status == "fail"
+
+
+# ── ADMIN_API_TOKEN ───────────────────────────────────────────────────────────
+
+
+def test_check_admin_api_token_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "ADMIN_API_TOKEN", "tok-abc123")
+    status, _ = _check_admin_api_token()
+    assert status == "pass"
+
+
+def test_check_admin_api_token_not_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "ADMIN_API_TOKEN", None)
+    status, msg = _check_admin_api_token()
+    assert status == "warn"
+    assert "503" in msg
+
+
+# ── DATABASE ──────────────────────────────────────────────────────────────────
+
+
+def test_check_database_sqlite_writable(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(settings, "DATABASE_URL", None)
+    monkeypatch.setattr(settings, "DB_PATH", str(tmp_path / "test.db"))
+    status, msg = _check_database()
+    assert status == "pass"
+    assert "writable" in msg
+
+
+def test_check_database_sqlite_not_writable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ro_dir = tmp_path / "readonly"
+    ro_dir.mkdir()
+    ro_dir.chmod(0o444)
+    monkeypatch.setattr(settings, "DATABASE_URL", None)
+    monkeypatch.setattr(settings, "DB_PATH", str(ro_dir / "test.db"))
+    try:
+        status, msg = _check_database()
+        assert status == "fail"
+        assert "not writable" in msg
+    finally:
+        ro_dir.chmod(0o755)
+
+
+def test_check_database_postgres_unreachable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "DATABASE_URL", "postgresql://user:pass@localhost:9999/db")
+    mock_engine = MagicMock()
+    mock_engine.connect.side_effect = Exception("Connection refused")
+    with patch("sqlalchemy.create_engine", return_value=mock_engine):
+        status, msg = _check_database()
+    assert status == "fail"
+    assert "unreachable" in msg
+
+
+# ── SLACK TOKEN SHAPE ─────────────────────────────────────────────────────────
+
+
+def test_check_slack_token_shape_not_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "SLACK_BOT_TOKEN", None)
+    status, msg = _check_slack_token_shape()
+    assert status == "pass"
+    assert "skipping" in msg
+
+
+def test_check_slack_token_shape_valid(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "SLACK_BOT_TOKEN", "xoxb-123456789")
+    status, _ = _check_slack_token_shape()
+    assert status == "pass"
+
+
+def test_check_slack_token_shape_malformed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "SLACK_BOT_TOKEN", "xoxp-wrong-prefix")
+    status, msg = _check_slack_token_shape()
+    assert status == "warn"
+    assert "malformed" in msg
+
+
+# ── SLACK PAIRING ─────────────────────────────────────────────────────────────
+
+
+def test_check_slack_pairing_both_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "SLACK_BOT_TOKEN", "xoxb-123")
+    monkeypatch.setattr(settings, "SLACK_SIGNING_SECRET", "secret")
+    status, msg = _check_slack_pairing()
+    assert status == "pass"
+    assert "both set" in msg
+
+
+def test_check_slack_pairing_both_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "SLACK_BOT_TOKEN", None)
+    monkeypatch.setattr(settings, "SLACK_SIGNING_SECRET", None)
+    status, msg = _check_slack_pairing()
+    assert status == "pass"
+    assert "both unset" in msg
+
+
+def test_check_slack_pairing_token_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "SLACK_BOT_TOKEN", "xoxb-123")
+    monkeypatch.setattr(settings, "SLACK_SIGNING_SECRET", None)
+    status, msg = _check_slack_pairing()
+    assert status == "warn"
+    assert "SLACK_SIGNING_SECRET" in msg
+
+
+def test_check_slack_pairing_secret_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "SLACK_BOT_TOKEN", None)
+    monkeypatch.setattr(settings, "SLACK_SIGNING_SECRET", "secret")
+    status, msg = _check_slack_pairing()
+    assert status == "warn"
+    assert "SLACK_BOT_TOKEN" in msg
+
+
+# ── SLACK PUBLIC URL ──────────────────────────────────────────────────────────
+
+
+def test_check_slack_public_url_not_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "SLACK_BOT_TOKEN", None)
+    monkeypatch.setattr(settings, "SLACK_SIGNING_SECRET", None)
+    status, msg = _check_slack_public_url()
+    assert status == "pass"
+    assert "skipping" in msg
+
+
+def test_check_slack_public_url_localhost_warns(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "SLACK_BOT_TOKEN", "xoxb-123")
+    monkeypatch.setattr(settings, "SLACK_SIGNING_SECRET", "secret")
+    monkeypatch.setattr(settings, "PUBLIC_URL", "http://localhost:3001")
+    status, msg = _check_slack_public_url()
+    assert status == "warn"
+    assert "localhost" in msg
+
+
+def test_check_slack_public_url_public_passes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "SLACK_BOT_TOKEN", "xoxb-123")
+    monkeypatch.setattr(settings, "SLACK_SIGNING_SECRET", "secret")
+    monkeypatch.setattr(settings, "PUBLIC_URL", "https://myapp.example.com")
+    status, _ = _check_slack_public_url()
+    assert status == "pass"
+
+
+# ── DISCOVERY FILE ────────────────────────────────────────────────────────────
+
+
+def test_check_discovery_file_not_found(tmp_path: Path) -> None:
+    with patch.object(Path, "home", return_value=tmp_path):
+        status, msg = _check_discovery_file()
+    assert status == "pass"
+    assert "not found" in msg
+
+
+def test_check_discovery_file_writable(tmp_path: Path) -> None:
+    (tmp_path / ".awaithumans-dev.json").write_text("{}", encoding="utf-8")
+    with patch.object(Path, "home", return_value=tmp_path):
+        status, msg = _check_discovery_file()
+    assert status == "pass"
+    assert "writable" in msg
+
+
+def test_check_discovery_file_is_directory(tmp_path: Path) -> None:
+    (tmp_path / ".awaithumans-dev.json").mkdir()
+    with patch.object(Path, "home", return_value=tmp_path):
+        status, msg = _check_discovery_file()
+    assert status == "fail"
+    assert "directory" in msg


### PR DESCRIPTION
## What

Implements `awaithumans doctor` — a pre-flight CLI command that scans the environment for the 7 most common misconfigurations before the server starts, prints a color-coded report, and exits non-zero if any check fails.

Closes #147

---

## Why

Every misconfiguration in the issue table currently surfaces as a cryptic runtime error or stack trace — often 30+ minutes into debugging a fresh install. This command catches all 7 in under 2 seconds, before `awaithumans dev` ever runs.

---

## Files changed

### `packages/python/awaithumans/cli/commands/doctor.py` _(new)_

Core implementation. Follows the exact same pattern as the existing command files (`version.py` → skeleton, `add_user.py` → typer args, `bootstrap_operator.py` → async + session).

**7 checks implemented:**

| Check | How |
|---|---|
| `AWAITHUMANS_PAYLOAD_KEY` set + decodes to 32 bytes | Calls `get_key()` from `encryption.py` in a try/except — reuses existing validator, no duplicated logic. `reset_key_cache()` called first to ensure a fresh env read. |
| `AWAITHUMANS_ADMIN_API_TOKEN` set | Reads `settings.ADMIN_API_TOKEN` directly from the pydantic-settings singleton. |
| Database writable | SQLite path: touches a temp file in the DB directory and removes it. Postgres path: attempts a real `sqlalchemy.create_engine` connect with `connect_timeout=5`. sqlalchemy import is kept inline (only needed on the postgres branch). |
| `SLACK_BOT_TOKEN` shape | Checks token starts with `xoxb-`. Skips gracefully if Slack is not configured. |
| Slack token + signing secret pairing | Both set or both unset = pass. One without the other = warn with the specific missing var named. |
| `PUBLIC_URL` localhost when Slack is configured | Checks for `localhost` or `127.0.0.1` in `settings.PUBLIC_URL` when any Slack credential is present. |
| Discovery file (`~/.awaithumans-dev.json`) | Checks `Path.home() / DISCOVERY_FILE_NAME` (constant from `utils/constants.py`). Catches the Docker bind-mount gotcha where the path becomes a directory. |

**Output format:**
- `✓` green (pass), `⚠` yellow (warn), `✗` red (fail) via `rich.console.Console` + `rich.text.Text` — `rich` is already a dep via `typer`
- Summary line: `N checks passed, N warnings, N errors.`
- `Run \`awaithumans dev\` when ready.` printed only when exit code is 0
- Exit code 1 if any check fails; warnings don't block

**Import hygiene (CODE_QUALITY.md compliant):**
- stdlib first (`os`, `pathlib.Path`), then third-party (`typer`, `rich`), then first-party (`awaithumans.*`)
- `DISCOVERY_FILE_NAME` imported from `utils/constants.py` at module level — no inline imports except the conditional sqlalchemy load
- Verified clean with `ruff check`, `ruff format --check`, and `mypy` (strict mode)

---

### `packages/python/awaithumans/cli/main.py` _(modified)_

Two lines added:
- `from awaithumans.cli.commands.doctor import doctor` — with the existing import block
- `app.command()(doctor)` — registered alongside all other commands

---

### `packages/python/tests/cli/__init__.py` _(new)_

Empty init to create the `tests/cli/` package. No existing `tests/cli/` directory existed in the repo.

---

### `packages/python/tests/cli/test_doctor.py` _(new)_

21 unit tests — one per check covering happy path + every failure mode. All pass in 0.14s.

**Pattern:** `monkeypatch.setattr(settings, "FIELD", value)` to mock env — same convention as `tests/core/`. `tmp_path` fixture for filesystem checks. `unittest.mock.patch.object` for `Path.home()`. `unittest.mock.MagicMock` + `patch` for sqlalchemy postgres path (avoids real network calls).

| Test | What it covers |
|---|---|
| `test_check_payload_key_valid` | Valid `token_urlsafe(32)` key → pass |
| `test_check_payload_key_not_set` | `None` → fail with "not set" |
| `test_check_payload_key_wrong_length` | Short base64 → fail |
| `test_check_admin_api_token_set` | Token present → pass |
| `test_check_admin_api_token_not_set` | `None` → warn, mentions 503 |
| `test_check_database_sqlite_writable` | Writable `tmp_path` → pass |
| `test_check_database_sqlite_not_writable` | `chmod 0o444` dir → fail |
| `test_check_database_postgres_unreachable` | Mocked engine raises → fail |
| `test_check_slack_token_shape_not_configured` | No token → pass + skipping |
| `test_check_slack_token_shape_valid` | `xoxb-` prefix → pass |
| `test_check_slack_token_shape_malformed` | `xoxp-` prefix → warn |
| `test_check_slack_pairing_both_set` | Token + secret → pass |
| `test_check_slack_pairing_both_unset` | Neither → pass |
| `test_check_slack_pairing_token_only` | Token only → warn, names missing var |
| `test_check_slack_pairing_secret_only` | Secret only → warn, names missing var |
| `test_check_slack_public_url_not_configured` | No Slack → pass + skipping |
| `test_check_slack_public_url_localhost_warns` | localhost URL + Slack configured → warn |
| `test_check_slack_public_url_public_passes` | Public HTTPS URL → pass |
| `test_check_discovery_file_not_found` | File absent → pass |
| `test_check_discovery_file_writable` | File exists + writable → pass |
| `test_check_discovery_file_is_directory` | Path is a dir → fail (Docker gotcha) |

**Pre-existing test failures confirmed unrelated:** `pytest_asyncio` not installed in dev env causes 12 collection errors across `tests/auth/`, `tests/email/`, etc. — verified identical failures on clean checkout before any of our changes.

---

### `README.md` _(modified)_

Added `## Troubleshooting` section between `## Status` and `## Packages` — as required by the issue's "Done means" criteria. Points operators to `awaithumans doctor` as the first thing to run when something breaks.

---

## Files read but not modified

These were read to understand conventions and reuse existing logic:

- `packages/python/awaithumans/server/core/encryption.py` — source of `get_key()`, `EncryptionKeyError`, `EncryptionNotConfiguredError`, `reset_key_cache()`
- `packages/python/awaithumans/server/core/config.py` — pydantic-settings `Settings` singleton; all field names, `database_url_sync` property
- `packages/python/awaithumans/utils/constants.py` — `DISCOVERY_FILE_NAME = ".awaithumans-dev.json"`
- `packages/python/awaithumans/cli/commands/version.py` — simplest command skeleton
- `packages/python/awaithumans/cli/commands/add_user.py` — typer args pattern
- `packages/python/awaithumans/cli/commands/bootstrap_operator.py` — async + DB session pattern
- `packages/python/awaithumans/cli/commands/_session.py` — session helper (not needed for doctor, confirmed)
- `packages/python/tests/core/test_config_unknown_env_keys.py` — test conventions (monkeypatch, tmp_path, assertion style)
- `CODE_QUALITY.md` — import ordering rules, inline import policy, line length, ruff/mypy requirements
- `CONTRIBUTING.md` — migration rules, single-head invariant (no migrations needed for this PR)
- `pyproject.toml` — ruff config (`line-length = 100`, `select = ["E","F","I","N","UP","B","SIM","T20"]`), mypy strict, pytest config

---

## One open question for review

The issue sketch shows `AWAITHUMANS_API_KEY` as check #2. The actual `Settings` class has no `API_KEY` field — the closest matching field is `ADMIN_API_TOKEN` (`AWAITHUMANS_ADMIN_API_TOKEN`), which gates admin endpoints. I implemented the check against that field. Please confirm this is the intended mapping, or point me to the right field and I'll update in one line.