### PR TITLE
chore(repo): point URL refs at canonical renamed repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 <div align="center">
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/awaithumans/awaithumans/main/docs/logo/dark.svg">
-  <img alt="awaithumans" src="https://raw.githubusercontent.com/awaithumans/awaithumans/main/docs/logo/light.svg" width="520">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/awaithumans/awaithumans-human-in-the-loop-ai-agents/main/docs/logo/dark.svg">
+  <img alt="awaithumans" src="https://raw.githubusercontent.com/awaithumans/awaithumans-human-in-the-loop-ai-agents/main/docs/logo/light.svg" width="520">
 </picture>
 
 <br>
@@ -15,12 +15,12 @@
 
 [![PyPI installs](https://img.shields.io/pepy/dt/awaithumans?style=for-the-badge&label=PyPI%20installs&color=3775A9&logo=pypi&logoColor=white)](https://pepy.tech/project/awaithumans)
 [![npm installs](https://img.shields.io/npm/dt/awaithumans?style=for-the-badge&label=npm%20installs&color=CB3837&logo=npm&logoColor=white)](https://www.npmjs.com/package/awaithumans)
-[![GitHub stars](https://img.shields.io/github/stars/awaithumans/awaithumans?style=for-the-badge&color=FBBF24&logo=github&logoColor=white&label=GitHub%20stars)](https://github.com/awaithumans/awaithumans)
+[![GitHub stars](https://img.shields.io/github/stars/awaithumans/awaithumans-human-in-the-loop-ai-agents?style=for-the-badge&color=FBBF24&logo=github&logoColor=white&label=GitHub%20stars)](https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents)
 
 [![PyPI](https://img.shields.io/pypi/v/awaithumans?label=pypi&color=3775A9&logo=pypi&logoColor=white)](https://pypi.org/project/awaithumans/)
 [![npm](https://img.shields.io/npm/v/awaithumans?label=npm&color=CB3837&logo=npm&logoColor=white)](https://www.npmjs.com/package/awaithumans)
-[![CI](https://img.shields.io/github/actions/workflow/status/awaithumans/awaithumans/test.yml?label=tests&logo=github&logoColor=white)](https://github.com/awaithumans/awaithumans/actions/workflows/test.yml)
-[![License](https://img.shields.io/badge/license-Apache_2.0-blue)](https://github.com/awaithumans/awaithumans/blob/main/LICENSE)
+[![CI](https://img.shields.io/github/actions/workflow/status/awaithumans/awaithumans-human-in-the-loop-ai-agents/test.yml?label=tests&logo=github&logoColor=white)](https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents/actions/workflows/test.yml)
+[![License](https://img.shields.io/badge/license-Apache_2.0-blue)](https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents/blob/main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
 [![Discord](https://img.shields.io/badge/discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/Kewdh7vjdc)
 
@@ -56,9 +56,9 @@ The agent waits on `decision` like it waits on any other Promise or Future.
 A human gets notified ([Slack](https://slack.com), email, dashboard), reviews the request, and
 submits a typed response. The agent resumes with the typed answer.
 
-![awaithumans demo — an agent creates a task, a human reviews it, the agent resumes with the typed response](https://raw.githubusercontent.com/awaithumans/awaithumans/main/docs/images/hero-demo.gif)
+![awaithumans demo — an agent creates a task, a human reviews it, the agent resumes with the typed response](https://raw.githubusercontent.com/awaithumans/awaithumans-human-in-the-loop-ai-agents/main/docs/images/hero-demo.gif)
 
-![The awaithumans dashboard — pending tasks queued for human review](https://raw.githubusercontent.com/awaithumans/awaithumans/main/docs/images/hero-dashboard.png)
+![The awaithumans dashboard — pending tasks queued for human review](https://raw.githubusercontent.com/awaithumans/awaithumans-human-in-the-loop-ai-agents/main/docs/images/hero-dashboard.png)
 
 ---
 
@@ -170,7 +170,7 @@ Add `notify=["slack:#ops"]` and the task lands in the channel with a
 response form opens as a modal. Completing it unblocks the agent
 just like the dashboard path.
 
-![Slack broadcast — a task posted to a channel with a Claim button](https://raw.githubusercontent.com/awaithumans/awaithumans/main/docs/images/slack-broadcast.png)
+![Slack broadcast — a task posted to a channel with a Claim button](https://raw.githubusercontent.com/awaithumans/awaithumans-human-in-the-loop-ai-agents/main/docs/images/slack-broadcast.png)
 
 ```python
 decision = await await_human(
@@ -323,16 +323,16 @@ the entire extension surface.
 
 Drop this badge in your project's README so folks know where the HITL primitive came from:
 
-[![Powered by awaithumans](https://raw.githubusercontent.com/awaithumans/awaithumans/main/docs/images/badges/powered-by-awaithumans.svg)](https://github.com/awaithumans/awaithumans)
+[![Powered by awaithumans](https://raw.githubusercontent.com/awaithumans/awaithumans-human-in-the-loop-ai-agents/main/docs/images/badges/powered-by-awaithumans.svg)](https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents)
 
 ```markdown
-[![Powered by awaithumans](https://raw.githubusercontent.com/awaithumans/awaithumans/main/docs/images/badges/powered-by-awaithumans.svg)](https://github.com/awaithumans/awaithumans)
+[![Powered by awaithumans](https://raw.githubusercontent.com/awaithumans/awaithumans-human-in-the-loop-ai-agents/main/docs/images/badges/powered-by-awaithumans.svg)](https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents)
 ```
 
 Or generate a generic variant via [shields.io](https://shields.io):
 
 ```markdown
-[![Powered by awaithumans](https://img.shields.io/badge/Powered_by-awaithumans-00E676)](https://github.com/awaithumans/awaithumans)
+[![Powered by awaithumans](https://img.shields.io/badge/Powered_by-awaithumans-00E676)](https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents)
 ```
 
 ---
@@ -374,7 +374,7 @@ the project's trademarks without permission.
 
 The full primitive, all three channels (dashboard / Slack / email), both durable adapters (Temporal / LangGraph), AI verification across four providers, and one-command self-hosting are all live in this release.
 
-This is a young project — APIs are stable for v0.x, but expect rough edges in the long tail. File issues, open PRs, drop questions in [Discussions](https://github.com/awaithumans/awaithumans/discussions) or [Discord](https://discord.gg/Kewdh7vjdc). Every reproducible bug report shipped with a fix in v0.2.
+This is a young project — APIs are stable for v0.x, but expect rough edges in the long tail. File issues, open PRs, drop questions in [Discussions](https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents/discussions) or [Discord](https://discord.gg/Kewdh7vjdc). Every reproducible bug report shipped with a fix in v0.2.
 
 For the post-launch roadmap — local task book for runtimes without an orchestrator, custom router strategies, post-launch hardening — see [Roadmap & help wanted](https://docs.awaithumans.dev/community/roadmap).
 
@@ -392,9 +392,9 @@ awaithumans is built by the maintainers and these brilliant community contributo
     <b>Hiren Gajjar</b>
   </a><br>
   <sub><code>awaithumans doctor</code></sub><br>
-  <sub><a href="https://github.com/awaithumans/awaithumans/pull/150">#150</a></sub>
+  <sub><a href="https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents/pull/150">#150</a></sub>
 </td>
 </tr>
 </table>
 
-Want to be on this list? Pick a [`good first issue`](https://github.com/awaithumans/awaithumans/labels/good%20first%20issue), drop a comment on it to claim, and we'll review your PR within ~24h. As we grow, this gallery shrinks each avatar back down to a tight grid — same shape, more faces.
+Want to be on this list? Pick a [`good first issue`](https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents/labels/good%20first%20issue), drop a comment on it to claim, and we'll review your PR within ~24h. As we grow, this gallery shrinks each avatar back down to a tight grid — same shape, more faces.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -115,7 +115,7 @@
       "anchors": [
         {
           "anchor": "GitHub",
-          "href": "https://github.com/awaithumans/awaithumans",
+          "href": "https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents",
           "icon": "github"
         },
         {
@@ -125,7 +125,7 @@
         },
         {
           "anchor": "Releases",
-          "href": "https://github.com/awaithumans/awaithumans/releases",
+          "href": "https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents/releases",
           "icon": "tag"
         }
       ]
@@ -148,11 +148,11 @@
     "links": [
       {
         "label": "GitHub",
-        "href": "https://github.com/awaithumans/awaithumans"
+        "href": "https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents"
       },
       {
         "label": "Releases",
-        "href": "https://github.com/awaithumans/awaithumans/releases"
+        "href": "https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents/releases"
       }
     ],
     "primary": {
@@ -175,7 +175,7 @@
   },
   "footer": {
     "socials": {
-      "github": "https://github.com/awaithumans/awaithumans",
+      "github": "https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents",
       "x": "https://x.com/awaithumans"
     },
     "links": [
@@ -192,7 +192,7 @@
           },
           {
             "label": "Releases",
-            "href": "https://github.com/awaithumans/awaithumans/releases"
+            "href": "https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents/releases"
           }
         ]
       },
@@ -243,7 +243,7 @@
         "items": [
           {
             "label": "GitHub",
-            "href": "https://github.com/awaithumans/awaithumans"
+            "href": "https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents"
           },
           {
             "label": "Discord",

--- a/packages/dashboard/components/console-banner.tsx
+++ b/packages/dashboard/components/console-banner.tsx
@@ -27,7 +27,7 @@ export function ConsoleBanner() {
 		// invitation. Short, specific, not generic AI filler.
 		// eslint-disable-next-line no-console
 		console.log(
-			"%c$ await_human()%c\n%c# the human layer for AI agents\n# source: github.com/awaithumans/awaithumans",
+			"%c$ await_human()%c\n%c# the human layer for AI agents\n# source: github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents",
 			mono,
 			"",
 			body,

--- a/packages/dashboard/lib/constants.ts
+++ b/packages/dashboard/lib/constants.ts
@@ -50,7 +50,7 @@ export const DOCS_BASE_URL = "https://docs.awaithumans.dev";
 export const DOCS_TROUBLESHOOTING_URL = `${DOCS_BASE_URL}/troubleshooting`;
 
 /** Project links. */
-export const GITHUB_URL = "https://github.com/awaithumans/awaithumans";
+export const GITHUB_URL = "https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents";
 
 /** Shown in the sidebar footer. Bump on each dashboard release. */
 export const APP_VERSION = "v0.1.0 · alpha";

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -37,7 +37,7 @@
   "license": "SEE LICENSE IN LICENSE",
   "repository": {
     "type": "git",
-    "url": "https://github.com/awaithumans/awaithumans",
+    "url": "https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents",
     "directory": "packages/dashboard"
   }
 }

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-<img alt="awaithumans" src="https://cdn.jsdelivr.net/gh/awaithumans/awaithumans@main/docs/logo/light.svg" width="520">
+<img alt="awaithumans" src="https://cdn.jsdelivr.net/gh/awaithumans/awaithumans-human-in-the-loop-ai-agents@main/docs/logo/light.svg" width="520">
 
 <br>
 
@@ -11,14 +11,14 @@
 <br>
 
 [![PyPI installs](https://img.shields.io/pepy/dt/awaithumans?style=for-the-badge&label=PyPI%20installs&color=3775A9&logo=pypi&logoColor=white)](https://pepy.tech/project/awaithumans)
-[![GitHub stars](https://img.shields.io/github/stars/awaithumans/awaithumans?style=for-the-badge&color=FBBF24&logo=github&logoColor=white&label=GitHub%20stars)](https://github.com/awaithumans/awaithumans)
+[![GitHub stars](https://img.shields.io/github/stars/awaithumans/awaithumans-human-in-the-loop-ai-agents?style=for-the-badge&color=FBBF24&logo=github&logoColor=white&label=GitHub%20stars)](https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents)
 
 [![PyPI](https://img.shields.io/pypi/v/awaithumans?label=pypi&color=3775A9&logo=pypi&logoColor=white)](https://pypi.org/project/awaithumans/)
 [![Python](https://img.shields.io/badge/python-3.10%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
-[![License](https://img.shields.io/badge/license-Apache_2.0-blue)](https://github.com/awaithumans/awaithumans/blob/main/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache_2.0-blue)](https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents/blob/main/LICENSE)
 [![Discord](https://img.shields.io/badge/discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/Kewdh7vjdc)
 
-[**Docs**](https://docs.awaithumans.dev) · [**Quickstart**](https://docs.awaithumans.dev/quickstart) · [**Examples**](https://github.com/awaithumans/awaithumans/tree/main/examples) · [**Discord**](https://discord.gg/Kewdh7vjdc)
+[**Docs**](https://docs.awaithumans.dev) · [**Quickstart**](https://docs.awaithumans.dev/quickstart) · [**Examples**](https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents/tree/main/examples) · [**Discord**](https://discord.gg/Kewdh7vjdc)
 
 </div>
 
@@ -46,9 +46,9 @@ if decision.approved:
     process_refund(...)
 ```
 
-![awaithumans demo — an agent creates a task, a human reviews it, the agent resumes with the typed response](https://cdn.jsdelivr.net/gh/awaithumans/awaithumans@main/docs/images/hero-demo.gif)
+![awaithumans demo — an agent creates a task, a human reviews it, the agent resumes with the typed response](https://cdn.jsdelivr.net/gh/awaithumans/awaithumans-human-in-the-loop-ai-agents@main/docs/images/hero-demo.gif)
 
-![The awaithumans dashboard — pending tasks queued for human review](https://cdn.jsdelivr.net/gh/awaithumans/awaithumans@main/docs/images/hero-dashboard.png)
+![The awaithumans dashboard — pending tasks queued for human review](https://cdn.jsdelivr.net/gh/awaithumans/awaithumans-human-in-the-loop-ai-agents@main/docs/images/hero-dashboard.png)
 
 ---
 
@@ -147,7 +147,7 @@ Slack channel broadcasts post a "Claim this task" button; first
 clicker atomically wins. Direct messages and emails go straight to
 the recipient.
 
-![Slack broadcast — a task posted to a channel with a Claim button](https://cdn.jsdelivr.net/gh/awaithumans/awaithumans@main/docs/images/slack-broadcast.png)
+![Slack broadcast — a task posted to a channel with a Claim button](https://cdn.jsdelivr.net/gh/awaithumans/awaithumans-human-in-the-loop-ai-agents@main/docs/images/slack-broadcast.png)
 
 ---
 
@@ -185,16 +185,16 @@ human with the reason attached. [Claude](https://www.anthropic.com/claude), [Ope
 
 ## Documentation
 
-- **Repository:** [github.com/awaithumans/awaithumans](https://github.com/awaithumans/awaithumans)
+- **Repository:** [github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents](https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents)
 - **Full docs:** [awaithumans.dev](https://awaithumans.dev)
-- **Examples:** [`examples/quickstart/`](https://github.com/awaithumans/awaithumans/tree/main/examples/quickstart) and [`examples/quickstart-ts/`](https://github.com/awaithumans/awaithumans/tree/main/examples/quickstart-ts)
-- **Changelog:** [`CHANGELOG.md`](https://github.com/awaithumans/awaithumans/blob/main/CHANGELOG.md)
+- **Examples:** [`examples/quickstart/`](https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents/tree/main/examples/quickstart) and [`examples/quickstart-ts/`](https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents/tree/main/examples/quickstart-ts)
+- **Changelog:** [`CHANGELOG.md`](https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents/blob/main/CHANGELOG.md)
 
 ---
 
 ## License
 
-[Apache License 2.0](https://github.com/awaithumans/awaithumans/blob/main/LICENSE)
+[Apache License 2.0](https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents/blob/main/LICENSE)
 across the whole package — SDK, server, dashboard, adapters, channels.
 Permissive, OSI-approved, with an explicit patent grant. Use it in
 proprietary stacks, fork it, ship it inside paid products.

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -141,8 +141,8 @@ awaithumans = "awaithumans.cli.main:app"
 
 [project.urls]
 Homepage = "https://awaithumans.dev"
-Repository = "https://github.com/awaithumans/awaithumans"
-Issues = "https://github.com/awaithumans/awaithumans/issues"
+Repository = "https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents"
+Issues = "https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents/issues"
 Documentation = "https://awaithumans.dev/docs"
 
 [tool.ruff]

--- a/packages/typescript-sdk/README.md
+++ b/packages/typescript-sdk/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-<img alt="awaithumans" src="https://cdn.jsdelivr.net/gh/awaithumans/awaithumans@main/docs/logo/light.svg" width="520">
+<img alt="awaithumans" src="https://cdn.jsdelivr.net/gh/awaithumans/awaithumans-human-in-the-loop-ai-agents@main/docs/logo/light.svg" width="520">
 
 <br>
 
@@ -11,14 +11,14 @@
 <br>
 
 [![npm installs](https://img.shields.io/npm/dt/awaithumans?style=for-the-badge&label=npm%20installs&color=CB3837&logo=npm&logoColor=white)](https://www.npmjs.com/package/awaithumans)
-[![GitHub stars](https://img.shields.io/github/stars/awaithumans/awaithumans?style=for-the-badge&color=FBBF24&logo=github&logoColor=white&label=GitHub%20stars)](https://github.com/awaithumans/awaithumans)
+[![GitHub stars](https://img.shields.io/github/stars/awaithumans/awaithumans-human-in-the-loop-ai-agents?style=for-the-badge&color=FBBF24&logo=github&logoColor=white&label=GitHub%20stars)](https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents)
 
 [![npm](https://img.shields.io/npm/v/awaithumans?label=npm&color=CB3837&logo=npm&logoColor=white)](https://www.npmjs.com/package/awaithumans)
 [![Node](https://img.shields.io/badge/node-20%2B-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
-[![License](https://img.shields.io/badge/license-Apache_2.0-blue)](https://github.com/awaithumans/awaithumans/blob/main/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache_2.0-blue)](https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents/blob/main/LICENSE)
 [![Discord](https://img.shields.io/badge/discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/Kewdh7vjdc)
 
-[**Docs**](https://docs.awaithumans.dev) · [**Quickstart**](https://docs.awaithumans.dev/quickstart) · [**Examples**](https://github.com/awaithumans/awaithumans/tree/main/examples/quickstart-ts) · [**Discord**](https://discord.gg/Kewdh7vjdc)
+[**Docs**](https://docs.awaithumans.dev) · [**Quickstart**](https://docs.awaithumans.dev/quickstart) · [**Examples**](https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents/tree/main/examples/quickstart-ts) · [**Discord**](https://discord.gg/Kewdh7vjdc)
 
 </div>
 
@@ -53,9 +53,9 @@ if (decision.approved) {
 }
 ```
 
-![awaithumans demo — an agent creates a task, a human reviews it, the agent resumes with the typed response](https://cdn.jsdelivr.net/gh/awaithumans/awaithumans@main/docs/images/hero-demo.gif)
+![awaithumans demo — an agent creates a task, a human reviews it, the agent resumes with the typed response](https://cdn.jsdelivr.net/gh/awaithumans/awaithumans-human-in-the-loop-ai-agents@main/docs/images/hero-demo.gif)
 
-![The awaithumans dashboard — pending tasks queued for human review](https://cdn.jsdelivr.net/gh/awaithumans/awaithumans@main/docs/images/hero-dashboard.png)
+![The awaithumans dashboard — pending tasks queued for human review](https://cdn.jsdelivr.net/gh/awaithumans/awaithumans-human-in-the-loop-ai-agents@main/docs/images/hero-dashboard.png)
 
 ---
 
@@ -96,11 +96,11 @@ powershell -c "irm https://astral.sh/uv/install.ps1 | iex"  # windows
 First run prints a setup URL. Open it, create the operator account,
 you're in. The dashboard is at `http://localhost:3001`.
 
-Prefer Docker? `docker run -p 3001:3001 ghcr.io/awaithumans/awaithumans:latest`.
+Prefer Docker? `docker run -p 3001:3001 ghcr.io/awaithumans/awaithumans-human-in-the-loop-ai-agents:latest`.
 
 Tasks can be delivered to Slack channels with a "Claim this task" button — first clicker atomically wins, response form opens as a modal, agent unblocks when they submit. Add `notify: ["slack:#ops"]` to the `awaitHuman()` call:
 
-![Slack broadcast — a task posted to a channel with a Claim button](https://cdn.jsdelivr.net/gh/awaithumans/awaithumans@main/docs/images/slack-broadcast.png)
+![Slack broadcast — a task posted to a channel with a Claim button](https://cdn.jsdelivr.net/gh/awaithumans/awaithumans-human-in-the-loop-ai-agents@main/docs/images/slack-broadcast.png)
 
 ---
 
@@ -140,16 +140,16 @@ client.onAwait((task) => ({ approved: true, note: "looks good" }));
 
 ## Documentation
 
-- **Repository:** [github.com/awaithumans/awaithumans](https://github.com/awaithumans/awaithumans)
+- **Repository:** [github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents](https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents)
 - **Full docs:** [awaithumans.dev](https://awaithumans.dev)
-- **Quickstart:** [`examples/quickstart-ts/`](https://github.com/awaithumans/awaithumans/tree/main/examples/quickstart-ts)
-- **Changelog:** [`CHANGELOG.md`](https://github.com/awaithumans/awaithumans/blob/main/CHANGELOG.md)
+- **Quickstart:** [`examples/quickstart-ts/`](https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents/tree/main/examples/quickstart-ts)
+- **Changelog:** [`CHANGELOG.md`](https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents/blob/main/CHANGELOG.md)
 
 ---
 
 ## License
 
-[Apache License 2.0](https://github.com/awaithumans/awaithumans/blob/main/LICENSE).
+[Apache License 2.0](https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents/blob/main/LICENSE).
 The TypeScript SDK, every adapter subpath export, and the Python
 server + dashboard it talks to are all under the same license —
 permissive, OSI-approved, with an explicit patent grant.

--- a/packages/typescript-sdk/README.md
+++ b/packages/typescript-sdk/README.md
@@ -96,7 +96,7 @@ powershell -c "irm https://astral.sh/uv/install.ps1 | iex"  # windows
 First run prints a setup URL. Open it, create the operator account,
 you're in. The dashboard is at `http://localhost:3001`.
 
-Prefer Docker? `docker run -p 3001:3001 ghcr.io/awaithumans/awaithumans-human-in-the-loop-ai-agents:latest`.
+Prefer Docker? `docker run -p 3001:3001 ghcr.io/awaithumans/awaithumans:latest`.
 
 Tasks can be delivered to Slack channels with a "Claim this task" button — first clicker atomically wins, response form opens as a modal, agent unblocks when they submit. Add `notify: ["slack:#ops"]` to the `awaitHuman()` call:
 

--- a/packages/typescript-sdk/package.json
+++ b/packages/typescript-sdk/package.json
@@ -64,7 +64,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/awaithumans/awaithumans",
+    "url": "https://github.com/awaithumans/awaithumans-human-in-the-loop-ai-agents",
     "directory": "packages/typescript-sdk"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

- Repo was renamed from `awaithumans/awaithumans` to `awaithumans/awaithumans-human-in-the-loop-ai-agents` to lift discovery on GitHub search (keyword density per the standard pre-1k-stars SEO playbook).
- Auto-redirects keep existing clones, badges, and inbound links working, but in-tree refs should resolve to the canonical name directly so shields.io / jsDelivr / PyPI / npm / Mintlify skip the redirect hop.
- 50 line replacements across 9 files. Equal insertions/deletions.

## In scope

- `README.md` — badge URLs, image srcs, contributor section link, Discussions/labels links
- `packages/python/README.md`, `packages/typescript-sdk/README.md` — same shape
- `packages/python/pyproject.toml` — PyPI \`Repository\` + \`Issues\` metadata
- `packages/dashboard/package.json`, `packages/typescript-sdk/package.json` — npm \`repository.url\`
- `packages/dashboard/components/console-banner.tsx` — printed banner string
- `packages/dashboard/lib/constants.ts` — \`GITHUB_URL\` constant
- \`docs/docs.json\` — Mintlify nav links to repo / releases

## Skipped on purpose

- \`CHANGELOG.md\` — historical entries stay verbatim; PR/issue redirects still resolve.
- \`ghcr.io/awaithumans/awaithumans\` Docker refs — short form is better UX; registry name is independent of GitHub SEO.
- \`examples/langgraph-py/graph.py\` — only ref is a half-written placeholder comment (\`/issues/...\`); not worth touching.

## Test plan

- [ ] CI green
- [ ] README badges resolve directly without the redirect hop
- [ ] \`pip show awaithumans\` shows the new repo URL after next release
- [ ] \`npm view awaithumans repository.url\` shows the new repo URL after next release
- [ ] Mintlify docs nav links open the canonical repo page

🤖 Generated with [Claude Code](https://claude.com/claude-code)