### PR TITLE
fix(temporal): defer httpx import out of the workflow-replay path

### DIFF
--- a/packages/python/awaithumans/adapters/temporal/__init__.py
+++ b/packages/python/awaithumans/adapters/temporal/__init__.py
@@ -50,7 +50,6 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any, TypeVar
 
-import httpx
 from pydantic import BaseModel
 
 from awaithumans.errors import (
@@ -160,6 +159,12 @@ async def awaithumans_create_task(req: _CreateTaskInput) -> dict[str, Any]:
     Temporal's automatic activity retries cover transient server
     errors; the workflow's wait_condition only proceeds once the
     activity returns a task_id."""
+    # httpx pulls in urllib.request transitively, which the workflow
+    # sandbox forbids at replay time. Keeping the import inside the
+    # activity body (which runs outside the sandbox) keeps the module
+    # import-safe for workflow code.
+    import httpx
+
     headers: dict[str, str] = {}
     if req.api_key:
         headers["Authorization"] = f"Bearer {req.api_key}"

--- a/packages/python/awaithumans/client.py
+++ b/packages/python/awaithumans/client.py
@@ -7,10 +7,12 @@ import hashlib
 import json
 import logging
 import sys
-from typing import TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
-import httpx
 from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    import httpx  # noqa: F401
 
 from awaithumans.errors import (
     MarketplaceNotAvailableError,
@@ -159,6 +161,11 @@ async def await_human(
     form_definition = extract_form(response_schema).model_dump(mode="json")
 
     # ── Create task on the server ────────────────────────────────────
+    # Deferred so `awaithumans` is import-safe inside a Temporal workflow
+    # sandbox; httpx transitively pulls in urllib.request, which the
+    # sandbox forbids at workflow replay time.
+    import httpx
+
     async with httpx.AsyncClient(timeout=SDK_CREATE_TIMEOUT_SECONDS) as client:
         create_body = {
             "task": task,
@@ -213,6 +220,8 @@ async def _poll_until_terminal(
     The server's poll endpoint holds the connection for up to 25 seconds
     per request.
     """
+    import httpx
+
     async with httpx.AsyncClient(
         timeout=POLL_INTERVAL_SECONDS + SDK_POLL_TIMEOUT_BUFFER_SECONDS,
     ) as client:

--- a/packages/python/awaithumans/embed.py
+++ b/packages/python/awaithumans/embed.py
@@ -23,8 +23,6 @@ import os
 import sys
 from dataclasses import dataclass
 
-import httpx
-
 DEFAULT_SERVER = "http://localhost:3001"
 
 
@@ -61,6 +59,11 @@ async def embed_token(
         body["sub"] = sub
     if ttl_seconds is not None:
         body["ttl_seconds"] = ttl_seconds
+
+    # Deferred so `awaithumans` is import-safe inside a Temporal workflow
+    # sandbox; httpx transitively pulls in urllib.request, which the
+    # sandbox forbids at workflow replay time.
+    import httpx
 
     async with httpx.AsyncClient(timeout=15.0) as client:
         res = await client.post(

--- a/packages/python/tests/adapters/test_temporal_adapter.py
+++ b/packages/python/tests/adapters/test_temporal_adapter.py
@@ -34,6 +34,7 @@ import pytest
 from pydantic import BaseModel
 
 from awaithumans.adapters.temporal import (
+    _CreateTaskInput,
     _signal_name,
     awaithumans_create_task,
     dispatch_signal,
@@ -41,15 +42,21 @@ from awaithumans.adapters.temporal import (
 from awaithumans.errors import (
     TaskCancelledError,
 )
-from awaithumans.server.core import encryption
-from awaithumans.server.core.config import settings
-from awaithumans.server.services.webhook_dispatch import sign_body
+
+# Server-side modules (encryption, settings, webhook_dispatch) are
+# imported lazily inside the fixture/helper bodies that use them. At
+# module top they would pull in cryptography and httpx, both of which
+# the Temporal workflow sandbox forbids at workflow-replay time when
+# this file is loaded as the host module of the workflow class.
 
 
 @pytest.fixture(autouse=True)
 def _payload_key() -> Iterator[None]:
     """HKDF derives the webhook key from PAYLOAD_KEY — required for
     `sign_body` and `verify_signature` to work."""
+    from awaithumans.server.core import encryption
+    from awaithumans.server.core.config import settings
+
     original = settings.PAYLOAD_KEY
     settings.PAYLOAD_KEY = secrets.token_urlsafe(32)
     encryption.reset_key_cache()
@@ -91,6 +98,8 @@ class _FakeTemporalClient:
 
 
 def _signed_body(payload: dict[str, Any]) -> tuple[bytes, str]:
+    from awaithumans.server.services.webhook_dispatch import sign_body
+
     body = json.dumps(payload).encode()
     return body, sign_body(body)
 
@@ -150,6 +159,8 @@ async def test_dispatch_signal_rejects_bad_signature() -> None:
 
 @pytest.mark.asyncio
 async def test_dispatch_signal_rejects_non_json_body() -> None:
+    from awaithumans.server.services.webhook_dispatch import sign_body
+
     client = _FakeTemporalClient()
     body = b"not-json"
     sig = sign_body(body)
@@ -258,14 +269,13 @@ async def test_await_human_returns_response_after_signal(
 
     # Stub the create-task activity so we don't need a real
     # awaithumans server. It returns a synthetic task_id and the
-    # workflow proceeds to wait_condition. The `@activity.defn`
-    # decoration is required as of temporalio >=1.x — the Worker
-    # rejects bare callables on its `activities=` list.
-    @activity.defn
-    async def fake_create(req: Any) -> dict:
-        # Type erased to `Any` so temporalio's @activity.defn type-
-        # hint resolver doesn't try to look up the function-local
-        # `adapter` symbol from module globals.
+    # workflow proceeds to wait_condition. The activity is registered
+    # under the same name the workflow dispatches by; the workflow runs
+    # inside the temporal sandbox with its own fresh import of the
+    # adapter, so an attribute-level monkeypatch on the outside-sandbox
+    # module would not be visible to the workflow's call site.
+    @activity.defn(name="awaithumans_create_task")
+    async def fake_create(req: _CreateTaskInput) -> dict:
         return {"id": "task-stub", "idempotency_key": req.idempotency_key}
 
     monkeypatch.setattr(adapter, "awaithumans_create_task", fake_create)
@@ -286,7 +296,10 @@ async def test_await_human_returns_response_after_signal(
                 task_queue="test-q",
             )
 
-            idem = adapter._default_idempotency_key("Approve refund?", _Payload(amount=100))
+            # The adapter derives the default idempotency key from the
+            # workflow id (`temporal:{workflow_id}`, PR #72); the signal
+            # name we send back has to match that derivation.
+            idem = f"temporal:{wf_id}"
             signal = adapter._signal_name(idem)
             await asyncio.sleep(0.5)  # let workflow register handler
             await handle.signal(
@@ -317,11 +330,10 @@ async def test_await_human_raises_typed_error_on_cancelled_status(
 
     from awaithumans.adapters import temporal as adapter
 
-    @activity.defn
-    async def fake_create(req: Any) -> dict:
-        # Type erased to `Any` so temporalio's @activity.defn type-
-        # hint resolver doesn't try to look up the function-local
-        # `adapter` symbol from module globals.
+    # See comment in test_await_human_returns_response_after_signal for
+    # why we register the stub under the same name as the real activity.
+    @activity.defn(name="awaithumans_create_task")
+    async def fake_create(req: _CreateTaskInput) -> dict:
         return {"id": "task-stub", "idempotency_key": req.idempotency_key}
 
     monkeypatch.setattr(adapter, "awaithumans_create_task", fake_create)
@@ -336,7 +348,10 @@ async def test_await_human_raises_typed_error_on_cancelled_status(
         ):
             wf_id = f"wf-{uuid.uuid4()}"
             handle = await client.start_workflow(_CancelWorkflow.run, id=wf_id, task_queue="test-q")
-            idem = adapter._default_idempotency_key("Approve refund?", _Payload(amount=100))
+            # The adapter derives the default idempotency key from the
+            # workflow id (`temporal:{workflow_id}`, PR #72); the signal
+            # name we send back has to match that derivation.
+            idem = f"temporal:{wf_id}"
             await asyncio.sleep(0.5)
             await handle.signal(
                 adapter._signal_name(idem),
@@ -377,11 +392,11 @@ async def test_create_task_activity_posts_with_bearer_when_api_key_set(
         kw.pop("transport", None)
         return real_client(transport=httpx.MockTransport(fake_handler), **kw)
 
-    # Adapter imports `httpx` at module level (not inline), so we
-    # patch the attribute reference the activity actually uses.
-    import awaithumans.adapters.temporal as adapter
-
-    monkeypatch.setattr(adapter.httpx, "AsyncClient", _factory)
+    # Adapter lazy-imports `httpx` inside the activity body (kept off the
+    # module top so the workflow sandbox can load this file). Patching
+    # the httpx module itself is what the activity's `import httpx` will
+    # observe.
+    monkeypatch.setattr(httpx, "AsyncClient", _factory)
 
     from awaithumans.adapters.temporal import _CreateTaskInput
 


### PR DESCRIPTION
## Summary

Fixes the two pre-existing failures in \`tests/adapters/test_temporal_adapter.py\`:

- \`test_await_human_returns_response_after_signal\`
- \`test_await_human_raises_typed_error_on_cancelled_status\`

Both failed at workflow validation with:

\`\`\`
RestrictionError: Cannot access __mro_entries__ on urllib.request.Request from inside a workflow.
\`\`\`

## Root cause

\`httpx\` was imported at module top in three files reachable from the workflow's transitive import graph. The workflow file does \`from awaithumans.adapters import temporal as _adapter\`, which triggers \`awaithumans/__init__.py\`, which eagerly imports \`client.py\` and \`embed.py\`. \`httpx\` in turn pulls in \`urllib.request\`, which the Temporal workflow sandbox forbids at workflow-replay time.

## Fix

Fix path 1 from the task brief (lazy import inside the function that uses it), per the adapter's existing pattern: \`awaithumans.forms\` is already lazy-loaded inside \`await_human\` for the same reason. \`httpx\` is only used at runtime inside the network-calling functions, so moving \`import httpx\` into the bodies of \`awaithumans_create_task\`, \`await_human\`, \`_poll_until_terminal\`, and \`embed_token\` keeps the workflow's import-time surface clean while preserving runtime behavior.

After the urllib block was removed, the same tests surfaced two further pre-existing failures that the sandbox had masked:

1. \`cryptography\` was pulled in by module-top imports of server-side modules (\`encryption\`, \`webhook_dispatch\`) in the test file. Those are only consumed by the in-file PAYLOAD_KEY fixture and the dispatch-test helpers, so the imports moved into the fixture / helper bodies that use them.
2. The workflow tests referenced \`adapter._default_idempotency_key\` (the pre-#72 content-hash default) and registered the stub activity under its function name \`fake_create\`. The current adapter derives the default key as \`temporal:{workflow_id}\` and the workflow dispatches the activity by name \`awaithumans_create_task\`. The test now computes \`idem = f\"temporal:{wf_id}\"\` and registers the stub as \`@activity.defn(name=\"awaithumans_create_task\")\`, with \`req\` typed as \`_CreateTaskInput\` (now in module globals) so the temporal data converter rehydrates the dataclass on the activity side.

## Base branch

Filed against \`fix/adapter-tests-payload-key\` (#154) because reproducing the urllib error requires the \`@activity.defn\` baseline that PR adds. When #154 merges into main, GitHub will auto-retarget this PR.

## Test plan

- [x] \`uv run pytest tests/adapters/test_temporal_adapter.py::test_await_human_returns_response_after_signal\` passes
- [x] \`uv run pytest tests/adapters/test_temporal_adapter.py::test_await_human_raises_typed_error_on_cancelled_status\` passes
- [x] All 17 tests in \`tests/adapters/\` pass
- [x] Full suite (685 + 17) passes, no regressions
- [x] \`ruff check\` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)