### PR TITLE
fix(server): translate ?sslmode=... between libpq and asyncpg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ uv.lock
 # Dev-mode auto-generated state — payload encryption key + admin
 # token + sqlite DB. Per-developer secrets, never committed.
 .awaithumans/
+
+# Claude Code local artifacts
+.claude/

--- a/packages/python/awaithumans/server/core/config.py
+++ b/packages/python/awaithumans/server/core/config.py
@@ -167,26 +167,43 @@ class Settings(BaseSettings):
 
     @property
     def database_url_async(self) -> str:
-        """Resolved async database URL."""
+        """Resolved async database URL.
+
+        Accepts a libpq-style ``?sslmode=...`` query param (the form
+        every managed Postgres provider — Azure, Heroku, Supabase,
+        Render — hands you) and translates it to asyncpg's
+        ``?ssl=...`` so the URL works without manual editing. asyncpg
+        accepts the SAME set of values as libpq (``disable``, ``allow``,
+        ``prefer``, ``require``, ``verify-ca``, ``verify-full``) under
+        a different parameter name; without the translation the
+        connection silently hangs or raises ``ClientConfigurationError``.
+        """
         if self.DATABASE_URL:
             url = self.DATABASE_URL
             if url.startswith("postgres://"):
-                return url.replace("postgres://", "postgresql+asyncpg://", 1)
-            if url.startswith("postgresql://"):
-                return url.replace("postgresql://", "postgresql+asyncpg://", 1)
-            return url
+                url = url.replace("postgres://", "postgresql+asyncpg://", 1)
+            elif url.startswith("postgresql://"):
+                url = url.replace("postgresql://", "postgresql+asyncpg://", 1)
+            return _translate_libpq_to_asyncpg(url)
 
         Path(self.DB_PATH).parent.mkdir(parents=True, exist_ok=True)
         return f"sqlite+aiosqlite:///{self.DB_PATH}"
 
     @property
     def database_url_sync(self) -> str:
-        """Resolved sync database URL (for migrations)."""
+        """Resolved sync database URL (for migrations).
+
+        Reverse of the async path: if the operator supplied an
+        asyncpg-style ``?ssl=...`` param, translate it to
+        ``?sslmode=...`` so psycopg (which alembic uses for migrations)
+        accepts it. Most operators paste a libpq URL — but the
+        async->sync round-trip should also work without surprises.
+        """
         if self.DATABASE_URL:
             url = self.DATABASE_URL
             if url.startswith("postgres://"):
-                return url.replace("postgres://", "postgresql://", 1)
-            return url
+                url = url.replace("postgres://", "postgresql://", 1)
+            return _translate_asyncpg_to_libpq(url)
 
         Path(self.DB_PATH).parent.mkdir(parents=True, exist_ok=True)
         return f"sqlite:///{self.DB_PATH}"
@@ -201,6 +218,38 @@ class Settings(BaseSettings):
     @property
     def is_production(self) -> bool:
         return self.ENVIRONMENT.upper() == "PRODUCTION"
+
+
+# Both libpq (sslmode=...) and asyncpg (ssl=...) accept the same
+# set of values, just under different parameter names. The two
+# helpers below translate between the styles so an operator's
+# pasted-from-cloud-provider URL works on both the async runtime
+# engine AND the sync alembic engine without manual editing.
+_SSL_VALUES = ("disable", "allow", "prefer", "require", "verify-ca", "verify-full")
+
+
+def _translate_libpq_to_asyncpg(url: str) -> str:
+    """``?sslmode=require`` → ``?ssl=require`` for every supported value.
+
+    asyncpg's own DSN parser rejects ``sslmode`` as a parameter name
+    (it understands the values but not the libpq key). Translating
+    here means a single canonical ``DATABASE_URL`` env var works on
+    both Postgres clients.
+    """
+    for value in _SSL_VALUES:
+        url = url.replace(f"sslmode={value}", f"ssl={value}")
+    return url
+
+
+def _translate_asyncpg_to_libpq(url: str) -> str:
+    """``?ssl=require`` → ``?sslmode=require``.
+
+    Reverse of the above so psycopg (used by alembic for migrations)
+    accepts an asyncpg-style URL too.
+    """
+    for value in _SSL_VALUES:
+        url = url.replace(f"ssl={value}", f"sslmode={value}")
+    return url
 
 
 settings = Settings()

--- a/packages/python/tests/server/test_database_url_normalization.py
+++ b/packages/python/tests/server/test_database_url_normalization.py
@@ -1,0 +1,107 @@
+"""Postgres URL SSL parameter normalization.
+
+When operators deploy against a managed Postgres provider (Azure,
+Heroku, Supabase, Render, etc.) the provider hands them a URL with
+``?sslmode=require``. Without translation:
+
+- The async engine uses asyncpg which doesn't recognize ``sslmode``
+  as a parameter NAME (it accepts the same VALUES under ``ssl=``).
+- The sync engine uses psycopg which doesn't recognize ``ssl=``.
+
+We translate in both directions so the same DATABASE_URL works for
+both the runtime engine AND alembic migrations.
+
+These are unit tests against the Settings property rather than full
+DB connections — verifying the wire format, not Postgres behavior.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from awaithumans.server.core.config import Settings
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"],
+)
+def test_async_translates_libpq_sslmode_to_asyncpg_ssl(value: str) -> None:
+    """Operator-pasted libpq URL works on asyncpg without edits."""
+    s = Settings(
+        DATABASE_URL=f"postgresql://user:pw@host:5432/db?sslmode={value}"
+    )
+    assert s.database_url_async == (
+        f"postgresql+asyncpg://user:pw@host:5432/db?ssl={value}"
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"],
+)
+def test_sync_translates_asyncpg_ssl_to_libpq_sslmode(value: str) -> None:
+    """Operator pasted an asyncpg-style URL — alembic still works."""
+    s = Settings(
+        DATABASE_URL=f"postgresql://user:pw@host:5432/db?ssl={value}"
+    )
+    assert s.database_url_sync == (
+        f"postgresql://user:pw@host:5432/db?sslmode={value}"
+    )
+
+
+def test_async_handles_heroku_postgres_scheme() -> None:
+    """Heroku still hands out ``postgres://``; we accept it as
+    a synonym for ``postgresql://``."""
+    s = Settings(DATABASE_URL="postgres://user:pw@host:5432/db?sslmode=require")
+    assert s.database_url_async == (
+        "postgresql+asyncpg://user:pw@host:5432/db?ssl=require"
+    )
+
+
+def test_async_preserves_url_without_ssl_param() -> None:
+    """No SSL param → no translation, just driver rewrite."""
+    s = Settings(DATABASE_URL="postgresql://user:pw@host:5432/db")
+    assert s.database_url_async == "postgresql+asyncpg://user:pw@host:5432/db"
+
+
+def test_sync_preserves_url_without_ssl_param() -> None:
+    s = Settings(DATABASE_URL="postgresql://user:pw@host:5432/db")
+    assert s.database_url_sync == "postgresql://user:pw@host:5432/db"
+
+
+def test_async_passes_through_already_async_url() -> None:
+    """``postgresql+asyncpg://`` URLs land unchanged on the driver
+    rewrite step; the SSL translation still runs."""
+    s = Settings(
+        DATABASE_URL="postgresql+asyncpg://user:pw@host:5432/db?sslmode=require"
+    )
+    assert s.database_url_async == (
+        "postgresql+asyncpg://user:pw@host:5432/db?ssl=require"
+    )
+
+
+def test_sync_translation_with_multiple_query_params() -> None:
+    """Operators sometimes pass extra params alongside sslmode
+    (application_name, connect_timeout, etc.). Only ssl= gets
+    rewritten."""
+    s = Settings(
+        DATABASE_URL=(
+            "postgresql://user:pw@host:5432/db?ssl=require"
+            "&application_name=alembic"
+        )
+    )
+    assert s.database_url_sync == (
+        "postgresql://user:pw@host:5432/db?sslmode=require"
+        "&application_name=alembic"
+    )
+
+
+def test_sqlite_url_is_unaffected() -> None:
+    """SQLite URLs don't have SSL semantics; the helpers shouldn't
+    touch them."""
+    # The helper functions are pure string ops; SQLite goes through
+    # a separate fallback in the property. Confirm that fallback.
+    s = Settings(DATABASE_URL=None, DB_PATH="/tmp/test.db")
+    assert s.database_url_async == "sqlite+aiosqlite:////tmp/test.db"
+    assert s.database_url_sync == "sqlite:////tmp/test.db"


### PR DESCRIPTION
## Summary
- Operators deploying to managed Postgres providers (Azure Flex, Heroku, Supabase, Render, Neon, etc.) get URLs with `?sslmode=require` by convention.
- asyncpg's runtime engine doesn't accept that key (wants `ssl=`); psycopg/alembic doesn't accept `ssl=`. Either way the same `DATABASE_URL` env var was broken on one path.
- The fix adds bidirectional translation in `database_url_async` and `database_url_sync` so a single `DATABASE_URL` works for both engines, regardless of which SSL style the operator pasted.

## Repro
Deploy to Azure Container Apps against Azure Database for PostgreSQL Flexible Server. Set:

```
AWAITHUMANS_DATABASE_URL=postgresql://user:pw@host:5432/db?sslmode=require
```

Before this PR: the lifespan startup silently hangs at "Waiting for application startup" — asyncpg blocks on a malformed connect arg instead of erroring. Worked around by switching to SQLite.

After this PR: works as-is.

## Test plan
- [x] 18 new unit tests cover both directions, all six valid SSL values, the Heroku-flavored `postgres://` scheme, mixed query params alongside `sslmode`, and the SQLite passthrough
- [x] Full server suite still green (743 passed)
- [ ] Manual smoke test on Azure Container Apps once the image rebuilds

🤖 Generated with [Claude Code](https://claude.com/claude-code)