### PR TITLE
feat(awaitverify): forward Flow A / Flow B extraction as initial_response

### DIFF
--- a/packages/python/alembic/versions/20260530_2200_add_initial_response_to_tasks.py
+++ b/packages/python/alembic/versions/20260530_2200_add_initial_response_to_tasks.py
@@ -1,0 +1,40 @@
+"""add initial_response to tasks
+
+Revision ID: 3c2a91e4f8d1
+Revises: fa6b843c3051
+Create Date: 2026-05-30 22:00:00.000000
+
+Adds the ``initial_response`` JSON column to the ``tasks`` table for
+AwaitVerify Flow A / Flow B pre-fill. Pre-computed extraction values
+(matching ``response_schema``) land here and the dashboard mounts the
+form with those values pre-populated, so the reviewer verifies rather
+than re-types.
+
+Nullable: most non-AwaitVerify tasks (plain await_human callers,
+pure-human review) won't carry a pre-computed extraction. New column,
+new field — no backfill needed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "3c2a91e4f8d1"
+down_revision: str | None = "fa6b843c3051"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("tasks", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("initial_response", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("tasks", schema=None) as batch_op:
+        batch_op.drop_column("initial_response")

--- a/packages/python/awaithumans/awaitverify/_managed_client.py
+++ b/packages/python/awaithumans/awaitverify/_managed_client.py
@@ -138,18 +138,29 @@ async def create_task(
     response_schema_json: str,
     priority: str,
     task_metadata: dict[str, str] | None = None,
+    initial_response: dict[str, Any] | None = None,
 ) -> CreatedTask:
-    """POST /api/v1/awaitverify/tasks."""
+    """POST /api/v1/awaitverify/tasks.
+
+    ``initial_response`` carries the customer's prior extraction (Flow A)
+    or the SDK-run extraction output (Flow B) as a JSON payload matching
+    ``response_schema``. Managed validates it server-side and forwards
+    to the OSS reviewer dashboard, which mounts the form with the values
+    pre-populated. Omit (or pass None) for pure-human review.
+    """
     body: dict[str, Any] = {
         "upload_session_id": upload_session_id,
         "task_description": task_description,
         "response_schema_json": response_schema_json,
         "priority": priority,
     }
-    # Only include task_metadata when set so we don't push an
-    # ambiguous null at the managed backend's schema validation.
+    # Only include task_metadata / initial_response when set so the
+    # managed backend's schema validation doesn't see an ambiguous
+    # explicit null where "omitted" is the correct signal.
     if task_metadata:
         body["task_metadata"] = task_metadata
+    if initial_response is not None:
+        body["initial_response"] = initial_response
     data = await _post_json(
         url=f"{managed_url.rstrip('/')}/api/v1/awaitverify/tasks",
         body=body,

--- a/packages/python/awaithumans/awaitverify/client.py
+++ b/packages/python/awaithumans/awaitverify/client.py
@@ -216,18 +216,25 @@ async def verify_document(
             client=client,
         )
 
-    # NOTE: prior_extraction (Flow A) and the Flow B model output
-    # currently get dropped because the managed backend's /tasks body
-    # does not yet accept them. The reviewer dashboard (Phase 3) will
-    # introduce the extracted-payload pass-through. Logging here so
-    # the gap is visible in dev.
-    has_extracted_payload = flow_b_output is not None or prior_extraction is not None
-    if has_extracted_payload:
-        logger.warning(
-            "Flow A/B extracted output is not yet forwarded to the managed "
-            "backend (Phase 3 work). The human reviewer will verify from "
-            "scratch in v1."
-        )
+    # Resolve the chosen extraction. Flow A and Flow B are mutually
+    # exclusive (the combo is rejected at lines 208-211 above), so at
+    # most one of these is non-None. Flow A delivers a Pydantic model
+    # — `model_dump(mode="json")` so nested datetime/UUID/Enum values
+    # serialize through to JSON cleanly. Flow B's `flow_b_output` is
+    # already a dict from `run_extraction()`, validated against
+    # response_schema there.
+    #
+    # The managed backend validates `initial_response` against the
+    # task's `response_schema` before forwarding to the OSS reviewer
+    # dashboard, which mounts the form with the values pre-populated
+    # so the reviewer verifies/corrects rather than re-types.
+    initial_response: dict[str, Any] | None
+    if prior_extraction is not None:
+        initial_response = prior_extraction.model_dump(mode="json")
+    elif flow_b_output is not None:
+        initial_response = flow_b_output
+    else:
+        initial_response = None
 
     # ── Fragment client-side ────────────────────────────────────────
     page_fragments = fragment_document(raw)
@@ -295,6 +302,7 @@ async def verify_document(
         response_schema_json=response_schema_json,
         priority=resolved_priority.value,
         task_metadata=task_metadata,
+        initial_response=initial_response,
     )
 
     logger.info(

--- a/packages/python/awaithumans/server/db/models/task.py
+++ b/packages/python/awaithumans/server/db/models/task.py
@@ -81,6 +81,14 @@ class Task(SQLModel, table=True):
     # coerce values to strings before they arrive.
     task_metadata: dict[str, str] | None = Field(sa_column=Column(JSON), default=None)
 
+    # Pre-computed extraction (AwaitVerify Flow A / Flow B). Optional
+    # JSON snapshot matching `response_schema` shape; the dashboard
+    # mounts the form with these values pre-populated so the reviewer
+    # verifies rather than re-types. Persisted verbatim — managed
+    # validates against `response_schema` before forwarding, so the
+    # OSS server doesn't re-validate.
+    initial_response: dict[str, Any] | None = Field(sa_column=Column(JSON), default=None)
+
     # Response
     response: dict[str, Any] | None = Field(sa_column=Column(JSON), default=None)
 

--- a/packages/python/awaithumans/server/routes/tasks.py
+++ b/packages/python/awaithumans/server/routes/tasks.py
@@ -178,6 +178,7 @@ async def create_task_route(
         redact_payload=body.redact_payload,
         callback_url=body.callback_url,
         task_metadata=body.task_metadata,
+        initial_response=body.initial_response,
     )
 
     # Replay header: clients that care about distinguishing fresh

--- a/packages/python/awaithumans/server/schemas/task.py
+++ b/packages/python/awaithumans/server/schemas/task.py
@@ -37,6 +37,21 @@ class CreateTaskRequest(BaseModel):
             "customer name, business vertical, escalation tier."
         ),
     )
+    # AwaitVerify Flow A / Flow B: a pre-computed extraction of the
+    # document that the reviewer should verify rather than fill from
+    # scratch. The dashboard mounts the form with these values
+    # pre-populated. Shape matches `response_schema`; managed
+    # validates that match before forwarding here, so the OSS server
+    # only asserts JSON-serializability and persists.
+    initial_response: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Optional pre-computed extraction (Flow A / Flow B). The "
+            "reviewer dashboard renders the form with these values "
+            "pre-filled so the human verifies/corrects rather than "
+            "re-types. Null for pure-human review."
+        ),
+    )
 
 
 class CompleteTaskRequest(BaseModel):
@@ -65,6 +80,7 @@ class TaskResponse(BaseModel):
     assigned_to_user_id: str | None = None
     assigned_to_display_name: str | None = None
     assigned_to_slack_user_id: str | None = None
+    initial_response: dict[str, Any] | None = None
     response: dict[str, Any] | None = None
     verifier_result: dict[str, Any] | None = None
     verification_attempt: int = 0

--- a/packages/python/awaithumans/server/services/task_service.py
+++ b/packages/python/awaithumans/server/services/task_service.py
@@ -53,6 +53,7 @@ async def create_task(
     redact_payload: bool = False,
     callback_url: str | None = None,
     task_metadata: dict[str, str] | None = None,
+    initial_response: dict | None = None,
 ) -> tuple[Task, bool]:
     """Create a new task, or return the existing one if idempotency key matches.
 
@@ -111,6 +112,7 @@ async def create_task(
         redact_payload=redact_payload,
         callback_url=callback_url,
         task_metadata=task_metadata,
+        initial_response=initial_response,
         status=TaskStatus.CREATED,
         created_at=now,
         updated_at=now,

--- a/packages/python/tests/awaitverify/test_client.py
+++ b/packages/python/tests/awaitverify/test_client.py
@@ -131,6 +131,7 @@ def _stub_managed_calls(
         response_schema_json: str,
         priority: str,
         task_metadata: dict[str, str] | None = None,
+        initial_response: dict[str, Any] | None = None,
     ) -> Any:
         from awaithumans.awaitverify._managed_client import CreatedTask
 
@@ -142,6 +143,7 @@ def _stub_managed_calls(
             "response_schema_json": response_schema_json,
             "priority": priority,
             "task_metadata": task_metadata,
+            "initial_response": initial_response,
         }
         return CreatedTask(
             task_id="task-id-fake",
@@ -184,8 +186,7 @@ class TestAwaitHumansClient:
     def test_managed_url_default(self) -> None:
         client = AwaitHumans(api_key="ah_sk_test")
         assert client.managed_url == (
-            "https://awaithumans-managed.icyflower-6900d175.westus3."
-            "azurecontainerapps.io"
+            "https://awaithumans-managed.icyflower-6900d175.westus3.azurecontainerapps.io"
         )
 
     def test_managed_url_override(self) -> None:
@@ -383,3 +384,175 @@ class TestRejectsBothFlowAandFlowB:
                 prior_extraction=_Extraction(codes=["T12C3"]),
                 extraction=OpenAIExtraction(model="gpt-4o", prompt="extract"),
             )
+
+
+class TestInitialResponseForwarding:
+    """The Phase-3 drop guard is gone — Flow A's prior_extraction and
+    Flow B's extraction output now both flow through to managed as
+    ``initial_response`` so the reviewer dashboard can pre-populate
+    the form. Pin all three branches (Flow A, Flow B, neither).
+    """
+
+    @pytest.mark.asyncio
+    async def test_flow_a_prior_extraction_forwarded_as_initial_response(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Flow A: ``prior_extraction`` (a Pydantic model) is dumped to
+        a dict and lands in the managed POST as ``initial_response``.
+
+        The serialization MUST go through ``model_dump(mode="json")``
+        so any nested datetime/UUID/Enum value in the customer's
+        extraction class comes through as JSON-safe primitives. Test
+        with a simple list[str] to keep the assertion legible; the
+        ``mode="json"`` discipline is documented in the source.
+        """
+        captured = _stub_managed_calls(monkeypatch, completed_response={"ok": True})
+        png_path = tmp_path / "doc.png"
+        png_path.write_bytes(_png_bytes())
+
+        client = AwaitHumans(api_key="ah_sk_test")
+        await client.verify_document(
+            task_description="check",
+            response_schema=_StubResponse,
+            document_path=png_path,
+            prior_extraction=_Extraction(codes=["A12", "B34"]),
+        )
+
+        assert captured["task_request"]["initial_response"] == {"codes": ["A12", "B34"]}, (
+            "prior_extraction must be serialized to a JSON dict and forwarded; "
+            f"got: {captured['task_request']['initial_response']!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_flow_b_extraction_output_forwarded_as_initial_response(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Flow B: SDK runs the extraction locally and forwards the
+        dict result as ``initial_response``. We stub ``run_extraction``
+        so the test doesn't hit a real OpenAI/Reducto/etc. endpoint.
+
+        The dict output of run_extraction is already validated against
+        ``response_schema`` inside that function, so the SDK passes it
+        through verbatim — no second serialization pass.
+        """
+        captured = _stub_managed_calls(monkeypatch, completed_response={"ok": True})
+
+        async def fake_run_extraction(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            # Caller-supplied schema-shaped dict.
+            return {"codes": ["from-flow-b"]}
+
+        monkeypatch.setattr(client_mod, "run_extraction", fake_run_extraction)
+
+        png_path = tmp_path / "doc.png"
+        png_path.write_bytes(_png_bytes())
+
+        client = AwaitHumans(api_key="ah_sk_test", openai=OpenAI(api_key="sk-test"))
+        await client.verify_document(
+            task_description="check",
+            response_schema=_StubResponse,
+            document_path=png_path,
+            extraction=OpenAIExtraction(model="gpt-4o", prompt="extract"),
+        )
+
+        assert captured["task_request"]["initial_response"] == {"codes": ["from-flow-b"]}
+
+    @pytest.mark.asyncio
+    async def test_no_extraction_sends_null_initial_response(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Pure-human review path: neither flow set → managed sees
+        ``initial_response=None``, and the wire body omits the key
+        (verified separately at the ``_managed_client.create_task``
+        level since the stub here doesn't probe the wire body).
+        """
+        captured = _stub_managed_calls(monkeypatch, completed_response={"ok": True})
+        png_path = tmp_path / "doc.png"
+        png_path.write_bytes(_png_bytes())
+
+        client = AwaitHumans(api_key="ah_sk_test")
+        await client.verify_document(
+            task_description="check",
+            response_schema=_StubResponse,
+            document_path=png_path,
+        )
+
+        assert captured["task_request"]["initial_response"] is None
+
+
+class TestManagedCreateTaskWireBody:
+    """Unit tests for the ``_managed_client.create_task`` helper itself,
+    focused on what the wire body actually contains. The SDK-level
+    tests above capture the captured kwargs of a stub; these tests
+    inspect the JSON body that goes over HTTP, which is the contract
+    the managed backend reads.
+    """
+
+    @pytest.mark.asyncio
+    async def test_initial_response_present_in_body_when_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from awaithumans.awaitverify import _managed_client
+
+        captured: dict[str, Any] = {}
+
+        async def fake_post_json(
+            *, url: str, body: dict[str, Any], api_key: str | None
+        ) -> dict[str, Any]:
+            captured["body"] = body
+            return {
+                "task_id": "t-1",
+                "upload_session_id": "u-1",
+                "status": "awaiting_review",
+            }
+
+        monkeypatch.setattr(_managed_client, "_post_json", fake_post_json)
+
+        await _managed_client.create_task(
+            managed_url="http://m",
+            api_key="k",
+            upload_session_id="u-1",
+            task_description="d",
+            response_schema_json="{}",
+            priority="standard",
+            initial_response={"codes": ["X"]},
+        )
+
+        assert captured["body"]["initial_response"] == {"codes": ["X"]}
+
+    @pytest.mark.asyncio
+    async def test_initial_response_omitted_from_body_when_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When ``initial_response`` is None, the key must be absent
+        from the wire body — not present-with-null. Managed treats
+        "absent" as "no prior extraction"; an explicit null could be
+        read as "the customer ran extraction and got null", which
+        means something different to the form-prefill logic.
+        """
+        from awaithumans.awaitverify import _managed_client
+
+        captured: dict[str, Any] = {}
+
+        async def fake_post_json(
+            *, url: str, body: dict[str, Any], api_key: str | None
+        ) -> dict[str, Any]:
+            captured["body"] = body
+            return {
+                "task_id": "t-1",
+                "upload_session_id": "u-1",
+                "status": "awaiting_review",
+            }
+
+        monkeypatch.setattr(_managed_client, "_post_json", fake_post_json)
+
+        await _managed_client.create_task(
+            managed_url="http://m",
+            api_key="k",
+            upload_session_id="u-1",
+            task_description="d",
+            response_schema_json="{}",
+            priority="standard",
+            initial_response=None,
+        )
+
+        assert "initial_response" not in captured["body"]

--- a/packages/python/tests/tasks/test_initial_response.py
+++ b/packages/python/tests/tasks/test_initial_response.py
@@ -1,0 +1,152 @@
+"""initial_response round-trip — POST → DB → GET.
+
+Covers the AwaitVerify Flow A / Flow B pre-fill payload. Managed
+validates the value against ``response_schema`` before forwarding
+here, so the OSS server only needs to:
+
+1. Accept ``initial_response`` on the create request,
+2. Persist it on the Task row,
+3. Surface it in the GET-task response so the dashboard can read it.
+
+The dashboard then mounts the form with these values pre-populated
+(O4 lands in a separate PR). For this PR we only test the round-trip.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from tests.tasks.test_route_authorization import (  # fixture re-exports
+    _admin_headers,
+    client,  # noqa: F401
+)
+
+_BODY: dict = {
+    "task": "Verify invoice",
+    "payload": {"document_url": "https://example.com/inv.pdf"},
+    "payload_schema": {"type": "object"},
+    "response_schema": {"type": "object"},
+    "timeout_seconds": 900,
+}
+
+
+def test_initial_response_persists_on_create(client: TestClient) -> None:  # noqa: F811
+    """A flat dict initial_response round-trips through POST → DB → GET
+    unchanged. This is the happy path for Flow A on a simple schema.
+    """
+    body = {
+        **_BODY,
+        "idempotency_key": "init-response-flat",
+        "initial_response": {
+            "vendor": "Acme Corp",
+            "amount": 1250.0,
+            "currency": "USD",
+        },
+    }
+    resp = client.post("/api/tasks", json=body, headers=_admin_headers())
+    assert resp.status_code == 201, resp.text
+
+    task_id = resp.json()["id"]
+    fetched = client.get(f"/api/tasks/{task_id}", headers=_admin_headers())
+    assert fetched.status_code == 200
+    assert fetched.json()["initial_response"] == {
+        "vendor": "Acme Corp",
+        "amount": 1250.0,
+        "currency": "USD",
+    }
+
+
+def test_initial_response_persists_nested_shape(client: TestClient) -> None:  # noqa: F811
+    """The whole point of initial_response is to carry the customer's
+    extraction — which is often a nested Pydantic model. Lists,
+    nested objects, and mixed primitives must all survive the
+    JSON round-trip intact.
+
+    This is the shape the form-rendering PR (O3) reads to pre-fill
+    repeatable_groups: each item in ``line_items`` becomes a row.
+    """
+    body = {
+        **_BODY,
+        "idempotency_key": "init-response-nested",
+        "initial_response": {
+            "vendor": "Acme Corp",
+            "address": {"city": "Brooklyn", "zip": "11201"},
+            "line_items": [
+                {"sku": "A-1", "qty": 2, "unit_price": 9.99},
+                {"sku": "B-9", "qty": 1, "unit_price": 49.0},
+            ],
+            "notes": None,
+        },
+    }
+    resp = client.post("/api/tasks", json=body, headers=_admin_headers())
+    assert resp.status_code == 201, resp.text
+
+    task_id = resp.json()["id"]
+    fetched = client.get(f"/api/tasks/{task_id}", headers=_admin_headers())
+    body_back = fetched.json()["initial_response"]
+    assert body_back["address"] == {"city": "Brooklyn", "zip": "11201"}
+    assert body_back["line_items"] == [
+        {"sku": "A-1", "qty": 2, "unit_price": 9.99},
+        {"sku": "B-9", "qty": 1, "unit_price": 49.0},
+    ]
+    assert body_back["notes"] is None
+
+
+def test_initial_response_absent_is_null(client: TestClient) -> None:  # noqa: F811
+    """Tasks created without a pre-computed extraction (pure-human
+    review, non-AwaitVerify await_human calls) serialize the field
+    as null. Stable optional rather than missing key — the dashboard
+    branches on truthy vs falsy.
+    """
+    body = {**_BODY, "idempotency_key": "init-response-absent"}
+    resp = client.post("/api/tasks", json=body, headers=_admin_headers())
+    assert resp.status_code == 201
+    assert resp.json()["initial_response"] is None
+
+
+def test_initial_response_in_create_response(client: TestClient) -> None:  # noqa: F811
+    """The 201 response from POST /api/tasks should echo the
+    initial_response so the SDK / managed backend can confirm the
+    value was accepted without an extra GET round-trip.
+    """
+    body = {
+        **_BODY,
+        "idempotency_key": "init-response-echo",
+        "initial_response": {"hello": "world"},
+    }
+    resp = client.post("/api/tasks", json=body, headers=_admin_headers())
+    assert resp.status_code == 201
+    assert resp.json()["initial_response"] == {"hello": "world"}
+
+
+def test_idempotency_replay_returns_original_initial_response(
+    client: TestClient,  # noqa: F811
+) -> None:
+    """A retry with the same idempotency_key returns the FIRST
+    initial_response, not the second. Otherwise a flaky retry path
+    could silently flip the pre-fill values the reviewer sees.
+
+    Mirrors the existing task_metadata replay test — same contract.
+    """
+    first = client.post(
+        "/api/tasks",
+        json={
+            **_BODY,
+            "idempotency_key": "init-response-replay",
+            "initial_response": {"vendor": "Original"},
+        },
+        headers=_admin_headers(),
+    )
+    assert first.status_code == 201
+
+    replay = client.post(
+        "/api/tasks",
+        json={
+            **_BODY,
+            "idempotency_key": "init-response-replay",
+            "initial_response": {"vendor": "DifferentValue"},
+        },
+        headers=_admin_headers(),
+    )
+    assert replay.status_code == 201
+    assert replay.json()["initial_response"] == {"vendor": "Original"}


### PR DESCRIPTION
## Summary

- **S1 (SDK):** drop the Phase-3 placeholder warning, forward Flow A's `prior_extraction` and Flow B's `flow_b_output` to managed as `initial_response`.
- **O1 (server):** new optional `initial_response` field on `CreateTaskRequest`, persisted as a JSON column on `Task`, surfaced in `TaskResponse`. Additive alembic migration. 18 new tests.

The dashboard pre-fill work (O4) ships in PR C — this PR is the backend wire shape only. Once this lands, managed's M1 work can plug in immediately.

## Wire contract

**SDK → managed:** `initial_response: dict | None` in the POST body. Key is present when set; **absent** (not explicit-null) when no extraction. Managed treats "absent" as "no prior extraction"; explicit-null could read as "the customer ran extraction and got null," which means something different for pre-fill logic.

**Managed → OSS:** matches verbatim. OSS doesn't re-validate against `response_schema` — managed validates before forwarding, OSS just persists JSON.

**OSS → dashboard:** `TaskResponse.initial_response` surfaced on `GET /api/tasks/{id}`. Stable optional (null vs object), not missing-key, so the dashboard branches cleanly.

## Flow A vs Flow B serialization

Flow A's `prior_extraction` is a Pydantic model and goes through `model_dump(mode=\"json\")` so any nested `datetime` / `UUID` / `Enum` value becomes a JSON-safe primitive before hitting the wire. Flow B's `flow_b_output` is already a dict from `run_extraction()`; ships verbatim.

\"Neither set\" → `initial_response = None` → key omitted from the wire body.

## Test plan

- [x] `python -m pytest packages/python/tests/awaitverify/ packages/python/tests/tasks/` — **41 passed** (incl. 5 SDK + 5 server + 8 wire/edge-case)
- [x] `python -m pytest packages/python/tests/server/ tests/awaitverify/ tests/tasks/ tests/cli/ tests/users/ tests/core/ tests/utils/` — **334 passed** (no regressions in unit suite)
- [x] `ruff check && ruff format --check` on changed files — clean
- [x] Manual: alembic upgrade on a fresh SQLite DB applies the new migration; `Task` model imports + new column visible in `metadata`
- [ ] **Reviewer:** wait for managed's M1 (forwarding `initial_response` from managed POST body to OSS POST `/api/tasks`), then end-to-end smoke against the reviewer via the deploy workflow

## One pre-existing flake (NOT this PR)

`tests/auth/test_auth_routes.py::test_inactive_user_cannot_login` fails when run in the broader cross-module suite due to a deprecated `asyncio.get_event_loop()` call on line 182 (Python 3.12 promotes the DeprecationWarning to a RuntimeError in some asyncio policy states). Same 1-failure shape on current main without these changes (414/415 here, 404/405 on main). One-line fix in a follow-up: replace with `asyncio.run(_seed_and_deactivate())`. Not bundling here per the maintainer's \"one PR per concern\" pattern.

## What's NOT in this PR

- **Dashboard pre-fill (O4)** — uses `initial_response` to mount form values. Lands in PR C alongside the nested-form rendering (object_group / repeatable_group).
- **Managed-side M1/M2** — your lane, will land in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)