### PR TITLE
fix(server): log lifespan startup tracebacks before re-raising

### DIFF
--- a/packages/python/awaithumans/server/app.py
+++ b/packages/python/awaithumans/server/app.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import sys
+import traceback
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager, suppress
 from pathlib import Path
@@ -105,44 +107,69 @@ class EmbedResponseHeadersMiddleware(BaseHTTPMiddleware):
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-    """Startup and shutdown lifecycle."""
-    # Fail fast on a misconfigured PAYLOAD_KEY (bad length, bad base64,
-    # missing entirely). The key is needed for every signed-session
-    # cookie, but `get_key()` was only invoked lazily on the first
-    # request that needed it — which for new operators is the signup
-    # POST. The lazy failure surfaced as a generic
-    # 500 INTERNAL_ERROR with the helpful EncryptionKeyError message
-    # buried in server logs and the operator left with a half-created
-    # user row, no session, and no path forward (#140).
-    #
-    # Calling get_key() here surfaces the same error message at boot,
-    # before uvicorn accepts traffic — so the operator sees the
-    # remediation hint on the very first run, not after their first
-    # failed signup.
+    """Startup and shutdown lifecycle.
+
+    The entire startup body is wrapped so that any exception during
+    init_db(), scheduler creation, or first-run-token generation is
+    logged with a full traceback before being re-raised. Without this,
+    uvicorn's lifespan path catches startup exceptions and exits the
+    container with code 3 and no traceback in stdout/stderr — only
+    ``INFO: Waiting for application startup.`` and silence. The
+    pattern bit operators four times during a single Azure Container
+    Apps rollout (missing psycopg2-binary, bad Postgres URL hostname,
+    asyncpg auth failure, opaque Postgres lifespan crash). Logging at
+    ERROR level AND writing the traceback directly to stderr means
+    the cause survives both default log-config filtering and any
+    runtime that drops stderr-vs-stdout one way or the other.
+    """
     try:
-        get_key()
-    except (EncryptionKeyError, EncryptionNotConfiguredError) as exc:
-        logger.error(
-            "Refusing to start: AWAITHUMANS_PAYLOAD_KEY is misconfigured. %s",
-            exc,
-        )
+        # Fail fast on a misconfigured PAYLOAD_KEY (bad length, bad base64,
+        # missing entirely). The key is needed for every signed-session
+        # cookie, but `get_key()` was only invoked lazily on the first
+        # request that needed it — which for new operators is the signup
+        # POST. The lazy failure surfaced as a generic
+        # 500 INTERNAL_ERROR with the helpful EncryptionKeyError message
+        # buried in server logs and the operator left with a half-created
+        # user row, no session, and no path forward (#140).
+        #
+        # Calling get_key() here surfaces the same error message at boot,
+        # before uvicorn accepts traffic — so the operator sees the
+        # remediation hint on the very first run, not after their first
+        # failed signup.
+        try:
+            get_key()
+        except (EncryptionKeyError, EncryptionNotConfiguredError) as exc:
+            logger.error(
+                "Refusing to start: AWAITHUMANS_PAYLOAD_KEY is misconfigured. %s",
+                exc,
+            )
+            raise
+
+        await init_db()
+        logger.info("Database initialized")
+
+        # Capture whether this is first-run inside the lifespan (the DB
+        # session is ready here). The banner itself prints after uvicorn
+        # logs "Application startup complete" so it's the LAST thing the
+        # operator sees — not buried between alembic migrations and the
+        # "Running on http://..." line.
+        setup_url = await _first_run_setup_url()
+
+        scheduler_task = asyncio.create_task(run_timeout_scheduler())
+        webhook_task = asyncio.create_task(run_webhook_scheduler())
+        banner_task: asyncio.Task[None] | None = None
+        if setup_url:
+            banner_task = asyncio.create_task(_print_banner_after_startup(setup_url))
+    except Exception:
+        tb = traceback.format_exc()
+        logger.error("Lifespan startup failed — server will exit.\n%s", tb)
+        # Also write straight to stderr in case logging is misconfigured or
+        # filtered. Operators reading container logs (Azure Container Apps,
+        # Docker, k8s) need at least one of these to survive. Using
+        # sys.stderr.write (not print) so the ruff print-check stays clean.
+        sys.stderr.write(tb)
+        sys.stderr.flush()
         raise
-
-    await init_db()
-    logger.info("Database initialized")
-
-    # Capture whether this is first-run inside the lifespan (the DB
-    # session is ready here). The banner itself prints after uvicorn
-    # logs "Application startup complete" so it's the LAST thing the
-    # operator sees — not buried between alembic migrations and the
-    # "Running on http://..." line.
-    setup_url = await _first_run_setup_url()
-
-    scheduler_task = asyncio.create_task(run_timeout_scheduler())
-    webhook_task = asyncio.create_task(run_webhook_scheduler())
-    banner_task: asyncio.Task[None] | None = None
-    if setup_url:
-        banner_task = asyncio.create_task(_print_banner_after_startup(setup_url))
 
     yield
 

--- a/packages/python/tests/server/test_lifespan_traceback_logging.py
+++ b/packages/python/tests/server/test_lifespan_traceback_logging.py
@@ -1,0 +1,157 @@
+"""Regression: lifespan startup failures must surface a traceback.
+
+uvicorn's lifespan protocol catches exceptions raised during startup
+and exits the worker without printing them. Operators on Azure
+Container Apps and similar runtimes saw container exit code 3 with
+only ``INFO: Waiting for application startup.`` in the logs — no
+indication of which import / config / DB call actually blew up. The
+fix in ``server/app.py`` wraps the lifespan body so any startup
+exception is logged at ERROR level (with ``traceback.format_exc()``)
+and the same traceback is also written directly to stderr, so at
+least one of the two channels survives whatever the runtime does
+with stdout/stderr/log filtering.
+
+These tests pin both delivery channels: the ``logger.error`` call
+(verified by spying on the logger directly, which is robust to
+global logging-config drift between tests) and the stderr write
+(verified via ``capsys``). If either disappears, the silent-exit
+regression returns.
+"""
+
+from __future__ import annotations
+
+import secrets
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from awaithumans.server import app as app_module
+from awaithumans.server.app import create_app, lifespan
+from awaithumans.server.core import encryption
+from awaithumans.server.core.config import settings
+
+
+@pytest.fixture
+def _valid_payload_key() -> Any:
+    """Make sure the PAYLOAD_KEY pre-check passes so the test can
+    exercise the post-key startup path (init_db etc.)."""
+    original = settings.PAYLOAD_KEY
+    settings.PAYLOAD_KEY = secrets.token_urlsafe(32)
+    encryption.reset_key_cache()
+    yield
+    settings.PAYLOAD_KEY = original
+    encryption.reset_key_cache()
+
+
+def _format_log_call(call: Any) -> str:
+    """Join positional args of a logger.error mock call so we can grep
+    the formatted message text for substrings. The fix passes the
+    traceback as a positional arg (``logger.error("...\n%s", tb)``)."""
+    return " ".join(str(a) for a in call.args)
+
+
+async def test_init_db_failure_logs_traceback(
+    _valid_payload_key: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``init_db()`` raising surfaces a full traceback via
+    ``logger.error`` AND a direct stderr write.
+
+    The exception class is unique to this test (so we know it's the
+    one we injected, not unrelated failure noise) and the message
+    is distinctive enough to substring-match. Both channels must
+    carry the traceback — they are two independent safety nets
+    and the silent-exit regression was bad enough that we don't
+    trust either one alone given how badly the failure mode
+    degraded before the fix.
+    """
+    boom_message = "SIMULATED_INIT_DB_FAILURE_12345"
+
+    class _SimulatedInitFailureError(RuntimeError):
+        pass
+
+    fake_init = AsyncMock(side_effect=_SimulatedInitFailureError(boom_message))
+
+    app = create_app()
+
+    with (
+        patch("awaithumans.server.app.init_db", fake_init),
+        patch.object(app_module.logger, "error") as mock_error,
+        pytest.raises(_SimulatedInitFailureError) as excinfo,
+    ):
+        async with lifespan(app):
+            pytest.fail("lifespan body should not yield when init_db raises")
+
+    # The original exception must propagate unchanged so uvicorn still
+    # exits non-zero. A swallowed re-raise would be just as bad as
+    # the original silent-exit regression.
+    assert boom_message in str(excinfo.value)
+
+    # logger.error must have been called at least once with the
+    # lifespan-failure marker AND the traceback substance. The class
+    # name proves traceback.format_exc() was used (str(exc) wouldn't
+    # include the class). The boom_message proves the chained cause
+    # is intact.
+    error_payloads = [_format_log_call(c) for c in mock_error.call_args_list]
+    combined = "\n".join(error_payloads)
+    assert any("Lifespan startup failed" in p for p in error_payloads), (
+        f"Expected 'Lifespan startup failed' in a logger.error call; got: {combined!r}"
+    )
+    assert "_SimulatedInitFailureError" in combined, (
+        f"Expected traceback class in logger.error args; got: {combined!r}"
+    )
+    assert boom_message in combined, (
+        f"Expected boom message in logger.error args; got: {combined!r}"
+    )
+
+    # stderr carries the direct print fallback. Same substring checks
+    # — both channels must independently survive log-config drift.
+    captured = capsys.readouterr()
+    assert "_SimulatedInitFailureError" in captured.err, (
+        f"Expected traceback class on stderr; got: {captured.err!r}"
+    )
+    assert boom_message in captured.err, f"Expected boom message on stderr; got: {captured.err!r}"
+
+
+async def test_first_run_setup_url_failure_logs_traceback(
+    _valid_payload_key: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A failure inside ``_first_run_setup_url`` (e.g. count_users raising
+    because the schema is unexpectedly empty after init_db succeeded)
+    must also be surfaced. This covers post-DB-init startup steps,
+    which are the trickiest to debug remotely because they happen
+    after the first reassuring "Database initialized" log line.
+
+    ``init_db`` is stubbed to a no-op so the alembic migration runner
+    doesn't fire and reshape global logging via ``fileConfig`` mid-test
+    — that interaction is what makes capsys-on-stdout assertions
+    flaky across test orderings.
+    """
+    boom_message = "SIMULATED_FIRST_RUN_FAILURE_67890"
+
+    class _SimulatedFirstRunFailureError(RuntimeError):
+        pass
+
+    fake_first_run = AsyncMock(side_effect=_SimulatedFirstRunFailureError(boom_message))
+
+    app = create_app()
+
+    with (
+        patch("awaithumans.server.app.init_db", AsyncMock(return_value=None)),
+        patch("awaithumans.server.app._first_run_setup_url", fake_first_run),
+        patch.object(app_module.logger, "error") as mock_error,
+        pytest.raises(_SimulatedFirstRunFailureError),
+    ):
+        async with lifespan(app):
+            pytest.fail("lifespan should not yield when first-run URL lookup fails")
+
+    error_payloads = [_format_log_call(c) for c in mock_error.call_args_list]
+    combined = "\n".join(error_payloads)
+    assert "_SimulatedFirstRunFailureError" in combined
+    assert boom_message in combined
+
+    captured = capsys.readouterr()
+    assert "_SimulatedFirstRunFailureError" in captured.err
+    assert boom_message in captured.err


### PR DESCRIPTION
## Summary

- Wrap the lifespan startup body in `try/except` and log the full `traceback.format_exc()` at ERROR level + stderr before re-raising, so uvicorn-swallowed startup failures stop being invisible in container logs.
- Add `tests/server/test_lifespan_traceback_logging.py` with two regression tests covering an `init_db` failure and a post-init `_first_run_setup_url` failure.
- No behaviour change for successful boots; the exception still propagates so uvicorn exits non-zero.

## Why

A real launch deployment to Azure Container Apps hit four separate lifespan failures back-to-back (missing `psycopg2-binary`, bad Postgres URL hostname, asyncpg auth failure, an opaque Postgres lifespan crash) and each time the container logs were the same: `INFO: Waiting for application startup.` followed by exit code 3 and silence. uvicorn's lifespan path catches startup exceptions and discards the traceback, which is a defensible default for a generic ASGI host but a debugging nightmare for an operator who can only see container logs.

The fix gives operators a traceback through two independent channels:

- `logger.error("... %s", traceback.format_exc())` so anything wired into the structured log pipeline gets it.
- `sys.stderr.write(tb); sys.stderr.flush()` so even if logging is misconfigured or filtered (or `alembic.config.fileConfig` swapped the root handler out, which happens during migrations), the traceback still makes it to container stderr.

The exception is still re-raised so the container exits non-zero on bad config — only the observability gap is closed.

## How the test resists flakiness

- Spies on `app_module.logger` via `patch.object` instead of using `caplog`. `setup_logging()` clears root handlers when it runs, which evicts caplog's handler. Spying on the module-level logger bypasses that.
- The second test stubs `init_db` to a no-op so alembic's `fileConfig` call doesn't fire and reshape global logging mid-test.
- Uses unique exception class names + sentinel boom-strings so substring assertions can't accidentally match noise from another test.

## Test plan

- [x] `python -m pytest packages/python/tests/server/` — 34 passed (2 new tests + 32 existing)
- [x] `ruff check && ruff format --check` on changed files — clean
- [x] Local end-to-end repro: patched `init_db` to raise `RuntimeError`, ran `lifespan` in a tiny script, confirmed both `logger.error` traceback (stdout) and direct stderr traceback are emitted before the exception propagates.
- [ ] Reviewer: confirm the new `try`/`except Exception` doesn't accidentally widen behaviour for the existing `EncryptionKeyError` path — the inner block still logs its actionable hint first, then the outer block adds the traceback on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)