### PR TITLE
chore(docs): point GHCR references at the renamed repo

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,10 @@ name: Docker image
 #  - every push of a `v*.*.*` tag (tags: `:vX.Y.Z`, `:X.Y.Z`, `:latest`)
 #  - manual dispatch for one-off builds
 #
-# Publishes to ghcr.io/<owner>/awaithumans. GHCR is free, integrates
+# Publishes to ghcr.io/<owner>/<repo>, which after the repo rename is
+# ghcr.io/awaithumans/awaithumans-human-in-the-loop-ai-agents. The legacy
+# ghcr.io/awaithumans/awaithumans image is frozen at a pre-rename build.
+# GHCR is free, integrates
 # with GitHub auth (no extra secrets needed — GITHUB_TOKEN works), and
 # supports multi-arch manifests out of the box.
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 #   3. `runtime` — slim Python, installs the wheel with [server]
 #       extras, runs as a non-root user, exposes :3001.
 #
-# Users run `docker run -p 3001:3001 ghcr.io/awaithumans/awaithumans`
+# Users run `docker run -p 3001:3001 ghcr.io/awaithumans/awaithumans-human-in-the-loop-ai-agents`
 # and get API + UI on the same port. No Python toolchain needed.
 # ──────────────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -282,8 +282,15 @@ dev` (via [uv](https://astral.sh/uv)) so you never touch a Python env.
 ## Self-hosted
 
 ```bash
-docker run -p 3001:3001 ghcr.io/awaithumans/awaithumans:latest
+docker run -p 3001:3001 ghcr.io/awaithumans/awaithumans-human-in-the-loop-ai-agents:latest
 ```
+
+> **Note on the image name.** The canonical image is
+> `ghcr.io/awaithumans/awaithumans-human-in-the-loop-ai-agents`. The
+> shorter `ghcr.io/awaithumans/awaithumans` from earlier release notes
+> is **deprecated** and frozen at a pre-rename build — older docs and
+> blog posts pointing there pull a stale image. Update any pipelines
+> or compose files referencing the short name.
 
 Or `docker compose up` with the included `docker-compose.yml`
 (optional Postgres block inside). Backs everything — API, dashboard,
@@ -358,7 +365,7 @@ actionable fixes. Catches ~80% of first-run issues in under 2 seconds.
 |---|---|---|
 | `awaithumans` (Python SDK + server + CLI + dashboard) | PyPI | Apache 2.0 |
 | `awaithumans` (TypeScript SDK) | npm | Apache 2.0 |
-| `ghcr.io/awaithumans/awaithumans` (container) | GHCR | Apache 2.0 |
+| `ghcr.io/awaithumans/awaithumans-human-in-the-loop-ai-agents` (container) | GHCR | Apache 2.0 |
 
 **License:** [Apache License 2.0](LICENSE). Permissive, OSI-approved,
 with an explicit patent grant. Use it in proprietary stacks, fork it,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@
 
 services:
   awaithumans:
-    image: ghcr.io/awaithumans/awaithumans:latest
+    image: ghcr.io/awaithumans/awaithumans-human-in-the-loop-ai-agents:latest
     # Build from source instead if you're working in the repo:
     # build: .
     restart: unless-stopped

--- a/docs/self-hosting/docker-compose.mdx
+++ b/docs/self-hosting/docker-compose.mdx
@@ -26,7 +26,7 @@ For local development against the source tree, use `awaithumans dev` instead —
 ```yaml
 services:
   server:
-    image: ghcr.io/awaithumans/awaithumans:latest
+    image: ghcr.io/awaithumans/awaithumans-human-in-the-loop-ai-agents:latest
     ports:
       - "3001:3001"
     environment:

--- a/examples/quickstart-ts/README.md
+++ b/examples/quickstart-ts/README.md
@@ -114,6 +114,6 @@ typed `decision` back. No JSON-twiddling.
   `notify: ["email:reviewer@company.com"]`. Needs the channel
   configured on the server — see [docs](https://docs.awaithumans.dev).
 - **Docker:** don't want to install uv? `docker run -p 3001:3001
-  ghcr.io/awaithumans/awaithumans:latest` runs the same server.
+  ghcr.io/awaithumans/awaithumans-human-in-the-loop-ai-agents:latest` runs the same server.
 - **Python:** the same flow in Python —
   [`examples/quickstart/`](../quickstart/).

--- a/packages/typescript-sdk/README.md
+++ b/packages/typescript-sdk/README.md
@@ -96,7 +96,7 @@ powershell -c "irm https://astral.sh/uv/install.ps1 | iex"  # windows
 First run prints a setup URL. Open it, create the operator account,
 you're in. The dashboard is at `http://localhost:3001`.
 
-Prefer Docker? `docker run -p 3001:3001 ghcr.io/awaithumans/awaithumans:latest`.
+Prefer Docker? `docker run -p 3001:3001 ghcr.io/awaithumans/awaithumans-human-in-the-loop-ai-agents:latest`.
 
 Tasks can be delivered to Slack channels with a "Claim this task" button — first clicker atomically wins, response form opens as a modal, agent unblocks when they submit. Add `notify: ["slack:#ops"]` to the `awaitHuman()` call:
 


### PR DESCRIPTION
## Summary

- Sweep \`Dockerfile\`, \`docker-compose.yml\`, \`docs/self-hosting/docker-compose.mdx\`, examples, and READMEs to use \`ghcr.io/awaithumans/awaithumans-human-in-the-loop-ai-agents\`.
- Add a deprecation callout in the main README's Self-hosted section pointing operators at the new name.
- Update the docker.yml workflow comment to call out the old name as frozen.

## Why

After the repo rename, the workflow continued pushing to \`ghcr.io/\${{ github.repository }}\` (which is correct — that resolves to the new name) but every doc still pointed at the short \`ghcr.io/awaithumans/awaithumans\`. The short name is stuck on the pre-rename build, so operators following older quickstarts or blog posts were silently pulling a stale image with no signal that something was off.

Going with option (b) from the deployment debrief: sweep the references rather than dual-push both names from the workflow. Dual-push would defer the cleanup forever and operators would still pull stale \`:latest\` whenever the short tag lagged a release. A clean cut here makes the canonical name discoverable everywhere people actually look first.

## Intentionally NOT touched

- \`CHANGELOG.md\` historical entries — they describe what was published at the time. Rewriting would falsify the record.
- \`.github/RELEASE_NOTES_v0.1.X.md\` — same reasoning. An operator following the v0.1.7 release notes verbatim still pulls the same v0.1.7 image they would have gotten then. Only \`:main\` and \`:latest\` on the short name are now stale.

## Test plan

- [x] \`grep -rn \"ghcr.io/awaithumans/awaithumans[^-]\"\` shows only intentional remaining references (historical CHANGELOG / release notes, and the deprecation callouts).
- [x] Diff is comment-only and reference-only — no logic changes.
- [ ] Reviewer: confirm the docker workflow still authenticates correctly and the canonical image keeps building from \`ghcr.io/\${{ github.repository }}\` (no change there, just a comment update).
- [ ] Optional: file a GHCR settings ticket to mark the legacy image package as deprecated in the GHCR UI itself. Not in this PR's scope but worth doing once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)