### PR TITLE
fix(server): add psycopg2-binary so alembic can run on Postgres

### DIFF
--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -82,6 +82,16 @@ server = [
     "alembic>=1.14.0",
     "aiosqlite>=0.20.0",
     "asyncpg>=0.30.0",
+    # asyncpg is the async runtime driver, but alembic uses *sync*
+    # SQLAlchemy and SQLAlchemy's default sync Postgres dialect
+    # (`postgresql://...`) imports psycopg2. Without it,
+    # `alembic upgrade head` on a fresh Postgres deployment fails
+    # with `ModuleNotFoundError: No module named 'psycopg2'` during
+    # the server's startup lifespan — and the uvicorn lifespan
+    # swallows the traceback, so the operator sees the container
+    # exit silently. The `-binary` wheel avoids needing libpq + a
+    # C compiler at install time.
+    "psycopg2-binary>=2.9.10",
     "slack-sdk>=3.33.0",
     # slack_sdk has no runtime deps of its own — the async client
     # imports aiohttp lazily, so without this listed explicitly a fresh


### PR DESCRIPTION
## Summary

- `[server]` extras list `asyncpg` (async runtime driver) but not `psycopg2`. Alembic uses sync SQLAlchemy and SQLAlchemy's default sync Postgres dialect imports psycopg2, so `alembic upgrade head` against any Postgres deployment crashes with `ModuleNotFoundError: No module named 'psycopg2'` during the server's startup lifespan.
- Uvicorn's lifespan handler swallows the traceback, so the container exits silently with no useful log output — the operator just sees an unhealthy container.
- Fixed by adding `psycopg2-binary>=2.9.10` to the `[server]` extras. The `-binary` wheel ships with libpq embedded so `pip install awaithumans[server]` still works without a system C toolchain.

## Why this was hard to find

Found while deploying the OSS server to Azure Container Apps with `AWAITHUMANS_DATABASE_URL=postgresql://…`. The container kept exiting with code 3 right after `INFO: Waiting for application startup.` with no traceback. Reproduced manually by running `alembic upgrade head` inside the GHCR `:main` image with `--entrypoint python`, which surfaced the missing-module error in seconds.

Companion to #157 (sslmode/ssl translation) — together they make Postgres deployments actually work end to end.

## Test plan

- [ ] `pip install -e packages/python[server]` resolves cleanly on macOS + Linux
- [ ] Run server against a Postgres URL: `AWAITHUMANS_DATABASE_URL=postgresql://… awaithumans dev` boots without ModuleNotFoundError
- [ ] Alembic migrations apply against a fresh Postgres DB
- [ ] Existing SQLite path still works (no `DATABASE_URL` set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)