### PR TITLE
fix(server): preserve existing loggers when alembic runs

### DIFF
--- a/packages/python/alembic/env.py
+++ b/packages/python/alembic/env.py
@@ -23,7 +23,18 @@ from awaithumans.server.db import models  # noqa: F401
 config = context.config
 
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    # `disable_existing_loggers=False` is critical: the default (True)
+    # marks every logger created before this call as disabled, which
+    # silently drops any subsequent log records. Because alembic runs
+    # inside the app's startup lifespan (init_db -> alembic upgrade),
+    # leaving the default flips the app's own `awaithumans.server`
+    # logger to disabled and every post-migration warning / info call
+    # vanishes. That hid the ephemeral-SQLite warning in production
+    # and broke caplog-based tests for the same code path. Keeping
+    # alembic's own log config (which only configures the alembic /
+    # sqlalchemy loggers) while leaving everything else alone is the
+    # behavior we actually want.
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 # Override sqlalchemy.url with the app's resolved sync URL so alembic
 # and the app agree on which database to touch, regardless of how the


### PR DESCRIPTION
## Summary

`alembic/env.py` calls `fileConfig(...)` without `disable_existing_loggers=False`, so the default (True) kicks in and silently disables every logger created before alembic runs. Records on those loggers are then dropped on the floor.

Because `init_db()` runs inside the FastAPI lifespan and triggers an alembic migration on every startup, this affects production too — anything the app logs on `awaithumans.server` AFTER `init_db()` (the `"Database initialized"` line, the post-migration setup banner, and the new ephemeral-SQLite production warning from #161) is silently dropped.

It also explains why #161's caplog-based tests pass in isolation but fail in the full suite: once any earlier test runs `init_db()`, every subsequent test sees the logger disabled.

The one-line fix preserves alembic's own log config (the `alembic` / `sqlalchemy.engine` loggers declared in `alembic.ini`) while leaving every other logger in the process alone, which is the behavior we want.

## Reproduction

```python
import logging, asyncio
from awaithumans.server.db.connection import init_db
logger = logging.getLogger("awaithumans.server")
print("before:", logger.disabled)  # False
asyncio.run(init_db())
print("after :", logger.disabled)  # True  -> bug
logger.warning("dropped")          # no record emitted
```

After the fix, `after` prints `False` and the warning surfaces.

## Test plan
- [x] `pytest -q --ignore=tests/adapters/test_temporal_adapter.py` against this branch alone: 723 passed, 2 skipped, 0 failures
- [x] Same suite with #161's app.py + config.py + test file on top: **729 passed, 0 failures** (the 6 previously-failing tests pass once the logger isn't disabled)
- [x] No behavior change in dev (alembic still configures its own loggers identically)

## Follow-up

Once this lands, #161 needs a trivial `git rebase main` (no conflicts — different file) and its CI will go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)