### PR TITLE
feat(cli): add awaithumans serve production entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,4 +113,13 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD python -c "import urllib.request,sys; urllib.request.urlopen('http://localhost:3001/api/health', timeout=3)" \
       || exit 1
 
-CMD ["awaithumans", "dev"]
+# Production entrypoint. `awaithumans serve` is the prod-mode CLI:
+# it runs uvicorn against the FastAPI app factory with explicit defaults
+# and refuses to start unless storage (DATABASE_URL or DB_PATH) is set.
+# The Dockerfile pre-sets AWAITHUMANS_DB_PATH above, so the bare image
+# boots into single-node SQLite-on-volume mode — operators who outgrow
+# that point AWAITHUMANS_DATABASE_URL at Postgres and the env-var check
+# still passes. For local hacking on the source tree, use
+# `awaithumans dev` instead (auto-generates keys, tokens, and a SQLite
+# path under .awaithumans/).
+CMD ["awaithumans", "serve"]

--- a/docs/self-hosting/configuration.mdx
+++ b/docs/self-hosting/configuration.mdx
@@ -34,7 +34,7 @@ In dev (`awaithumans dev`), the CLI auto-generates these for you and writes the 
 | Variable | Default | Description |
 |---|---|---|
 | `AWAITHUMANS_DATABASE_URL` | (none) | Full Postgres URL. Overrides the SQLite default. |
-| `AWAITHUMANS_DB_PATH` | `.awaithumans/dev.db` | SQLite file path. Used when `DATABASE_URL` is unset. |
+| `AWAITHUMANS_DB_PATH` | `.awaithumans/dev.db` (dev only) | SQLite file path. Used when `DATABASE_URL` is unset. |
 
 ```bash
 # SQLite (dev / single-user)
@@ -43,6 +43,8 @@ AWAITHUMANS_DB_PATH=/var/lib/awaithumans/data.db
 # Postgres (production)
 AWAITHUMANS_DATABASE_URL=postgresql://user:pass@host:5432/dbname
 ```
+
+The `.awaithumans/dev.db` default is **only honored by `awaithumans dev`** (the local development CLI). `awaithumans serve` (the production entrypoint, and the default Docker CMD) refuses to start unless one of `AWAITHUMANS_DATABASE_URL` or `AWAITHUMANS_DB_PATH` is set explicitly — this prevents the silent-data-loss footgun where a container restart on an ephemeral filesystem wipes the SQLite file.
 
 ## Server
 

--- a/docs/self-hosting/docker-compose.mdx
+++ b/docs/self-hosting/docker-compose.mdx
@@ -15,6 +15,12 @@ docker compose up
 
 Once up, point your DNS at the host. Done.
 
+## Entrypoint: `awaithumans serve`
+
+The published image runs `awaithumans serve` as its `CMD`. That's the production entrypoint — it runs `uvicorn` against the FastAPI app factory and refuses to start unless `AWAITHUMANS_DATABASE_URL` (or, for SQLite-on-volume deployments, `AWAITHUMANS_DB_PATH`) is set explicitly. The compose example below satisfies that by setting `AWAITHUMANS_DATABASE_URL` to the bundled Postgres service.
+
+For local development against the source tree, use `awaithumans dev` instead — it auto-generates a `PAYLOAD_KEY`, an admin token, and a SQLite path under `./.awaithumans/`, and writes a discovery file so the SDK auto-connects. Don't use `dev` for any deployment you care about — the auto-provisioned SQLite path is not durable across container restarts on most runtimes.
+
 ## docker-compose.yml
 
 ```yaml

--- a/packages/python/awaithumans/cli/commands/serve.py
+++ b/packages/python/awaithumans/cli/commands/serve.py
@@ -1,0 +1,107 @@
+"""Production entrypoint — runs uvicorn against the app factory.
+
+This is the Docker / Kubernetes / Container Apps entrypoint. It differs
+from ``awaithumans dev`` in three important ways:
+
+1. **No dev affordances.** No SQLite path defaulting, no auto-generated
+   PAYLOAD_KEY, no auto-generated admin token, no discovery file. If
+   the operator hasn't set what's needed, the server refuses to start
+   (PAYLOAD_KEY) or this command refuses (DATABASE_URL / DB_PATH).
+2. **Explicit storage choice required.** Refuses to start if neither
+   ``AWAITHUMANS_DATABASE_URL`` nor ``AWAITHUMANS_DB_PATH`` is set.
+   The dev command silently falls back to ``.awaithumans/dev.db``
+   inside the container, which is ephemeral on Azure Container Apps
+   and a few other runtimes — operators lose all task data on every
+   restart and the only signal is a confused team.
+3. **No misleading log lines.** ``awaithumans dev`` prints
+   ``"SQLite database at .awaithumans/dev.db"`` even when
+   ``AWAITHUMANS_DATABASE_URL`` is set, because it was written for a
+   single use case and grew the prod path bolt-on. ``serve`` only
+   logs what's actually true.
+
+Defaults match the Dockerfile env: host ``0.0.0.0``, port ``3001``,
+log level ``info``. Override via env vars or CLI flags.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import typer
+
+logger = logging.getLogger("awaithumans.cli.serve")
+
+
+_MISSING_STORAGE_MESSAGE = (
+    "awaithumans serve: refusing to start — neither AWAITHUMANS_DATABASE_URL\n"
+    "nor AWAITHUMANS_DB_PATH is set.\n"
+    "\n"
+    "Production deployments must explicitly choose their data store. Pick one:\n"
+    "\n"
+    "  Postgres (recommended for any multi-instance or durable deployment):\n"
+    "    AWAITHUMANS_DATABASE_URL=postgresql://user:pw@host:5432/dbname\n"
+    "\n"
+    "  SQLite on a mounted, persistent volume:\n"
+    "    AWAITHUMANS_DB_PATH=/var/lib/awaithumans/awaithumans.db\n"
+    "\n"
+    "For local development that auto-provisions SQLite, use `awaithumans dev`\n"
+    "instead.\n"
+)
+
+
+def serve(
+    host: str = typer.Option(
+        "0.0.0.0",
+        help="Host interface to bind. Overrides AWAITHUMANS_HOST.",
+    ),
+    port: int = typer.Option(
+        3001,
+        help="Port to bind. Overrides AWAITHUMANS_PORT.",
+    ),
+    log_level: str = typer.Option(
+        "info",
+        help="Uvicorn log level (debug, info, warning, error).",
+    ),
+) -> None:
+    """Run the awaithumans server in production mode.
+
+    Unlike ``awaithumans dev``, this command does not auto-provision
+    keys, tokens, or a SQLite path. Set ``AWAITHUMANS_PAYLOAD_KEY``
+    and either ``AWAITHUMANS_DATABASE_URL`` or ``AWAITHUMANS_DB_PATH``
+    explicitly before running.
+    """
+    import uvicorn
+
+    # Hard refusal: production must explicitly pick a data store.
+    # We check raw env vars rather than settings.DATABASE_URL because
+    # settings.DB_PATH always has a non-empty default value, so we
+    # can't distinguish "operator chose it" from "Settings filled it in".
+    db_url = (os.environ.get("AWAITHUMANS_DATABASE_URL") or "").strip()
+    db_path = (os.environ.get("AWAITHUMANS_DB_PATH") or "").strip()
+    if not db_url and not db_path:
+        typer.echo(_MISSING_STORAGE_MESSAGE, err=True)
+        raise typer.Exit(code=1)
+
+    # Propagate CLI overrides into env so Settings (already imported
+    # by FastAPI route modules at module load time) sees them when
+    # create_app() runs. setdefault preserves operator-supplied env.
+    os.environ.setdefault("AWAITHUMANS_HOST", host)
+    os.environ.setdefault("AWAITHUMANS_PORT", str(port))
+    os.environ.setdefault("AWAITHUMANS_LOG_LEVEL", log_level.upper())
+
+    # Importing here (not at module level) keeps `awaithumans --help`
+    # and `awaithumans version` fast for the lightweight-SDK install
+    # path. The server modules pull in FastAPI, SQLModel, etc., which
+    # add ~300ms of import time we don't want on every CLI invocation.
+    from awaithumans.server.app import create_app
+
+    logger.info(
+        "Starting awaithumans server in production mode on http://%s:%d (database=%s)",
+        host,
+        port,
+        "postgres" if db_url else f"sqlite ({db_path})",
+    )
+
+    application = create_app(serve_dashboard=True)
+    uvicorn.run(application, host=host, port=port, log_level=log_level.lower())

--- a/packages/python/awaithumans/cli/main.py
+++ b/packages/python/awaithumans/cli/main.py
@@ -34,6 +34,7 @@ from awaithumans.cli.commands.list_service_keys import list_service_keys
 from awaithumans.cli.commands.list_users import list_users_cmd
 from awaithumans.cli.commands.remove_user import remove_user
 from awaithumans.cli.commands.revoke_service_key import revoke_service_key
+from awaithumans.cli.commands.serve import serve
 from awaithumans.cli.commands.set_password import set_password_cmd
 from awaithumans.cli.commands.version import version
 
@@ -44,6 +45,7 @@ app = typer.Typer(
 )
 
 app.command()(dev)
+app.command()(serve)
 app.command("bootstrap-operator")(bootstrap_operator)
 app.command("add-user")(add_user)
 app.command()(doctor)

--- a/packages/python/tests/cli/test_serve.py
+++ b/packages/python/tests/cli/test_serve.py
@@ -1,0 +1,161 @@
+"""Tests for the production ``awaithumans serve`` CLI entrypoint.
+
+The command is the Docker / Container Apps entrypoint. The two
+properties under test are:
+
+1. It refuses to start unless storage is explicitly configured —
+   ``AWAITHUMANS_DATABASE_URL`` or ``AWAITHUMANS_DB_PATH`` must be set
+   in the environment. Silent fallback to ``.awaithumans/dev.db``
+   was the failure mode that lost task data on Azure Container Apps
+   (the Dockerfile's ``VOLUME`` directive isn't honored everywhere).
+2. Once storage is set, it boots ``uvicorn.run`` against the
+   FastAPI app factory with explicit production defaults. The
+   real uvicorn loop is mocked so the test process doesn't actually
+   bind a socket.
+
+End-to-end "does it serve traffic" coverage is the integration
+suite's job; here we only pin the entrypoint contract.
+
+Note: we call ``serve(...)`` directly rather than going through
+``typer.testing.CliRunner`` because the installed click 8.3 +
+typer 0.15 combo trips a ``Parameter.make_metavar`` signature
+mismatch when rendering ``--help``. Direct calls keep the test
+focused on serve's own contract, not the typer/click plumbing.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+
+from awaithumans.cli.commands.serve import serve
+from awaithumans.cli.main import app as cli_app
+
+
+@pytest.fixture
+def _no_storage_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Wipe both storage env vars before each test so the fixture
+    starts from a clean slate. Otherwise the test process's own env
+    (e.g. a leaked AWAITHUMANS_DB_PATH from a previous test) would
+    make refusal tests pass falsely."""
+    monkeypatch.delenv("AWAITHUMANS_DATABASE_URL", raising=False)
+    monkeypatch.delenv("AWAITHUMANS_DB_PATH", raising=False)
+
+
+def test_serve_refuses_without_storage_env(
+    _no_storage_env: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """No DATABASE_URL, no DB_PATH → typer.Exit(1) with an actionable
+    message on stderr.
+
+    Both env names must appear in the error so an operator can find
+    the right knob without leaving the terminal. The message also
+    has to point at ``awaithumans dev`` as the local-dev alternative
+    so nobody mistakes the refusal for a missing-command error.
+    """
+    with pytest.raises(typer.Exit) as excinfo:
+        serve(host="0.0.0.0", port=3001, log_level="info")
+
+    assert excinfo.value.exit_code == 1
+    captured = capsys.readouterr()
+    # typer.echo(..., err=True) writes to stderr.
+    assert "AWAITHUMANS_DATABASE_URL" in captured.err
+    assert "AWAITHUMANS_DB_PATH" in captured.err
+    assert "awaithumans dev" in captured.err
+
+
+def test_serve_accepts_when_database_url_set(
+    _no_storage_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Postgres-style ``AWAITHUMANS_DATABASE_URL`` satisfies the
+    storage guard. uvicorn.run is mocked so the test doesn't
+    actually bind a port.
+    """
+    monkeypatch.setenv(
+        "AWAITHUMANS_DATABASE_URL",
+        "postgresql://u:p@localhost:5432/db",
+    )
+    monkeypatch.setenv("AWAITHUMANS_PAYLOAD_KEY", "x" * 43)
+
+    fake_uvicorn = MagicMock()
+    fake_app = MagicMock(name="FastAPIApp")
+
+    with (
+        patch.dict("sys.modules", {"uvicorn": fake_uvicorn}),
+        patch("awaithumans.server.app.create_app", return_value=fake_app),
+    ):
+        serve(host="0.0.0.0", port=3001, log_level="info")
+
+    fake_uvicorn.run.assert_called_once()
+    args, kwargs = fake_uvicorn.run.call_args
+    # uvicorn.run(app, host=..., port=..., log_level=...) — app is
+    # positional; the rest are keyword.
+    assert args[0] is fake_app
+    assert kwargs["host"] == "0.0.0.0"
+    assert kwargs["port"] == 3001
+    assert kwargs["log_level"] == "info"
+
+
+def test_serve_accepts_when_db_path_set(
+    _no_storage_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bare ``AWAITHUMANS_DB_PATH`` (volume-backed SQLite) also
+    satisfies the storage guard. This is the path the Dockerfile
+    pre-configures, so the bare image must boot cleanly.
+    """
+    monkeypatch.setenv("AWAITHUMANS_DB_PATH", "/var/lib/awaithumans/data.db")
+    monkeypatch.setenv("AWAITHUMANS_PAYLOAD_KEY", "x" * 43)
+
+    fake_uvicorn = MagicMock()
+    fake_app = MagicMock(name="FastAPIApp")
+
+    with (
+        patch.dict("sys.modules", {"uvicorn": fake_uvicorn}),
+        patch("awaithumans.server.app.create_app", return_value=fake_app),
+    ):
+        serve(host="0.0.0.0", port=3001, log_level="info")
+
+    fake_uvicorn.run.assert_called_once()
+
+
+def test_serve_refuses_when_storage_env_is_empty_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit-empty env vars (``AWAITHUMANS_DB_PATH=``) count as unset.
+
+    Operators sometimes leave a shell-substituted env var unfilled
+    (``AWAITHUMANS_DB_PATH=${DB_PATH:-}``) — that ends up as an empty
+    string in the container, NOT an unset key. The guard must treat
+    that as "operator didn't choose" to avoid the same silent-default
+    failure mode an actually-unset key would cause.
+    """
+    monkeypatch.setenv("AWAITHUMANS_DATABASE_URL", "")
+    monkeypatch.setenv("AWAITHUMANS_DB_PATH", "   ")  # whitespace-only
+
+    with pytest.raises(typer.Exit) as excinfo:
+        serve(host="0.0.0.0", port=3001, log_level="info")
+
+    assert excinfo.value.exit_code == 1
+
+
+def test_cli_registers_serve_command() -> None:
+    """The serve command must be registered on the top-level Typer app.
+
+    Catches the regression where main.py forgets to wire a new command
+    (the command file exists, the import works, the function is
+    callable, but ``typer`` never sees it). We inspect the Typer app's
+    registered_commands list directly because CliRunner trips a
+    click 8.3 / typer 0.15 compat bug on --help rendering.
+    """
+    command_names = {cmd.name or cmd.callback.__name__ for cmd in cli_app.registered_commands}
+    assert "serve" in command_names, (
+        f"Expected 'serve' in registered Typer commands; got {sorted(command_names)!r}"
+    )
+    # And `dev` must still be there too — the new command is additive,
+    # not a replacement.
+    assert "dev" in command_names


### PR DESCRIPTION
## Summary

- New CLI command \`awaithumans serve\` that runs uvicorn against the FastAPI app factory with explicit production defaults.
- Refuses to start unless \`AWAITHUMANS_DATABASE_URL\` or \`AWAITHUMANS_DB_PATH\` is set — no silent fallback to the ephemeral \`.awaithumans/dev.db\` default.
- Dockerfile \`CMD\` flipped from \`awaithumans dev\` to \`awaithumans serve\`.
- Self-hosting docs updated to describe the dev/serve split.

## Why

\`awaithumans dev\` was named \"dev\" because it's the dev-mode CLI: it auto-generates a \`PAYLOAD_KEY\`, an admin token, and a SQLite path under \`./.awaithumans/\`, prints a hardcoded \"SQLite database at .awaithumans/dev.db\" line even when \`AWAITHUMANS_DATABASE_URL\` is set, and (pre-#159) swallowed lifespan tracebacks. None of that is appropriate for a production container, but the Dockerfile was using it as \`CMD\` because no production entrypoint existed yet.

The most painful failure mode this gates against: on Azure Container Apps and a few other runtimes the Dockerfile's \`VOLUME\` directive is silently ignored, so the SQLite default at \`.awaithumans/dev.db\` ends up on an ephemeral overlay. Every container restart resets the task store. The operator's first sign was a confused team and no audit trail.

## The storage guard

\`serve\` checks \`os.environ\` (not \`settings.DATABASE_URL\`) because \`settings.DB_PATH\` always has a non-empty default value, so the Settings object can't distinguish \"operator chose it\" from \"Settings filled it in.\" Empty-string and whitespace-only env values are treated as unset — that catches the common shell-substitution footgun where \`AWAITHUMANS_DB_PATH=\${DB_PATH:-}\` leaves the var as an empty string in the container, NOT unset.

The Dockerfile pre-sets \`AWAITHUMANS_DB_PATH=/var/lib/awaithumans/awaithumans.db\`, so the bare image still boots into single-node SQLite-on-volume mode; operators who outgrow that set \`AWAITHUMANS_DATABASE_URL\` and the check passes either way.

## docker-compose.yml

No change needed — it doesn't override \`CMD\`, so it inherits whatever the image ships.

## Test plan

- [x] \`python -m pytest packages/python/tests/cli/ packages/python/tests/server/\` — 58 passed
- [x] \`ruff check && ruff format --check\` on changed files — clean
- [x] Manual smoke: \`unset AWAITHUMANS_DATABASE_URL AWAITHUMANS_DB_PATH; python -m awaithumans.cli.main serve\` exits 1 with the actionable error
- [x] Manual smoke: \`AWAITHUMANS_DB_PATH=/tmp/x.db AWAITHUMANS_PAYLOAD_KEY=... python -m awaithumans.cli.main serve\` proceeds past the guard
- [ ] Reviewer: build the image locally and confirm \`docker run\` boots with the new \`CMD\`; the Dockerfile pre-sets \`AWAITHUMANS_DB_PATH\` so the bare image should pass the guard
- [ ] Reviewer: the test file calls \`serve()\` directly instead of via \`CliRunner\` because installed click 8.3 + typer 0.15 trips \`Parameter.make_metavar(ctx)\`. If the maintainer pins newer versions that fix the compat issue, consider switching the tests to CliRunner for stronger coverage of the typer layer.

## Follow-up not in this PR

- Stacks naturally with #159 (lifespan-traceback logging). Together they mean any future startup failure in production is both surfaced (159) and not silently dropping back to a default DB (this PR).
- The ephemeral-SQLite warning (#3 in the deployment debrief) is a separate PR — it adds a runtime warning when \`serve\` accepts a \`DB_PATH\` but the filesystem looks ephemeral. Easier to land as its own concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)