### PR TITLE
test(adapters): fix 4 pre-existing failures from missing PAYLOAD_KEY fixture

### DIFF
--- a/packages/python/tests/adapters/conftest.py
+++ b/packages/python/tests/adapters/conftest.py
@@ -1,0 +1,41 @@
+"""Shared fixtures for adapter tests.
+
+The temporal/langgraph adapters and the webhook-signing path that
+backs them read `AWAITHUMANS_PAYLOAD_KEY` from `os.environ` directly
+(see PR #71 — the webhook_signing module stays free of the
+pydantic-settings dependency so it works in adapter receivers that
+don't install [server]).
+
+Without this fixture, every test that exercises a signed callback
+fails at module-load with `PayloadKeyMissingError`. Mirrors the
+identical fixture in `tests/auth/conftest.py`.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+from collections.abc import Iterator
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _payload_key_for_adapters() -> Iterator[None]:
+    fresh = secrets.token_urlsafe(32)
+    original_env = os.environ.get("AWAITHUMANS_PAYLOAD_KEY")
+    os.environ["AWAITHUMANS_PAYLOAD_KEY"] = fresh
+
+    # Reset the webhook-signing module's cached key so it picks up
+    # `fresh` on the next derivation.
+    from awaithumans.utils import webhook_signing
+
+    webhook_signing.reset_cache()
+
+    yield
+
+    if original_env is None:
+        os.environ.pop("AWAITHUMANS_PAYLOAD_KEY", None)
+    else:
+        os.environ["AWAITHUMANS_PAYLOAD_KEY"] = original_env
+    webhook_signing.reset_cache()

--- a/packages/python/tests/adapters/test_temporal_adapter.py
+++ b/packages/python/tests/adapters/test_temporal_adapter.py
@@ -250,6 +250,7 @@ async def test_await_human_returns_response_after_signal(
     """Happy path: workflow registers signal handler, fires create-task
     activity, signals from outside, workflow returns typed response."""
     pytest.importorskip("temporalio")
+    from temporalio import activity
     from temporalio.testing import WorkflowEnvironment
     from temporalio.worker import Worker
 
@@ -257,8 +258,14 @@ async def test_await_human_returns_response_after_signal(
 
     # Stub the create-task activity so we don't need a real
     # awaithumans server. It returns a synthetic task_id and the
-    # workflow proceeds to wait_condition.
-    async def fake_create(req: adapter._CreateTaskInput) -> dict:
+    # workflow proceeds to wait_condition. The `@activity.defn`
+    # decoration is required as of temporalio >=1.x — the Worker
+    # rejects bare callables on its `activities=` list.
+    @activity.defn
+    async def fake_create(req: Any) -> dict:
+        # Type erased to `Any` so temporalio's @activity.defn type-
+        # hint resolver doesn't try to look up the function-local
+        # `adapter` symbol from module globals.
         return {"id": "task-stub", "idempotency_key": req.idempotency_key}
 
     monkeypatch.setattr(adapter, "awaithumans_create_task", fake_create)
@@ -304,12 +311,17 @@ async def test_await_human_raises_typed_error_on_cancelled_status(
     """Webhook delivers status=cancelled → workflow raises
     TaskCancelledError, not TaskTimeoutError. Agents can distinguish."""
     pytest.importorskip("temporalio")
+    from temporalio import activity
     from temporalio.testing import WorkflowEnvironment
     from temporalio.worker import Worker
 
     from awaithumans.adapters import temporal as adapter
 
-    async def fake_create(req: adapter._CreateTaskInput) -> dict:
+    @activity.defn
+    async def fake_create(req: Any) -> dict:
+        # Type erased to `Any` so temporalio's @activity.defn type-
+        # hint resolver doesn't try to look up the function-local
+        # `adapter` symbol from module globals.
         return {"id": "task-stub", "idempotency_key": req.idempotency_key}
 
     monkeypatch.setattr(adapter, "awaithumans_create_task", fake_create)


### PR DESCRIPTION
## Summary

- Adds `tests/adapters/conftest.py` mirroring `tests/auth/conftest.py` so adapter tests that exercise signed callbacks no longer crash at module-load with `PayloadKeyMissingError`.
- Decorates the two `fake_create` stubs in `test_temporal_adapter.py` with `@activity.defn` so `temporalio.Worker(activities=...)` accepts them. Parameter type widened to `Any` because `@activity.defn`'s `get_type_hints()` runs in module globals and can't resolve the function-local `adapter` import.
- Result: 6 → 2 failures in `tests/adapters/`.

## Background

The four signature-verification tests below have been failing on `main` for a while:

- `test_dispatch_signal_routes_to_correct_workflow_and_signal`
- `test_dispatch_signal_rejects_bad_signature`
- `test_dispatch_signal_rejects_non_json_body`
- `test_dispatch_signal_rejects_missing_idempotency_key`

Root cause: `awaithumans.utils.webhook_signing` reads `AWAITHUMANS_PAYLOAD_KEY` from `os.environ` directly (deliberately, so it stays free of the `pydantic-settings` dependency and works in adapter receivers that don't install the `[server]` extra — see PR #71). Without an autouse fixture setting that env var, signature-verification tests fail at import time.

`tests/auth/conftest.py` already had the right fixture. Adding the same one under `tests/adapters/` fixes all four.

## Still failing (out of scope)

Two workflow integration tests still fail on a separate `temporalio` workflow sandbox restriction:

- `test_await_human_returns_response_after_signal`
- `test_await_human_raises_typed_error_on_cancelled_status`

Both error with `__mro_entries__ on urllib.request.Request restricted` — current temporalio's workflow sandbox blocks `urllib.request` imports during workflow replay. This needs either passthrough configuration on the worker or refactoring the imports out of the workflow path. Tracking separately.

## Test plan

- [x] `pytest tests/adapters/` locally: 4 previously-failing tests now pass; 2 unrelated failures remain
- [ ] CI green on this branch