### PR TITLE
fix(server): make datetime columns tz-aware on Postgres [LAUNCH-BLOCKING]

### DIFF
--- a/packages/python/awaithumans/server/db/connection.py
+++ b/packages/python/awaithumans/server/db/connection.py
@@ -9,12 +9,49 @@ import logging
 from collections.abc import AsyncGenerator
 from pathlib import Path
 
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 from alembic import command
 from alembic.config import Config as AlembicConfig
 from awaithumans.server.core.config import settings
+
+# Columns that pre-PR-6 alembic migrations created as
+# `TIMESTAMP WITHOUT TIME ZONE`. On Postgres asyncpg refuses to bind
+# tz-aware Python datetimes against these, which broke the timeout
+# and webhook schedulers in production. The startup patch below ALTERs
+# each one to `TIMESTAMP WITH TIME ZONE`, interpreting existing values
+# as UTC (which the service layer's `datetime.now(timezone.utc)` write
+# path always was). Listed (table, column) pairs only — never used as
+# a positive allowlist, always cross-checked against
+# information_schema so dropped or renamed columns no-op cleanly.
+#
+# Already tz-aware in their original migration (skipped):
+#   service_api_keys.{created_at,last_used_at,revoked_at} — 20260508_0510
+_NAIVE_TIMESTAMP_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("audit_entries", "created_at"),
+    ("consumed_email_tokens", "consumed_at"),
+    ("email_sender_identities", "verified_at"),
+    ("email_sender_identities", "created_at"),
+    ("email_sender_identities", "updated_at"),
+    ("slack_installations", "installed_at"),
+    ("slack_installations", "updated_at"),
+    ("slack_task_messages", "created_at"),
+    ("tasks", "created_at"),
+    ("tasks", "updated_at"),
+    ("tasks", "completed_at"),
+    ("tasks", "timed_out_at"),
+    ("tasks", "timeout_at"),
+    ("users", "last_assigned_at"),
+    ("users", "created_at"),
+    ("users", "updated_at"),
+    ("webhook_deliveries", "next_attempt_at"),
+    ("webhook_deliveries", "first_attempted_at"),
+    ("webhook_deliveries", "last_attempt_at"),
+    ("webhook_deliveries", "created_at"),
+    ("webhook_deliveries", "updated_at"),
+)
 
 logger = logging.getLogger("awaithumans.server.db")
 
@@ -90,6 +127,11 @@ async def init_db() -> None:
     Alembic is sync; we run it in a thread so we don't block the loop.
     Tests bypass init_db and use SQLModel.metadata.create_all directly
     against their own in-memory engines.
+
+    After alembic, runs `_patch_naive_timestamp_columns()` to repair
+    Postgres deployments whose pre-PR-6 migrations created datetime
+    columns without `TIMESTAMP WITH TIME ZONE`. Idempotent and a no-op
+    on SQLite — see the docstring on that function for the why.
     """
     import asyncio
 
@@ -98,6 +140,110 @@ async def init_db() -> None:
 
     await asyncio.to_thread(_run)
     logger.info("Database migrations applied (head)")
+
+    await _patch_naive_timestamp_columns()
+
+
+async def _patch_naive_timestamp_columns() -> None:
+    """Promote pre-PR-6 naive timestamp columns to ``TIMESTAMP WITH TIME ZONE``.
+
+    Background: the OSS server's service layer always wrote tz-aware
+    datetimes (``datetime.now(timezone.utc)``), but the original alembic
+    migrations declared ``sa.DateTime()`` without ``timezone=True``. On
+    SQLite this is invisible — SQLite has no real datetime type and
+    accepts the values as text. On Postgres each column lands as
+    ``TIMESTAMP WITHOUT TIME ZONE``, and asyncpg refuses to bind a
+    tz-aware Python datetime against it. The timeout scheduler's
+    ``WHERE timeout_at <= now`` query (and the webhook scheduler's
+    equivalent) crashes every tick.
+
+    The fix has three parts: (1) model declarations updated to use
+    ``tz_timestamp_column`` so new tables and tests are correct,
+    (2) this runtime patch to ALTER existing prod columns to match,
+    (3) the service layer was already correct.
+
+    Why a runtime patch instead of a new alembic revision: adding an
+    alembic migration that ALTERs columns on every prod database is
+    deploy-coupling we don't need. The patch is idempotent (skips
+    columns whose ``data_type`` is already ``timestamp with time
+    zone``), so booting an already-patched server is free. New
+    deployments run the original migrations, hit the patch once on
+    first boot, and stay correct after that. Once every running
+    deployment has booted under PR 6, the table contents are stable
+    and this function can be deleted.
+
+    SQLite is skipped entirely: ``information_schema`` doesn't exist,
+    ``timestamp with time zone`` is meaningless, and the bug never
+    manifested there in the first place.
+    """
+    url = settings.database_url_async
+    if not url.startswith(("postgresql://", "postgresql+")):
+        return
+
+    engine = get_async_engine()
+    async with engine.begin() as conn:
+        await _alter_naive_timestamps(conn, _NAIVE_TIMESTAMP_COLUMNS)
+
+
+async def _alter_naive_timestamps(
+    conn: object,  # AsyncConnection — typed loosely so tests can pass an AsyncMock
+    columns: tuple[tuple[str, str], ...],
+) -> int:
+    """Inner half of the patch — ALTER each naive column to tz-aware.
+
+    Split from ``_patch_naive_timestamp_columns`` so tests can drive
+    it with a mocked connection (the outer function's
+    ``engine.begin()`` async-context-manager is awkward to mock).
+    Returns the number of columns actually altered, which lets the
+    test assert idempotency: a second call against an already-patched
+    schema returns 0.
+    """
+    altered = 0
+    for table, column in columns:
+        current_type = (
+            await conn.execute(  # type: ignore[attr-defined]
+                text(
+                    "SELECT data_type FROM information_schema.columns "
+                    "WHERE table_name = :t AND column_name = :c"
+                ),
+                {"t": table, "c": column},
+            )
+        ).scalar_one_or_none()
+
+        # None: column doesn't exist (table not yet created on a
+        # fresh deploy where this runs before alembic finishes, or
+        # the column was renamed/dropped). Skip — alembic owns the
+        # column lifecycle, this patch is only here to repair type.
+        if current_type is None:
+            continue
+
+        # Already tz-aware: either alembic created it correctly
+        # (service_api_keys) or this patch ran on a previous boot.
+        if current_type != "timestamp without time zone":
+            continue
+
+        # AT TIME ZONE 'UTC' attaches a tz to the existing naive
+        # values. The service layer always wrote UTC by
+        # construction, so this is value-preserving — we're
+        # labeling the data with the timezone it already had,
+        # not converting it. Quoted identifiers because Postgres
+        # otherwise lowercases unquoted names; column names in
+        # this codebase happen to be lowercase already, but
+        # quoting is defensive against future renames.
+        await conn.execute(  # type: ignore[attr-defined]
+            text(
+                f'ALTER TABLE "{table}" '
+                f'ALTER COLUMN "{column}" TYPE TIMESTAMP WITH TIME ZONE '
+                f"USING \"{column}\" AT TIME ZONE 'UTC'"
+            )
+        )
+        altered += 1
+        logger.info(
+            "Promoted %s.%s to TIMESTAMP WITH TIME ZONE (UTC-anchored)",
+            table,
+            column,
+        )
+    return altered
 
 
 async def close_db() -> None:

--- a/packages/python/awaithumans/server/db/models/audit.py
+++ b/packages/python/awaithumans/server/db/models/audit.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from sqlmodel import JSON, Column, Field, SQLModel
 
-from awaithumans.server.db.models.base import new_id, utc_now
+from awaithumans.server.db.models.base import new_id, tz_timestamp_column, utc_now
 
 
 class AuditEntry(SQLModel, table=True):
@@ -44,4 +44,7 @@ class AuditEntry(SQLModel, table=True):
     embed_jti: str | None = Field(default=None, max_length=64)
 
     # When
-    created_at: datetime = Field(default_factory=utc_now)
+    created_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=tz_timestamp_column(),
+    )

--- a/packages/python/awaithumans/server/db/models/base.py
+++ b/packages/python/awaithumans/server/db/models/base.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from uuid import uuid4
 
+from sqlalchemy import Column, DateTime
+
 
 def utc_now() -> datetime:
     """Current UTC timestamp for default field values."""
@@ -14,3 +16,36 @@ def utc_now() -> datetime:
 def new_id() -> str:
     """Generate a new hex UUID for primary keys."""
     return uuid4().hex
+
+
+def tz_timestamp_column(*, nullable: bool = False, index: bool = False) -> Column:  # type: ignore[type-arg]
+    """Return a ``TIMESTAMP WITH TIME ZONE`` column declaration.
+
+    Pairs with the service-layer convention of writing tz-aware
+    ``datetime.now(timezone.utc)`` values. Without ``timezone=True``
+    SQLModel produces a plain ``DateTime``, which lands as
+    ``TIMESTAMP WITHOUT TIME ZONE`` on Postgres. asyncpg then refuses
+    to bind a tz-aware Python datetime to that column, and any query
+    that does ``WHERE column <= now`` blows up with
+    ``can't subtract offset-naive and offset-aware datetimes`` — the
+    failure mode the timeout and webhook schedulers hit in production
+    after the reviewer moved to Azure Postgres.
+
+    SQLite ignores the ``timezone=True`` hint at the storage layer
+    (datetimes round-trip as naive TEXT), so callers that mix code
+    paths between SQLite and Postgres should keep using
+    ``_ensure_utc(...)`` patterns on read. The point of this helper
+    is to make the *column declaration* correct so:
+
+    1. ``metadata.create_all`` (tests) produces tz-aware columns.
+    2. Future alembic autogenerate runs emit ``timezone=True``.
+    3. Existing Postgres deployments with naive columns get repaired
+       at boot by ``_patch_naive_timestamp_columns`` in
+       ``db/connection.py`` — it runs after alembic upgrade and
+       ALTERs any column still typed ``TIMESTAMP WITHOUT TIME ZONE``.
+
+    Each Field needs its own Column instance — don't cache the
+    return value or share it across fields, since SQLAlchemy mutates
+    Column state when binding to a Table.
+    """
+    return Column(DateTime(timezone=True), nullable=nullable, index=index)

--- a/packages/python/awaithumans/server/db/models/consumed_email_token.py
+++ b/packages/python/awaithumans/server/db/models/consumed_email_token.py
@@ -22,7 +22,7 @@ from datetime import datetime
 
 from sqlmodel import Field, SQLModel
 
-from awaithumans.server.db.models.base import utc_now
+from awaithumans.server.db.models.base import tz_timestamp_column, utc_now
 
 
 class ConsumedEmailToken(SQLModel, table=True):
@@ -31,4 +31,7 @@ class ConsumedEmailToken(SQLModel, table=True):
     __tablename__ = "consumed_email_tokens"
 
     jti: str = Field(primary_key=True, max_length=64)
-    consumed_at: datetime = Field(default_factory=utc_now)
+    consumed_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=tz_timestamp_column(),
+    )

--- a/packages/python/awaithumans/server/db/models/email_sender_identity.py
+++ b/packages/python/awaithumans/server/db/models/email_sender_identity.py
@@ -18,7 +18,7 @@ from sqlalchemy import Column
 from sqlmodel import Field, SQLModel
 
 from awaithumans.server.core.encryption import EncryptedString
-from awaithumans.server.db.models.base import utc_now
+from awaithumans.server.db.models.base import tz_timestamp_column, utc_now
 
 
 class EmailSenderIdentity(SQLModel, table=True):
@@ -52,7 +52,16 @@ class EmailSenderIdentity(SQLModel, table=True):
     # Unverified identities can still be used (operator's choice) but
     # the dashboard will flag them.
     verified: bool = Field(default=False)
-    verified_at: datetime | None = Field(default=None)
+    verified_at: datetime | None = Field(
+        default=None,
+        sa_column=tz_timestamp_column(nullable=True),
+    )
 
-    created_at: datetime = Field(default_factory=utc_now)
-    updated_at: datetime = Field(default_factory=utc_now)
+    created_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=tz_timestamp_column(),
+    )
+    updated_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=tz_timestamp_column(),
+    )

--- a/packages/python/awaithumans/server/db/models/service_api_key.py
+++ b/packages/python/awaithumans/server/db/models/service_api_key.py
@@ -22,6 +22,8 @@ from datetime import datetime
 
 from sqlmodel import Field, SQLModel
 
+from awaithumans.server.db.models.base import tz_timestamp_column
+
 
 class ServiceAPIKey(SQLModel, table=True):
     """One row per `ah_sk_*` key that can mint embed tokens."""
@@ -32,6 +34,17 @@ class ServiceAPIKey(SQLModel, table=True):
     name: str = Field(max_length=80)
     key_hash: str = Field(unique=True, max_length=64)
     key_prefix: str = Field(max_length=12)
-    created_at: datetime
-    last_used_at: datetime | None = None
-    revoked_at: datetime | None = None
+    # Already tz-aware in the original alembic migration (20260508_0510),
+    # so prod deploys don't need the startup patch to repair this table.
+    # We still declare timezone=True at the model level for consistency:
+    # tests using `metadata.create_all` then produce tz-aware columns
+    # too, matching what the migration created in prod.
+    created_at: datetime = Field(sa_column=tz_timestamp_column())
+    last_used_at: datetime | None = Field(
+        default=None,
+        sa_column=tz_timestamp_column(nullable=True),
+    )
+    revoked_at: datetime | None = Field(
+        default=None,
+        sa_column=tz_timestamp_column(nullable=True),
+    )

--- a/packages/python/awaithumans/server/db/models/slack_installation.py
+++ b/packages/python/awaithumans/server/db/models/slack_installation.py
@@ -18,7 +18,7 @@ from sqlalchemy import Column
 from sqlmodel import Field, SQLModel
 
 from awaithumans.server.core.encryption import EncryptedString
-from awaithumans.server.db.models.base import utc_now
+from awaithumans.server.db.models.base import tz_timestamp_column, utc_now
 
 
 class SlackInstallation(SQLModel, table=True):
@@ -47,5 +47,11 @@ class SlackInstallation(SQLModel, table=True):
     # Who kicked off the install — useful for support + audit.
     installed_by_user_id: str | None = Field(default=None)
 
-    installed_at: datetime = Field(default_factory=utc_now)
-    updated_at: datetime = Field(default_factory=utc_now)
+    installed_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=tz_timestamp_column(),
+    )
+    updated_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=tz_timestamp_column(),
+    )

--- a/packages/python/awaithumans/server/db/models/slack_task_message.py
+++ b/packages/python/awaithumans/server/db/models/slack_task_message.py
@@ -23,7 +23,7 @@ from datetime import datetime
 
 from sqlmodel import Field, SQLModel
 
-from awaithumans.server.db.models.base import new_id, utc_now
+from awaithumans.server.db.models.base import new_id, tz_timestamp_column, utc_now
 
 
 class SlackTaskMessage(SQLModel, table=True):
@@ -45,4 +45,7 @@ class SlackTaskMessage(SQLModel, table=True):
     # there's only one workspace by construction so we don't need to
     # pin one. Set when an OAuth-installed workspace posted.
     team_id: str | None = Field(default=None, max_length=64)
-    created_at: datetime = Field(default_factory=utc_now)
+    created_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=tz_timestamp_column(),
+    )

--- a/packages/python/awaithumans/server/db/models/task.py
+++ b/packages/python/awaithumans/server/db/models/task.py
@@ -8,7 +8,7 @@ from typing import Any
 from sqlalchemy import Index, text
 from sqlmodel import JSON, Column, Field, SQLModel
 
-from awaithumans.server.db.models.base import new_id, utc_now
+from awaithumans.server.db.models.base import new_id, tz_timestamp_column, utc_now
 from awaithumans.types import TaskStatus
 from awaithumans.utils.constants import TERMINAL_STATUSES_SET
 
@@ -79,9 +79,7 @@ class Task(SQLModel, table=True):
     # numbers / arrays / objects supplied here are still accepted
     # at the DB layer (SQLite is permissive), but the SDK + schema
     # coerce values to strings before they arrive.
-    task_metadata: dict[str, str] | None = Field(
-        sa_column=Column(JSON), default=None
-    )
+    task_metadata: dict[str, str] | None = Field(sa_column=Column(JSON), default=None)
 
     # Response
     response: dict[str, Any] | None = Field(sa_column=Column(JSON), default=None)
@@ -95,14 +93,29 @@ class Task(SQLModel, table=True):
     timeout_seconds: int
     redact_payload: bool = Field(default=False)
 
-    # Timestamps
-    created_at: datetime = Field(default_factory=utc_now)
-    updated_at: datetime = Field(default_factory=utc_now)
-    completed_at: datetime | None = Field(default=None)
-    timed_out_at: datetime | None = Field(default=None)
+    # Timestamps. All use `TIMESTAMP WITH TIME ZONE` via
+    # tz_timestamp_column so the timeout-scheduler query
+    # `Task.timeout_at <= datetime.now(timezone.utc)` doesn't trip
+    # asyncpg's naive-vs-aware bind check on Postgres.
+    created_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=tz_timestamp_column(),
+    )
+    updated_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=tz_timestamp_column(),
+    )
+    completed_at: datetime | None = Field(
+        default=None,
+        sa_column=tz_timestamp_column(nullable=True),
+    )
+    timed_out_at: datetime | None = Field(
+        default=None,
+        sa_column=tz_timestamp_column(nullable=True),
+    )
     timeout_at: datetime | None = Field(
         default=None,
-        index=True,
+        sa_column=tz_timestamp_column(nullable=True, index=True),
         description="Pre-computed: created_at + timeout_seconds. Used by timeout scheduler.",
     )
 

--- a/packages/python/awaithumans/server/db/models/user.py
+++ b/packages/python/awaithumans/server/db/models/user.py
@@ -27,7 +27,7 @@ from datetime import datetime
 from sqlalchemy import Index, text
 from sqlmodel import Field, SQLModel
 
-from awaithumans.server.db.models.base import new_id, utc_now
+from awaithumans.server.db.models.base import new_id, tz_timestamp_column, utc_now
 
 
 class User(SQLModel, table=True):
@@ -58,11 +58,20 @@ class User(SQLModel, table=True):
     # new hires get picked ahead of veterans (correct default — their
     # queue is empty). Updated transactionally when the router picks
     # this user.
-    last_assigned_at: datetime | None = Field(default=None)
+    last_assigned_at: datetime | None = Field(
+        default=None,
+        sa_column=tz_timestamp_column(nullable=True),
+    )
 
     # ── Timestamps ───────────────────────────────────────────────────
-    created_at: datetime = Field(default_factory=utc_now)
-    updated_at: datetime = Field(default_factory=utc_now)
+    created_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=tz_timestamp_column(),
+    )
+    updated_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=tz_timestamp_column(),
+    )
 
     __table_args__ = (
         # Email unique across rows that actually have one.

--- a/packages/python/awaithumans/server/db/models/webhook_delivery.py
+++ b/packages/python/awaithumans/server/db/models/webhook_delivery.py
@@ -37,7 +37,7 @@ from datetime import datetime
 from sqlalchemy import Index, LargeBinary
 from sqlmodel import Column, Field, SQLModel
 
-from awaithumans.server.db.models.base import new_id, utc_now
+from awaithumans.server.db.models.base import new_id, tz_timestamp_column, utc_now
 
 
 class WebhookDeliveryStatus(str, enum.Enum):
@@ -76,16 +76,36 @@ class WebhookDelivery(SQLModel, table=True):
 
     status: WebhookDeliveryStatus = Field(default=WebhookDeliveryStatus.PENDING)
 
-    # Bookkeeping for the retry loop.
+    # Bookkeeping for the retry loop. Timestamp columns are
+    # tz-aware so the scheduler's `next_attempt_at <= now` comparison
+    # against `datetime.now(timezone.utc)` doesn't trip asyncpg.
+    # The composite (status, next_attempt_at) index lives in
+    # `__table_args__` below, so we don't add a single-column index
+    # here even though next_attempt_at is hot-path.
     attempt_count: int = Field(default=0)
-    next_attempt_at: datetime = Field(default_factory=utc_now)
-    first_attempted_at: datetime | None = Field(default=None)
-    last_attempt_at: datetime | None = Field(default=None)
+    next_attempt_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=tz_timestamp_column(),
+    )
+    first_attempted_at: datetime | None = Field(
+        default=None,
+        sa_column=tz_timestamp_column(nullable=True),
+    )
+    last_attempt_at: datetime | None = Field(
+        default=None,
+        sa_column=tz_timestamp_column(nullable=True),
+    )
     last_error: str | None = Field(default=None)
     last_status_code: int | None = Field(default=None)
 
-    created_at: datetime = Field(default_factory=utc_now)
-    updated_at: datetime = Field(default_factory=utc_now)
+    created_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=tz_timestamp_column(),
+    )
+    updated_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=tz_timestamp_column(),
+    )
 
     __table_args__ = (
         # Composite index for the scheduler's hot-path scan.

--- a/packages/python/tests/server/test_tz_aware_postgres_datetimes.py
+++ b/packages/python/tests/server/test_tz_aware_postgres_datetimes.py
@@ -1,0 +1,387 @@
+"""Datetime columns must be tz-aware on Postgres.
+
+Background: pre-PR-6 OSS migrations declared datetime columns as bare
+``sa.DateTime()``, which lands as ``TIMESTAMP WITHOUT TIME ZONE`` on
+Postgres. The service layer always wrote tz-aware values
+(``datetime.now(timezone.utc)``), so asyncpg refused to bind them as
+parameters — every query that compared or inserted a datetime against
+those columns crashed. The visible breakage was the timeout/webhook
+schedulers ticking on errors and the operator-bootstrap
+``POST /api/setup/complete`` returning 500, making the reviewer
+dashboard unusable on Postgres.
+
+The fix has three parts:
+
+1. Model declarations use ``tz_timestamp_column()`` so new tables
+   (via ``metadata.create_all`` in tests and brand-new deploys) get
+   the right column type natively.
+2. A startup helper, ``_patch_naive_timestamp_columns``, ALTERs
+   pre-existing Postgres columns to ``TIMESTAMP WITH TIME ZONE``
+   after alembic upgrade. Idempotent and a no-op on SQLite.
+3. The patch list (``_NAIVE_TIMESTAMP_COLUMNS``) is kept in sync
+   with the metadata via a test in this file — so adding a new
+   tz-aware column to a model without updating the patch list
+   trips a clear failure here, not silent prod drift.
+
+These tests don't spin up a real Postgres (no testcontainers dep);
+they verify the schema-introspection contract and the patch-list
+coverage. End-to-end Postgres verification is the deploy step.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import DateTime
+from sqlmodel import SQLModel
+
+from awaithumans.server.db import models as _models  # noqa: F401  — import for table registration
+from awaithumans.server.db.connection import (
+    _NAIVE_TIMESTAMP_COLUMNS,
+    _alter_naive_timestamps,
+    _patch_naive_timestamp_columns,
+)
+from awaithumans.server.db.models.base import tz_timestamp_column
+
+# Columns already declared tz-aware in their *original* alembic migration —
+# i.e., they never landed as naive on Postgres, so the runtime patch
+# doesn't need to repair them. Today this is service_api_keys (created
+# in 20260508_0510 with explicit `sa.DateTime(timezone=True)`). Update
+# this set if a future migration adds another such column.
+_ALREADY_TZ_AWARE_IN_MIGRATION: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("service_api_keys", "created_at"),
+        ("service_api_keys", "last_used_at"),
+        ("service_api_keys", "revoked_at"),
+    }
+)
+
+
+def _tz_aware_columns_in_metadata() -> set[tuple[str, str]]:
+    """Walk SQLModel metadata and return every DateTime(timezone=True)
+    column as a (table, column) pair."""
+    found: set[tuple[str, str]] = set()
+    for table_name, table in SQLModel.metadata.tables.items():
+        for col in table.columns:
+            if isinstance(col.type, DateTime) and col.type.timezone:
+                found.add((table_name, col.name))
+    return found
+
+
+def test_helper_emits_tz_aware_column() -> None:
+    """`tz_timestamp_column()` returns a `DateTime(timezone=True)` Column.
+
+    Locking the contract because every datetime field downstream
+    relies on it. A regression here silently produces naive columns
+    in every new table without anyone noticing until the schedulers
+    crash on the next prod boot.
+    """
+    col = tz_timestamp_column()
+    assert isinstance(col.type, DateTime)
+    assert col.type.timezone is True
+    assert col.nullable is False
+    assert col.index is False
+
+    nullable_col = tz_timestamp_column(nullable=True)
+    assert nullable_col.nullable is True
+
+    indexed_col = tz_timestamp_column(nullable=True, index=True)
+    assert indexed_col.nullable is True
+    assert indexed_col.index is True
+
+
+def test_all_model_datetime_columns_are_tz_aware() -> None:
+    """Every datetime column in the SQLModel metadata is tz-aware.
+
+    If someone adds a model column with bare ``Field(default_factory
+    =utc_now)`` instead of ``sa_column=tz_timestamp_column(...)``,
+    they'll get a plain ``DateTime`` in metadata and the scheduler-
+    crash bug returns on the next Postgres deploy. This test pins
+    the contract: any DateTime in metadata MUST be ``timezone=True``.
+    """
+    naive_in_metadata: list[tuple[str, str]] = []
+    for table_name, table in SQLModel.metadata.tables.items():
+        for col in table.columns:
+            if isinstance(col.type, DateTime) and not col.type.timezone:
+                naive_in_metadata.append((table_name, col.name))
+
+    assert not naive_in_metadata, (
+        "Found naive datetime columns in SQLModel metadata. Every "
+        "datetime field must use sa_column=tz_timestamp_column(...) "
+        f"from server/db/models/base.py. Naive columns: {naive_in_metadata!r}"
+    )
+
+
+def test_patch_list_covers_every_tz_aware_column() -> None:
+    """Every tz-aware column in metadata is either in the patch list or
+    explicitly known to have been tz-aware from its original migration.
+
+    This is the test that catches drift: someone adds a new datetime
+    column with ``tz_timestamp_column()``, the alembic autogen
+    creates a `TIMESTAMP WITH TIME ZONE` column (good!), but pre-PR-6
+    Postgres deployments never get the chance to ALTER an existing
+    naive version because the column wasn't there. So actually a new
+    column doesn't need a patch entry. BUT if the column already
+    exists in a pre-PR-6 migration as naive, and the model gets
+    updated without adding it to `_NAIVE_TIMESTAMP_COLUMNS`, prod
+    silently stays broken.
+
+    The test enforces the strict invariant: the patch list is
+    exhaustive for the moment of this PR. If a future PR adds a tz
+    column to an existing table without a new migration (or with a
+    migration that adds it as tz-aware), update
+    ``_ALREADY_TZ_AWARE_IN_MIGRATION`` here too.
+    """
+    metadata_tz_cols = _tz_aware_columns_in_metadata()
+    patch_set = set(_NAIVE_TIMESTAMP_COLUMNS)
+
+    # Every tz-aware column should be either patched at boot or
+    # already-correct-in-migration.
+    uncovered = metadata_tz_cols - patch_set - _ALREADY_TZ_AWARE_IN_MIGRATION
+    assert not uncovered, (
+        "Tz-aware columns in models that aren't in _NAIVE_TIMESTAMP_COLUMNS "
+        "and aren't in the known-already-correct set. Either add them to "
+        f"_NAIVE_TIMESTAMP_COLUMNS in db/connection.py, or to "
+        f"_ALREADY_TZ_AWARE_IN_MIGRATION in this test file if their "
+        f"original migration already declared timezone=True: {sorted(uncovered)!r}"
+    )
+
+    # And the patch list shouldn't reference columns that aren't in
+    # the model — would mean stale entries from a deleted column.
+    extra = patch_set - metadata_tz_cols
+    assert not extra, (
+        "_NAIVE_TIMESTAMP_COLUMNS references columns that no longer exist "
+        f"in any model. Remove these stale entries: {sorted(extra)!r}"
+    )
+
+
+async def test_patch_is_noop_on_sqlite(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The outer ``_patch_naive_timestamp_columns`` early-exits on a
+    SQLite URL.
+
+    The patch's SQL ( ``information_schema.columns``,
+    ``TIMESTAMP WITH TIME ZONE`` ) is Postgres-specific. SQLite would
+    raise on the first query. Tests, dev mode, and any non-Postgres
+    self-host depend on this early return.
+
+    Patches ``get_async_engine`` to a sentinel that would fail the
+    test if invoked — proving the function bailed before touching
+    any DB machinery. ``database_url_async`` is a Settings property,
+    so we mock it at the module level rather than try to set it on
+    the singleton.
+    """
+    sqlite_url = "sqlite+aiosqlite:///./test-only.db"
+
+    # Stub the property to return SQLite. patch.object on a class
+    # property is the supported pattern; Settings.database_url_async
+    # is a @property so we replace the descriptor on the class.
+    from awaithumans.server.core.config import Settings
+
+    explosive_engine = MagicMock(
+        side_effect=AssertionError("engine should not be touched on SQLite")
+    )
+    monkeypatch.setattr(
+        "awaithumans.server.db.connection.get_async_engine",
+        explosive_engine,
+    )
+
+    with patch.object(
+        Settings,
+        "database_url_async",
+        new_callable=lambda: property(lambda self: sqlite_url),
+    ):
+        await _patch_naive_timestamp_columns()
+
+    explosive_engine.assert_not_called()
+
+
+async def test_patch_short_circuits_for_each_non_postgres_scheme(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Belt-and-braces: the URL prefix check has to match every
+    non-Postgres scheme we might see, not just sqlite. If a future
+    helper produces e.g. an unparseable URL, the patch should still
+    return early rather than crash trying to connect.
+
+    We don't actually run against every scheme — just verify the
+    bare URL check rejects anything that isn't `postgresql://` or
+    `postgresql+driver://`.
+    """
+    from awaithumans.server.core.config import Settings
+
+    explosive_engine = MagicMock(side_effect=AssertionError("engine touched"))
+    monkeypatch.setattr(
+        "awaithumans.server.db.connection.get_async_engine",
+        explosive_engine,
+    )
+
+    for url in (
+        "sqlite:///./x.db",
+        "sqlite+aiosqlite:///./x.db",
+        "mysql://u:p@h:3306/db",
+        "",
+    ):
+        with patch.object(
+            Settings,
+            "database_url_async",
+            new_callable=lambda u=url: property(lambda self: u),
+        ):
+            await _patch_naive_timestamp_columns()
+
+    explosive_engine.assert_not_called()
+
+
+async def test_alter_emits_correct_sql_for_naive_column() -> None:
+    """When a column is naive, the helper issues exactly the right
+    ALTER TABLE statement against the connection.
+
+    This is the load-bearing assertion for the production fix: the
+    SQL has to (a) ALTER the column to TIMESTAMP WITH TIME ZONE,
+    (b) preserve existing values via ``AT TIME ZONE 'UTC'`` so the
+    column gets labeled, not shifted, and (c) target the right
+    table/column. The test uses an AsyncMock connection so we can
+    inspect the SQL without a real Postgres.
+    """
+    # The mocked execute returns "timestamp without time zone" for the
+    # SELECT, simulating a naive column in Postgres' information_schema.
+    naive_result = MagicMock()
+    naive_result.scalar_one_or_none = MagicMock(return_value="timestamp without time zone")
+
+    # Each call to conn.execute returns the same result regardless of
+    # what was passed. That's fine — the SELECT and ALTER paths use
+    # the same mock, and we only assert on `scalar_one_or_none` for
+    # the SELECT.
+    mock_conn = MagicMock()
+    mock_conn.execute = AsyncMock(return_value=naive_result)
+
+    columns = (("tasks", "timeout_at"),)
+    altered = await _alter_naive_timestamps(mock_conn, columns)
+
+    assert altered == 1, "Expected exactly one column to be altered"
+    assert mock_conn.execute.call_count == 2, (
+        f"Expected SELECT then ALTER (2 calls); got: {mock_conn.execute.call_count}"
+    )
+
+    select_sql = str(mock_conn.execute.call_args_list[0].args[0])
+    assert "information_schema.columns" in select_sql
+    assert "table_name = :t" in select_sql
+    assert "column_name = :c" in select_sql
+
+    alter_sql = str(mock_conn.execute.call_args_list[1].args[0])
+    assert 'ALTER TABLE "tasks"' in alter_sql
+    assert 'ALTER COLUMN "timeout_at"' in alter_sql
+    assert "TYPE TIMESTAMP WITH TIME ZONE" in alter_sql
+    assert "AT TIME ZONE 'UTC'" in alter_sql
+
+
+async def test_alter_skips_already_tz_aware_columns() -> None:
+    """Idempotency check: re-running the patch is free.
+
+    The whole point of running this on every boot is that
+    self-healing must be cheap when there's nothing to heal. If the
+    SELECT returns ``timestamp with time zone``, no ALTER should
+    fire and ``altered`` should be 0. A regression here would mean
+    every server boot re-rewrites every datetime column on every
+    table — fine on tiny tables, catastrophic at scale.
+    """
+    aware_result = MagicMock()
+    aware_result.scalar_one_or_none = MagicMock(return_value="timestamp with time zone")
+
+    mock_conn = MagicMock()
+    mock_conn.execute = AsyncMock(return_value=aware_result)
+
+    columns = (("tasks", "timeout_at"), ("users", "created_at"))
+    altered = await _alter_naive_timestamps(mock_conn, columns)
+
+    assert altered == 0
+    # Only SELECT per column, no ALTER.
+    assert mock_conn.execute.call_count == 2, "Expected exactly one SELECT per column, no ALTERs"
+
+
+async def test_alter_skips_missing_columns() -> None:
+    """If ``information_schema`` returns no row (column was renamed
+    or dropped, or alembic hasn't created the table yet for some
+    reason), the helper skips that entry cleanly rather than
+    crashing.
+
+    Alembic owns column lifecycle. This patch is *only* a type
+    repair; it must never error on a missing column or it'd block
+    boot for a deployment that's mid-migration.
+    """
+    missing_result = MagicMock()
+    missing_result.scalar_one_or_none = MagicMock(return_value=None)
+
+    mock_conn = MagicMock()
+    mock_conn.execute = AsyncMock(return_value=missing_result)
+
+    altered = await _alter_naive_timestamps(
+        mock_conn,
+        (("tasks", "nonexistent_column"),),
+    )
+
+    assert altered == 0
+    assert mock_conn.execute.call_count == 1  # only the SELECT, no ALTER
+
+
+async def test_alter_mixed_naive_and_aware_columns() -> None:
+    """A realistic prod scenario: some columns are still naive (need
+    repair), some have already been altered on a prior boot. The
+    helper should ALTER only the naive ones and leave the aware
+    ones alone.
+    """
+    naive_result = MagicMock()
+    naive_result.scalar_one_or_none = MagicMock(return_value="timestamp without time zone")
+    aware_result = MagicMock()
+    aware_result.scalar_one_or_none = MagicMock(return_value="timestamp with time zone")
+
+    # First column: naive (SELECT then ALTER = 2 calls)
+    # Second column: aware (SELECT only = 1 call)
+    # Total: 3 calls. The execute mock returns naive_result first,
+    # naive_result for ALTER (irrelevant), then aware_result.
+    mock_conn = MagicMock()
+    mock_conn.execute = AsyncMock(side_effect=[naive_result, naive_result, aware_result])
+
+    columns = (("tasks", "timeout_at"), ("tasks", "created_at"))
+    altered = await _alter_naive_timestamps(mock_conn, columns)
+
+    assert altered == 1
+    assert mock_conn.execute.call_count == 3
+
+
+def test_patch_list_matches_pre_pr6_schema_exactly() -> None:
+    """Pin the exact contents of the patch list so a reviewer can
+    glance at this test and verify the (table, column) pairs match
+    the audit done in PR 6's design notes. Removing an entry without
+    confirming the corresponding column was migrated tz-aware first
+    is a hazard worth a test.
+    """
+    expected = {
+        ("audit_entries", "created_at"),
+        ("consumed_email_tokens", "consumed_at"),
+        ("email_sender_identities", "verified_at"),
+        ("email_sender_identities", "created_at"),
+        ("email_sender_identities", "updated_at"),
+        ("slack_installations", "installed_at"),
+        ("slack_installations", "updated_at"),
+        ("slack_task_messages", "created_at"),
+        ("tasks", "created_at"),
+        ("tasks", "updated_at"),
+        ("tasks", "completed_at"),
+        ("tasks", "timed_out_at"),
+        ("tasks", "timeout_at"),
+        ("users", "last_assigned_at"),
+        ("users", "created_at"),
+        ("users", "updated_at"),
+        ("webhook_deliveries", "next_attempt_at"),
+        ("webhook_deliveries", "first_attempted_at"),
+        ("webhook_deliveries", "last_attempt_at"),
+        ("webhook_deliveries", "created_at"),
+        ("webhook_deliveries", "updated_at"),
+    }
+    assert set(_NAIVE_TIMESTAMP_COLUMNS) == expected, (
+        "Patch list drifted from PR 6's documented audit. If this is "
+        "intentional (e.g., a new alembic migration created a column "
+        "tz-aware from the start), update _ALREADY_TZ_AWARE_IN_MIGRATION "
+        "above too."
+    )


### PR DESCRIPTION
## Severity

**Launch-blocking on Postgres deployments.** SQLite path unaffected. The reviewer dashboard is currently unusable on Postgres because operator-bootstrap (\`POST /api/setup/complete\`) returns 500 alongside the timeout/webhook scheduler crashes from the original handoff.

## Summary

- New \`tz_timestamp_column()\` helper in \`server/db/models/base.py\` that emits \`Column(DateTime(timezone=True), ...)\`. 24 datetime fields across 9 model files updated to use it.
- New startup helper \`_patch_naive_timestamp_columns()\` in \`server/db/connection.py\`, called from \`init_db()\` after alembic upgrade. Idempotent ALTER for 21 known-affected columns. No-op on SQLite.
- 10 new tests, including a metadata-introspection invariant that prevents future regressions.

## Why

Pre-PR-6 migrations declared datetime columns as bare \`sa.DateTime()\`, which lands as \`TIMESTAMP WITHOUT TIME ZONE\` on Postgres. The service layer has always written tz-aware values via \`datetime.now(timezone.utc)\`. asyncpg refuses to bind tz-aware Python datetimes against a tz-naive column, so every query that touched a datetime column crashed.

SQLite was invisible to this because SQLite has no real datetime type — datetimes round-trip as text and SQLite is permissive. Only Postgres surfaced the bug.

## The three coordinated parts

1. **Model declarations** now use \`tz_timestamp_column(...)\`. Tables created from metadata (tests + future alembic autogen) get the right column type natively. The helper accepts \`nullable=\` and \`index=\` so the existing \`timeout_at\` index is preserved.

2. **Startup repair** in \`_patch_naive_timestamp_columns()\`. After \`init_db()\` finishes alembic upgrade, this helper iterates the 21 columns that pre-PR-6 migrations created as naive and, for each, queries \`information_schema.columns\` and \`ALTER\`s if still naive. The \`USING column AT TIME ZONE 'UTC'\` clause attaches the timezone label without shifting values — value-preserving by construction because the service layer always wrote UTC.

3. **Drift protection** via \`test_patch_list_covers_every_tz_aware_column\`. Walks SQLModel metadata and asserts every tz-aware column in any model is either in \`_NAIVE_TIMESTAMP_COLUMNS\` or in an explicit known-correct set (just \`service_api_keys\` today, whose migration was already tz-aware). A future PR that adds a tz column to an existing pre-PR-6 table without a patch entry fails this test loudly.

## Why a runtime patch instead of a new alembic revision

Per the handoff: an alembic revision that ALTERs columns on every prod database is deploy-coupling we don't need. The runtime patch is idempotent (\`!= 'timestamp without time zone'\` → skip), so booting an already-patched server is free. Once every running deployment has booted under PR 6, the runtime patch can be deleted — its only purpose is to repair tables created by pre-PR-6 migrations.

Mirrors the same pattern already proven in \`awaithumans-managed-deploy/src/database/db.py\`, which has been running against the same Azure Postgres flexible-server instance.

## Cross-platform safety

- **SQLite (tests, dev mode, \`awaithumans dev\`):** URL prefix check at the top of \`_patch_naive_timestamp_columns()\` returns early. \`information_schema\` SQL never runs.
- **Postgres (new deploy):** alembic creates naive columns, patch runs once at boot, ALTERs to tz-aware. Next boot sees \`timestamp with time zone\` and short-circuits.
- **Postgres (existing prod with data):** \`AT TIME ZONE 'UTC'\` attaches the timezone label to existing values without shifting them — they were always UTC by service-layer convention.
- **Missing columns:** if alembic somehow hasn't created a table yet (mid-migration, renamed, dropped), the \`information_schema\` query returns None and the patch skips that entry. Alembic owns column lifecycle; the patch only repairs type.

## Test plan

- [x] \`python -m pytest packages/python/tests/ --ignore=tests/adapters\` — **766 passed** on SQLite (10 new + 756 existing, no regressions)
- [x] \`ruff check && ruff format --check\` on changed files — clean
- [x] Manual: \`init_db()\` on fresh SQLite runs every migration and short-circuits the patch
- [x] Helper assertions: \`tz_timestamp_column()\` produces \`DateTime(timezone=True)\`, every model column in metadata is tz-aware, patch list is exhaustive
- [x] Mocked-Postgres SQL assertions: emits the correct SELECT + ALTER, skips when already tz-aware, skips when column missing
- [ ] **Reviewer:** end-to-end Postgres verification per the handoff plan — trigger \`Deploy reviewers (OSS)\` workflow with \`image_tag=main\` once this merges, tail the new revision for ~2 minutes, confirm zero \`Error in timeout scheduler\` / \`Error in webhook scheduler tick\` lines AND that \`POST /api/setup/complete\` returns 2xx on a fresh operator bootstrap
- [ ] **Reviewer:** optionally run the AwaitVerify smoke test (\`/tmp/smoke_av.py\`) for a full round-trip

## Cleanup after rollout

Once every active deployment has booted under PR 6 and you've confirmed the columns are all tz-aware in prod, the runtime patch can be deleted in a follow-up. The model declarations and tests are the carry-forward state; \`_patch_naive_timestamp_columns\` is repair scaffolding with a finite lifetime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)