### PR TITLE
fix(server): warn loudly when production runs on ephemeral SQLite

### DIFF
--- a/docs/self-hosting/configuration.mdx
+++ b/docs/self-hosting/configuration.mdx
@@ -35,6 +35,7 @@ In dev (`awaithumans dev`), the CLI auto-generates these for you and writes the 
 |---|---|---|
 | `AWAITHUMANS_DATABASE_URL` | (none) | Full Postgres URL. Overrides the SQLite default. |
 | `AWAITHUMANS_DB_PATH` | `.awaithumans/dev.db` (dev only) | SQLite file path. Used when `DATABASE_URL` is unset. |
+| `AWAITHUMANS_ALLOW_EPHEMERAL_DB` | `false` | Acknowledges that SQLite-in-production is intentional. Suppresses the durability warning. See "Ephemeral SQLite warning" below. |
 
 ```bash
 # SQLite (dev / single-user)
@@ -45,6 +46,17 @@ AWAITHUMANS_DATABASE_URL=postgresql://user:pass@host:5432/dbname
 ```
 
 The `.awaithumans/dev.db` default is **only honored by `awaithumans dev`** (the local development CLI). `awaithumans serve` (the production entrypoint, and the default Docker CMD) refuses to start unless one of `AWAITHUMANS_DATABASE_URL` or `AWAITHUMANS_DB_PATH` is set explicitly — this prevents the silent-data-loss footgun where a container restart on an ephemeral filesystem wipes the SQLite file.
+
+### Ephemeral SQLite warning
+
+When `AWAITHUMANS_ENVIRONMENT=production` and the server is on SQLite (either via `AWAITHUMANS_DB_PATH` or an explicit `sqlite://` `DATABASE_URL`), the lifespan emits a loud multi-line WARNING explaining the data-loss risk and pointing at the two fixes. In most container runtimes — Azure Container Apps, plain Docker without `-v`, k8s without a PVC, Render free tier — the SQLite path lives on an ephemeral overlay filesystem. Every container restart wipes the task store and the audit trail, silently.
+
+To resolve:
+
+- **Move to Postgres** (recommended for any deployment you care about): set `AWAITHUMANS_DATABASE_URL=postgresql://...`.
+- **Confirm the SQLite path is durable** in your runtime's terms (a mounted volume, a PersistentVolumeClaim, an Azure Files share, etc.). The Dockerfile declares `VOLUME ["/var/lib/awaithumans"]`, but several runtimes ignore that directive — don't trust it as the only line of defense.
+
+Once durability is confirmed, set `AWAITHUMANS_ALLOW_EPHEMERAL_DB=true` to acknowledge the configuration and suppress the warning. An audit-level INFO record is still emitted so the decision shows up in logs.
 
 ## Server
 

--- a/packages/python/awaithumans/server/app.py
+++ b/packages/python/awaithumans/server/app.py
@@ -148,6 +148,14 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         await init_db()
         logger.info("Database initialized")
 
+        # Warn loudly when production is running on SQLite. In most
+        # container runtimes the default SQLite path is ephemeral —
+        # operators on Azure Container Apps and similar have lost task
+        # data on every restart because the Dockerfile's `VOLUME`
+        # directive isn't honored. The check runs after init_db so the
+        # warning is the LAST thing during DB setup and easy to spot.
+        _warn_if_ephemeral_sqlite_in_production()
+
         # Capture whether this is first-run inside the lifespan (the DB
         # session is ready here). The banner itself prints after uvicorn
         # logs "Application startup complete" so it's the LAST thing the
@@ -216,6 +224,77 @@ async def _print_banner_after_startup(setup_url: str) -> None:
 
     await asyncio.sleep(0.4)
     bootstrap.log_setup_banner(setup_url)
+
+
+def _warn_if_ephemeral_sqlite_in_production() -> None:
+    """Log an eye-catching multi-line WARNING when production is
+    running on SQLite without an explicit acknowledgment.
+
+    In most container runtimes (Azure Container Apps, plain Docker
+    without ``-v``, k8s without a PVC, Render free tier, …) the
+    default SQLite path lives on a writable-but-ephemeral overlay
+    filesystem. Every container restart wipes the task store and the
+    audit trail. The Dockerfile's ``VOLUME`` directive is supposed to
+    prevent that, but several runtimes ignore it silently.
+
+    Detecting "ephemeral" reliably from inside the process would
+    require runtime-specific filesystem heuristics that age badly.
+    Instead we trust the operator to know: in production with SQLite,
+    log a loud warning unless ``AWAITHUMANS_ALLOW_EPHEMERAL_DB=true``
+    is set — that env var is the operator's signed acknowledgment
+    that they've put the SQLite file on durable storage (or
+    genuinely don't care about durability).
+
+    Postgres deployments and non-production environments are silent
+    — they don't have the failure mode this warns about.
+    """
+    if not settings.is_production:
+        return
+
+    using_sqlite = not settings.DATABASE_URL or settings.DATABASE_URL.startswith(
+        ("sqlite://", "sqlite+aiosqlite://")
+    )
+    if not using_sqlite:
+        return
+
+    if settings.ALLOW_EPHEMERAL_DB:
+        # Operator has explicitly acknowledged the risk (e.g. they've
+        # mounted the DB_PATH directory off durable storage). Quietly
+        # note it at INFO so an audit log still shows the decision.
+        logger.info(
+            "AWAITHUMANS_ALLOW_EPHEMERAL_DB=true — skipping the "
+            "production-SQLite durability warning (operator-acknowledged)."
+        )
+        return
+
+    width = 72
+    divider = "═" * width
+    banner_lines = [
+        "",
+        divider,
+        "  WARNING: production environment is running on SQLite.",
+        "",
+        f"    DB path:  {settings.DB_PATH}",
+        f"    URL:      {settings.DATABASE_URL or '(unset — SQLite default)'}",
+        "",
+        "  In most container runtimes (Azure Container Apps, plain Docker,",
+        "  k8s without a PVC, Render free tier) the SQLite path lives on",
+        "  an ephemeral overlay filesystem. Every container restart wipes",
+        "  the task store and the audit trail — silently.",
+        "",
+        "  To fix:",
+        "    - Point AWAITHUMANS_DATABASE_URL at Postgres, OR",
+        "    - Confirm AWAITHUMANS_DB_PATH lives on a mounted, durable",
+        "      volume in your runtime's terms (not just an in-container path).",
+        "",
+        "  To silence this warning once durability is confirmed:",
+        "    AWAITHUMANS_ALLOW_EPHEMERAL_DB=true",
+        divider,
+        "",
+    ]
+    # Single multi-line WARNING record — pipelines aggregating on log
+    # level will surface it as one event, not 20 separate lines.
+    logger.warning("\n".join(banner_lines))
 
 
 def create_app(*, serve_dashboard: bool = True) -> FastAPI:

--- a/packages/python/awaithumans/server/core/config.py
+++ b/packages/python/awaithumans/server/core/config.py
@@ -28,6 +28,13 @@ class Settings(BaseSettings):
     # ── Database ─────────────────────────────────────────────────────
     DATABASE_URL: str | None = None
     DB_PATH: str = ".awaithumans/dev.db"
+    # Operator acknowledgement that the SQLite path lives on durable
+    # storage (or that data loss is acceptable). Suppresses the
+    # production-SQLite warning in `server/app.py` lifespan. Default
+    # False because the failure mode it warns about — silent data loss
+    # on container restart when the runtime ignores VOLUME — is severe
+    # and not detectable from inside the process.
+    ALLOW_EPHEMERAL_DB: bool = False
 
     # ── Dashboard auth ────────────────────────────────────────────────
     # Auth is always on. First-run state (empty users table) is handled

--- a/packages/python/tests/server/test_ephemeral_sqlite_warning.py
+++ b/packages/python/tests/server/test_ephemeral_sqlite_warning.py
@@ -1,0 +1,237 @@
+"""Boot-time guard against ephemeral SQLite in production.
+
+A production deployment that lands on the default SQLite path loses
+all task data on every container restart in most runtimes — Azure
+Container Apps, plain Docker without ``-v``, k8s without a PVC. The
+Dockerfile's ``VOLUME`` directive is meant to prevent this but isn't
+honored everywhere. The fix in ``server/app.py`` logs a loud
+multi-line WARNING when production is detected with SQLite, unless
+``AWAITHUMANS_ALLOW_EPHEMERAL_DB=true`` acknowledges the risk.
+
+These tests pin the four corners of the truth table:
+
+| ENVIRONMENT | DB         | ALLOW_EPHEMERAL_DB | WARN? |
+|-------------|------------|---------------------|-------|
+| production  | sqlite     | false               | YES   |
+| production  | sqlite     | true                | no    |
+| production  | postgres   | false               | no    |
+| development | sqlite     | false               | no    |
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from unittest.mock import patch
+
+import pytest
+
+from awaithumans.server.app import _warn_if_ephemeral_sqlite_in_production
+from awaithumans.server.core.config import settings
+
+
+@pytest.fixture
+def _restore_settings() -> Iterator[None]:
+    """Snapshot + restore the four Settings fields the helper reads."""
+    original = (
+        settings.ENVIRONMENT,
+        settings.DATABASE_URL,
+        settings.DB_PATH,
+        settings.ALLOW_EPHEMERAL_DB,
+    )
+    yield
+    (
+        settings.ENVIRONMENT,
+        settings.DATABASE_URL,
+        settings.DB_PATH,
+        settings.ALLOW_EPHEMERAL_DB,
+    ) = original
+
+
+def test_warns_in_production_with_sqlite_default(
+    _restore_settings: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The headline case: production + SQLite default + no
+    acknowledgement → one WARNING record containing the actionable
+    fix-up instructions.
+
+    Pins the message contents so an over-eager future cleanup can't
+    accidentally truncate the banner down to a one-liner that
+    operators skim past. The whole point of the verbose banner is
+    that an unfamiliar operator can fix the issue without leaving
+    the terminal.
+    """
+    settings.ENVIRONMENT = "production"
+    settings.DATABASE_URL = None
+    settings.DB_PATH = "/var/lib/awaithumans/awaithumans.db"
+    settings.ALLOW_EPHEMERAL_DB = False
+
+    with caplog.at_level(logging.WARNING, logger="awaithumans.server"):
+        _warn_if_ephemeral_sqlite_in_production()
+
+    warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warning_records) == 1, (
+        f"Expected exactly one WARNING record, got {len(warning_records)}"
+    )
+
+    msg = warning_records[0].getMessage()
+    # Headline marker — substring searches in log pipelines need it.
+    assert "production environment is running on SQLite" in msg
+    # Actionable remediations.
+    assert "AWAITHUMANS_DATABASE_URL" in msg
+    assert "AWAITHUMANS_DB_PATH" in msg
+    assert "AWAITHUMANS_ALLOW_EPHEMERAL_DB=true" in msg
+    # The resolved DB_PATH so the operator knows which file is at risk.
+    assert "/var/lib/awaithumans/awaithumans.db" in msg
+
+
+def test_warns_when_database_url_is_sqlite_scheme(
+    _restore_settings: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An explicit ``sqlite://`` or ``sqlite+aiosqlite://`` DATABASE_URL
+    still triggers the warning — the scheme, not just the
+    DATABASE_URL-is-None default, determines whether we're on SQLite.
+
+    Without this check, an operator who set
+    ``AWAITHUMANS_DATABASE_URL=sqlite:///./prod.db`` to be \"explicit\"
+    would silently get the same data-loss risk with no warning.
+    """
+    settings.ENVIRONMENT = "production"
+    settings.DATABASE_URL = "sqlite+aiosqlite:///./prod.db"
+    settings.DB_PATH = ".awaithumans/dev.db"
+    settings.ALLOW_EPHEMERAL_DB = False
+
+    with caplog.at_level(logging.WARNING, logger="awaithumans.server"):
+        _warn_if_ephemeral_sqlite_in_production()
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "production environment is running on SQLite" in warnings[0].getMessage()
+
+
+def test_silent_in_production_with_postgres(
+    _restore_settings: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Postgres deployments don't have the failure mode the banner
+    warns about. Stay quiet — log spam is its own anti-pattern."""
+    settings.ENVIRONMENT = "production"
+    settings.DATABASE_URL = "postgresql://u:p@host:5432/db"
+    settings.DB_PATH = ".awaithumans/dev.db"
+    settings.ALLOW_EPHEMERAL_DB = False
+
+    with caplog.at_level(logging.WARNING, logger="awaithumans.server"):
+        _warn_if_ephemeral_sqlite_in_production()
+
+    assert not [r for r in caplog.records if r.levelno == logging.WARNING], (
+        "Postgres deployments must not emit the ephemeral-SQLite warning"
+    )
+
+
+def test_silent_in_development_even_with_sqlite(
+    _restore_settings: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``awaithumans dev`` boots into SQLite by design — that's not a
+    production durability concern, so don't warn. The check is
+    gated on ``settings.is_production`` precisely so dev startup
+    stays quiet."""
+    settings.ENVIRONMENT = "development"
+    settings.DATABASE_URL = None
+    settings.DB_PATH = ".awaithumans/dev.db"
+    settings.ALLOW_EPHEMERAL_DB = False
+
+    with caplog.at_level(logging.WARNING, logger="awaithumans.server"):
+        _warn_if_ephemeral_sqlite_in_production()
+
+    assert not [r for r in caplog.records if r.levelno == logging.WARNING]
+
+
+def test_silenced_by_allow_ephemeral_db_acknowledgement(
+    _restore_settings: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``AWAITHUMANS_ALLOW_EPHEMERAL_DB=true`` is the operator's
+    signed acknowledgement that durability is handled elsewhere
+    (mounted volume, accepted-risk dev preview, etc.). The warning
+    is replaced by a single INFO record so the decision is still
+    auditable.
+
+    This pin matters because the env-var name is the contract: a
+    misspelling like ALLOWED_EPHEMERAL_DB or ALLOW_EPHEMERAL_DATABASE
+    would silently fail to suppress the warning and confuse
+    operators who think they configured the knob.
+    """
+    settings.ENVIRONMENT = "production"
+    settings.DATABASE_URL = None
+    settings.DB_PATH = "/var/lib/awaithumans/awaithumans.db"
+    settings.ALLOW_EPHEMERAL_DB = True
+
+    with caplog.at_level(logging.INFO, logger="awaithumans.server"):
+        _warn_if_ephemeral_sqlite_in_production()
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert not warnings, "Acknowledged ephemeral DB must not emit a WARNING"
+
+    infos = [r for r in caplog.records if r.levelno == logging.INFO]
+    assert any("operator-acknowledged" in r.getMessage() for r in infos), (
+        f"Expected an INFO acknowledgement record; got: {[r.getMessage() for r in infos]!r}"
+    )
+
+
+def test_warning_fires_from_lifespan_in_production(
+    _restore_settings: None,
+) -> None:
+    """End-to-end check: the lifespan helper actually calls the
+    ephemeral-SQLite check on the production path.
+
+    Without this, refactoring the call site (e.g. moving it into a
+    different helper) could silently drop the check while
+    ``_warn_if_ephemeral_sqlite_in_production`` itself still works.
+    The test mocks heavy startup bits so it focuses on the call
+    relationship, not the DB.
+
+    Spies on the module-level logger via ``patch.object`` instead of
+    using ``caplog`` because ``setup_logging()`` clears root handlers
+    on every ``create_app()``, which evicts caplog's handler and
+    would make this assertion a false negative.
+    """
+    import asyncio
+    import secrets
+    from unittest.mock import AsyncMock
+
+    from awaithumans.server import app as app_module
+    from awaithumans.server.app import create_app, lifespan
+    from awaithumans.server.core import encryption
+
+    settings.ENVIRONMENT = "production"
+    settings.DATABASE_URL = None
+    settings.DB_PATH = "/var/lib/awaithumans/awaithumans.db"
+    settings.ALLOW_EPHEMERAL_DB = False
+    settings.PAYLOAD_KEY = secrets.token_urlsafe(32)
+    encryption.reset_key_cache()
+
+    fake_init = AsyncMock(return_value=None)
+    fake_first_run = AsyncMock(return_value=None)
+
+    app = create_app()
+
+    async def _drive() -> None:
+        async with lifespan(app):
+            pass
+
+    with (
+        patch("awaithumans.server.app.init_db", fake_init),
+        patch("awaithumans.server.app._first_run_setup_url", fake_first_run),
+        patch.object(app_module.logger, "warning") as mock_warning,
+    ):
+        asyncio.run(_drive())
+
+    # The helper makes exactly one logger.warning call.
+    warning_payloads = [" ".join(str(a) for a in c.args) for c in mock_warning.call_args_list]
+    combined = "\n".join(warning_payloads)
+    assert "production environment is running on SQLite" in combined, (
+        f"Expected ephemeral-SQLite warning during lifespan; got: {combined!r}"
+    )


### PR DESCRIPTION
## Summary

- New lifespan helper `_warn_if_ephemeral_sqlite_in_production()` that emits a loud multi-line WARNING when production is on SQLite.
- New `AWAITHUMANS_ALLOW_EPHEMERAL_DB=true` env var (and `Settings.ALLOW_EPHEMERAL_DB` field) that acknowledges the risk and suppresses the warning (logs an audit INFO instead).
- Docs section in `configuration.mdx` explaining the failure mode and both remediations.

## Why

Several Azure Container Apps deployments lost task data on container restart because the runtime ignored the Dockerfile's `VOLUME` directive and the silent SQLite default landed on an ephemeral overlay. The same pattern hits plain Docker without `-v`, k8s without a PVC, and Render free tier.

Detecting "ephemeral" reliably from inside the process would require runtime-specific filesystem heuristics that age badly (probing /proc/mounts, looking for overlayfs, etc.). The cleaner contract: in production with SQLite, assume the worst and warn — let the operator silence the warning once they've confirmed durability.

## Truth table

| ENVIRONMENT | DB | ALLOW_EPHEMERAL_DB | Result |
|---|---|---|---|
| production | sqlite | false | WARNING (multi-line banner) |
| production | sqlite | true | INFO (acknowledged) |
| production | postgres | false | silent |
| development | sqlite | false | silent |

## Test plan

- [x] `python -m pytest packages/python/tests/server/` — 38 passed (6 new tests covering the truth table + lifespan integration)
- [x] `ruff check && ruff format --check` on changed files — clean
- [x] Manual: setting `AWAITHUMANS_ENVIRONMENT=production` with no DB URL surfaces the multi-line banner in the test process; setting `AWAITHUMANS_ALLOW_EPHEMERAL_DB=true` replaces it with the INFO acknowledgement.
- [ ] Reviewer: this PR branches from origin/main alongside #159 (lifespan tracebacks); both touch `server/app.py` lifespan but at non-overlapping points (the traceback wrapper around the whole body vs. a new call after `init_db()`). Trivial rebase whichever lands first.

## Follow-up not in this PR

- A "hard refuse to start unless `AWAITHUMANS_ALLOW_EPHEMERAL_DB=true`" mode is one branch away — the helper already centralizes the decision. The deployment debrief said warning-only is fine for now, so this PR doesn't ship it.
- The matching CLI guard in `awaithumans serve` (#160) refuses to start unless storage is set at all. Together they catch the two failure modes: no storage configured (CLI) and storage configured but on ephemeral FS (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)