### PR TITLE
fix(deps): patch uuid vulnerability via override, bump sdk to 0.1.8

### DIFF
--- a/examples/langgraph-ts/package-lock.json
+++ b/examples/langgraph-ts/package-lock.json
@@ -23,8 +23,8 @@
     },
     "../../packages/typescript-sdk": {
       "name": "awaithumans",
-      "version": "0.0.1",
-      "license": "MIT",
+      "version": "0.1.8",
+      "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.0",
         "zod-to-json-schema": "^3.23.0"
@@ -33,14 +33,14 @@
         "awaithumans": "bin/awaithumans.mjs"
       },
       "devDependencies": {
-        "@langchain/langgraph": "^0.2.0",
+        "@langchain/langgraph": "^0.2.0 || ^1.0.0",
         "@temporalio/client": "^1.0.0",
         "@temporalio/workflow": "^1.0.0",
         "typescript": "^5.7.0",
         "vitest": "^4.1.5"
       },
       "peerDependencies": {
-        "@langchain/langgraph": "^0.2.0",
+        "@langchain/langgraph": "^0.2.0 || ^1.0.0",
         "@temporalio/client": "^1.0.0",
         "@temporalio/workflow": "^1.0.0"
       },
@@ -606,20 +606,6 @@
         }
       }
     },
-    "node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -946,17 +932,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/zod": {

--- a/examples/langgraph-ts/package.json
+++ b/examples/langgraph-ts/package.json
@@ -21,6 +21,7 @@
     "typescript": "^5.7.0"
   },
   "overrides": {
-    "langsmith": ">=0.6.0"
+    "langsmith": ">=0.6.0",
+    "uuid": "^11.1.1"
   }
 }

--- a/packages/typescript-sdk/package-lock.json
+++ b/packages/typescript-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "awaithumans",
-  "version": "0.1.5",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "awaithumans",
-      "version": "0.1.5",
+      "version": "0.1.8",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.0",
@@ -225,21 +225,6 @@
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -632,20 +617,6 @@
       },
       "engines": {
         "node": ">= 20.0.0"
-      }
-    },
-    "node_modules/@temporalio/client/node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@temporalio/common": {
@@ -1864,10 +1835,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -1875,7 +1845,7 @@
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/packages/typescript-sdk/package.json
+++ b/packages/typescript-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awaithumans",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "HITL infrastructure for AI agents. Your agent calls awaitHuman(), a human reviews via Slack/email/dashboard, agent resumes with a typed response.",
   "type": "module",
   "sideEffects": false,
@@ -58,7 +58,8 @@
   },
   "overrides": {
     "langsmith": ">=0.6.0",
-    "protobufjs": "^7.5.8"
+    "protobufjs": "^7.5.8",
+    "uuid": "^11.1.1"
   },
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

Fixes Dependabot alerts **#39** (`examples/langgraph-ts/package-lock.json`) and **#40** (`packages/typescript-sdk/package-lock.json`):

> **uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided** (moderate)

Both manifests were transitively pulling vulnerable uuid:
- `uuid@9.0.1` via `@langchain/langgraph-sdk`
- `uuid@10.0.0` via other transitive paths

Both fall inside the advisory's `< 11.1.1` range.

## Fix

Add a `uuid` override pinned to `^11.1.1` in:
- `packages/typescript-sdk/package.json`
- `examples/langgraph-ts/package.json`

This forces every transitive install to resolve to `uuid@11.1.1` (the patched version) and keeps us out of the v12/v13 vulnerable subranges entirely.

After regenerating both lockfiles:
- typescript-sdk: single `uuid@11.1.1` install
- langgraph-ts: single `uuid@11.1.1` install
- `npm audit` reports zero vulnerabilities in both

Also bump `awaithumans` `0.1.7` -> `0.1.8` so the security fix reaches npm on next publish.

## Test plan

- [x] `npm run typecheck` clean in typescript-sdk
- [x] `npm test` -> 66/66 tests pass
- [x] Lockfiles regenerated, single `uuid@11.1.1` install in each project
- [x] `npm audit` reports 0 vulnerabilities
- [ ] CI green
- [ ] Dependabot alerts #39 and #40 auto-close after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)