### PR TITLE
feat(dashboard): group multi-image forms into a single carousel

### DIFF
--- a/packages/dashboard/components/form-renderer/image-carousel.tsx
+++ b/packages/dashboard/components/form-renderer/image-carousel.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+/**
+ * ImageCarousel — single-image-at-a-time viewer with prev/next, a
+ * "k / N" counter, keyboard arrow navigation, and a fit/actual zoom
+ * toggle. Rendered by the FormRenderer when a form has 2+ top-level
+ * image fields (typical AwaitVerify review surface: N document
+ * fragments).
+ *
+ * Reviewers work on laptops — we don't optimize for mobile, but the
+ * `<img>` container is overflow-auto in actual-size mode so native
+ * touchpad / pinch-zoom gestures work on the natural-size view
+ * without us reimplementing them.
+ *
+ * Keyboard:
+ *   ← / →   navigate. Suppressed when an INPUT / TEXTAREA /
+ *           contentEditable element is focused, so typing into the
+ *           reviewer's response form doesn't shuffle pages.
+ *   Esc     reset zoom to fit.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Eyebrow } from "@/components/eyebrow";
+import type { ImageField } from "@/lib/form-types";
+
+type Zoom = "fit" | "actual";
+
+export function ImageCarousel({ images }: { images: ImageField[] }) {
+	const [index, setIndex] = useState(0);
+	const [zoom, setZoom] = useState<Zoom>("fit");
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	const count = images.length;
+	const current = images[index];
+
+	const goPrev = useCallback(
+		() => setIndex((i) => (i > 0 ? i - 1 : i)),
+		[],
+	);
+	const goNext = useCallback(
+		() => setIndex((i) => (i < count - 1 ? i + 1 : i)),
+		[count],
+	);
+
+	// Keyboard navigation. Global listener, but skip when a text input
+	// has focus — the reviewer typing into the form's response fields
+	// should not shuffle pages. Reset zoom on Esc.
+	useEffect(() => {
+		function onKey(e: KeyboardEvent) {
+			const target = e.target as HTMLElement | null;
+			if (
+				target &&
+				(target.tagName === "INPUT" ||
+					target.tagName === "TEXTAREA" ||
+					target.isContentEditable)
+			) {
+				return;
+			}
+			if (e.key === "ArrowLeft") {
+				e.preventDefault();
+				goPrev();
+			} else if (e.key === "ArrowRight") {
+				e.preventDefault();
+				goNext();
+			} else if (e.key === "Escape") {
+				setZoom("fit");
+			}
+		}
+		window.addEventListener("keydown", onKey);
+		return () => window.removeEventListener("keydown", onKey);
+	}, [goPrev, goNext]);
+
+	// Reset zoom when the slide changes — operators expect a fresh
+	// view per page; carrying "actual" across slides leaves the next
+	// image scrolled to a meaningless position.
+	useEffect(() => {
+		setZoom("fit");
+	}, []);
+
+	return (
+		<div
+			ref={containerRef}
+			className="space-y-2"
+			data-testid="image-carousel"
+		>
+			{current.label && (
+				<Eyebrow weight="semibold" className="block text-white/50">
+					{current.label}
+				</Eyebrow>
+			)}
+
+			<div
+				className={
+					zoom === "fit"
+						? "rounded-md border border-white/10 bg-black/20 flex items-center justify-center min-h-[320px] max-h-[640px] overflow-hidden"
+						: "rounded-md border border-white/10 bg-black/20 max-h-[640px] overflow-auto"
+				}
+			>
+				{/* eslint-disable-next-line @next/next/no-img-element */}
+				<img
+					key={current.url}
+					src={current.url}
+					alt={current.alt ?? current.label ?? `Image ${index + 1} of ${count}`}
+					className={
+						zoom === "fit"
+							? "max-w-full max-h-[640px] object-contain"
+							: "block"
+					}
+				/>
+			</div>
+
+			<div className="flex items-center justify-between gap-2 text-sm">
+				<div className="flex items-center gap-1">
+					<button
+						type="button"
+						onClick={goPrev}
+						disabled={index === 0}
+						className="px-3 py-1 rounded-md border border-white/10 text-white/70 hover:text-white hover:border-white/30 disabled:opacity-30 disabled:cursor-not-allowed"
+						aria-label="Previous image"
+					>
+						◀
+					</button>
+					<button
+						type="button"
+						onClick={goNext}
+						disabled={index === count - 1}
+						className="px-3 py-1 rounded-md border border-white/10 text-white/70 hover:text-white hover:border-white/30 disabled:opacity-30 disabled:cursor-not-allowed"
+						aria-label="Next image"
+					>
+						▶
+					</button>
+					<span
+						className="ml-2 tabular-nums text-white/50"
+						aria-live="polite"
+					>
+						{index + 1} / {count}
+					</span>
+				</div>
+
+				<button
+					type="button"
+					onClick={() =>
+						setZoom((z) => (z === "fit" ? "actual" : "fit"))
+					}
+					className="px-3 py-1 rounded-md border border-white/10 text-white/70 hover:text-white hover:border-white/30"
+					aria-label={
+						zoom === "fit"
+							? "Switch to actual size"
+							: "Switch to fit"
+					}
+				>
+					{zoom === "fit" ? "Actual size" : "Fit"}
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/packages/dashboard/components/form-renderer/image-grouping.test.ts
+++ b/packages/dashboard/components/form-renderer/image-grouping.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for `groupImageFields` — the pure helper that decides when
+ * to collapse multiple image fields into a single carousel slot.
+ *
+ * The helper drives FormRenderer's rendering plan. Buggy grouping
+ * either (a) hides image fields the reviewer needs to see (skipped
+ * carousel emission) or (b) renders a noisy single-image carousel
+ * when an inline image would be cleaner. Both regressions are
+ * reviewer-visible, so the rules are pinned here.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { FormDefinition, ImageField } from "@/lib/form-types";
+
+import { groupImageFields } from "./image-grouping";
+
+function imageField(name: string, url: string): ImageField {
+	return {
+		kind: "image",
+		name,
+		label: null,
+		hint: null,
+		required: false,
+		url,
+		alt: null,
+		width: null,
+		height: null,
+	};
+}
+
+function shortText(name: string): FormDefinition["fields"][number] {
+	return {
+		kind: "short_text",
+		name,
+		label: name,
+		required: false,
+		hint: null,
+		placeholder: null,
+		max_length: null,
+		min_length: null,
+		pattern: null,
+		currency_code: null,
+		subtype: "plain",
+	} as unknown as FormDefinition["fields"][number];
+}
+
+describe("groupImageFields", () => {
+	it("returns fields as-is when there are no image fields", () => {
+		// Pure-form review — no document fragments at all (e.g. a
+		// custom HITL task that isn't AwaitVerify). Must not wrap
+		// anything in a carousel slot.
+		const slots = groupImageFields([
+			shortText("vendor"),
+			shortText("amount"),
+		]);
+		expect(slots).toEqual([
+			{ kind: "field", field: shortText("vendor") },
+			{ kind: "field", field: shortText("amount") },
+		]);
+	});
+
+	it("does NOT emit a carousel when there is exactly one image", () => {
+		// The carousel chrome (prev/next buttons, "1 / 1" counter)
+		// would be pure noise for a single-image form. Fall back to
+		// the inline ImageDisplayRenderer.
+		const fields = [imageField("doc_0", "http://x/0.png"), shortText("ok")];
+		const slots = groupImageFields(fields);
+
+		expect(slots).toHaveLength(2);
+		expect(slots[0]).toEqual({ kind: "field", field: fields[0] });
+		expect(slots[1]).toEqual({ kind: "field", field: fields[1] });
+	});
+
+	it("emits a single carousel slot when there are 2+ images", () => {
+		// The canonical AwaitVerify case: multi-page document arrives
+		// as N image fields. The reviewer should see one image at a
+		// time with controls, not a scrolling stack.
+		const img1 = imageField("doc_0", "http://x/0.png");
+		const img2 = imageField("doc_1", "http://x/1.png");
+		const fields = [img1, img2, shortText("vendor")];
+
+		const slots = groupImageFields(fields);
+		expect(slots).toHaveLength(2);
+		expect(slots[0]).toEqual({
+			kind: "carousel",
+			images: [img1, img2],
+		});
+		expect(slots[1]).toEqual({ kind: "field", field: shortText("vendor") });
+	});
+
+	it("places the carousel at the FIRST image position", () => {
+		// Field ordering matters — managed sometimes interleaves a
+		// short_text introduction before the images. The carousel
+		// should appear where the first image was, not at the top
+		// of the form.
+		const intro = shortText("intro");
+		const img1 = imageField("doc_0", "http://x/0.png");
+		const img2 = imageField("doc_1", "http://x/1.png");
+		const trailing = shortText("vendor");
+		const fields = [intro, img1, img2, trailing];
+
+		const slots = groupImageFields(fields);
+		expect(slots).toHaveLength(3);
+		expect(slots[0]).toEqual({ kind: "field", field: intro });
+		expect(slots[1]).toEqual({
+			kind: "carousel",
+			images: [img1, img2],
+		});
+		expect(slots[2]).toEqual({ kind: "field", field: trailing });
+	});
+
+	it("collects ALL image fields into the carousel, even if non-consecutive", () => {
+		// If managed ever interleaves a text field BETWEEN two image
+		// fields, the reviewer still expects all images grouped — a
+		// single carousel for the whole document, not two separate
+		// ones with an input wedged in.
+		const img1 = imageField("doc_0", "http://x/0.png");
+		const mid = shortText("note");
+		const img2 = imageField("doc_1", "http://x/1.png");
+		const fields = [img1, mid, img2];
+
+		const slots = groupImageFields(fields);
+		expect(slots).toHaveLength(2);
+		expect(slots[0]).toEqual({
+			kind: "carousel",
+			images: [img1, img2],
+		});
+		// The middle text field keeps its relative position AFTER
+		// the carousel — it was originally between the two images,
+		// but the carousel absorbs both image positions and the
+		// non-image field naturally lands after.
+		expect(slots[1]).toEqual({ kind: "field", field: mid });
+	});
+
+	it("preserves image order inside the carousel", () => {
+		// Reviewer mental model: page 1, page 2, page 3 …
+		// Shuffling the order would force them to verify pages
+		// against a random sequence. The helper must walk fields
+		// linearly.
+		const imgs = [
+			imageField("page_0", "http://x/0.png"),
+			imageField("page_1", "http://x/1.png"),
+			imageField("page_2", "http://x/2.png"),
+			imageField("page_3", "http://x/3.png"),
+			imageField("page_4", "http://x/4.png"),
+		];
+		const slots = groupImageFields(imgs);
+
+		expect(slots).toHaveLength(1);
+		const slot = slots[0];
+		expect(slot.kind).toBe("carousel");
+		if (slot.kind === "carousel") {
+			expect(slot.images.map((i) => i.name)).toEqual([
+				"page_0",
+				"page_1",
+				"page_2",
+				"page_3",
+				"page_4",
+			]);
+		}
+	});
+
+	it("returns an empty array for an empty form", () => {
+		// Degenerate but real: a brand-new form with no fields yet.
+		// Helper must not throw on the empty input.
+		expect(groupImageFields([])).toEqual([]);
+	});
+});

--- a/packages/dashboard/components/form-renderer/image-grouping.ts
+++ b/packages/dashboard/components/form-renderer/image-grouping.ts
@@ -1,0 +1,74 @@
+/**
+ * Image grouping helper for the form renderer.
+ *
+ * When a form has 2+ top-level image fields (e.g. AwaitVerify document
+ * fragments), we render them as a single carousel rather than a long
+ * vertical stack the reviewer has to scroll through. With a single
+ * image the form stays the way it is.
+ *
+ * `groupImageFields` walks the top-level field list ONCE and returns
+ * a plan the renderer can execute without re-scanning. The plan
+ * preserves field ordering: the carousel takes the position of the
+ * first image field, and non-image fields keep their original index.
+ *
+ * Scope: only top-level image fields. Image fields nested inside a
+ * `section_collapse` / `subform` / `repeatable_group` are left to
+ * render individually — those are rare (review forms put document
+ * fragments at the top level, not inside groupings) and the carousel
+ * UX assumes the images are the primary visual content of the form.
+ */
+
+import type { FormField, ImageField } from "@/lib/form-types";
+
+type CarouselSlot = {
+	kind: "carousel";
+	images: ImageField[];
+};
+
+type FieldSlot = {
+	kind: "field";
+	field: FormField;
+};
+
+export type RenderSlot = CarouselSlot | FieldSlot;
+
+/**
+ * Walk the field list and return the slots the renderer should emit
+ * in order. With 0 or 1 image fields the result is just the input
+ * fields wrapped as FieldSlot — no carousel slot is produced.
+ *
+ * With 2+ image fields, the carousel slot replaces the position of
+ * the FIRST image and the remaining image fields are dropped from
+ * the output (they live inside the carousel slot). Non-image fields
+ * keep their original order.
+ */
+export function groupImageFields(fields: FormField[]): RenderSlot[] {
+	const imageCount = fields.filter((f) => f.kind === "image").length;
+	if (imageCount <= 1) {
+		// 0 images: nothing to group.
+		// 1 image: also no grouping — single-image forms keep their
+		// inline image renderer. The carousel chrome (prev/next,
+		// counter) would be noise here.
+		return fields.map((field) => ({ kind: "field", field }));
+	}
+
+	const images = fields.filter(
+		(f): f is ImageField => f.kind === "image",
+	);
+
+	const slots: RenderSlot[] = [];
+	let carouselEmitted = false;
+	for (const field of fields) {
+		if (field.kind === "image") {
+			// The first image slot is replaced by the carousel; the rest
+			// are absorbed into it (no second emission).
+			if (!carouselEmitted) {
+				slots.push({ kind: "carousel", images });
+				carouselEmitted = true;
+			}
+			continue;
+		}
+		slots.push({ kind: "field", field });
+	}
+	return slots;
+}

--- a/packages/dashboard/components/form-renderer/index.tsx
+++ b/packages/dashboard/components/form-renderer/index.tsx
@@ -49,6 +49,8 @@ import {
 	SectionRenderer,
 } from "./layout";
 import { SubformRenderer, TableRenderer } from "./complex";
+import { ImageCarousel } from "./image-carousel";
+import { groupImageFields } from "./image-grouping";
 import type { FormValue } from "./types";
 
 export { buildResponseValue } from "./build-response-value";
@@ -62,17 +64,33 @@ type Props = {
 };
 
 export function FormRenderer({ form, value, onChange, disabled }: Props) {
+	// Group top-level image fields into a single carousel when there
+	// are 2+ — reviewers don't have to scroll a long vertical stack
+	// of document fragments. Single-image forms keep their inline
+	// renderer (no carousel chrome).
+	const slots = groupImageFields(form.fields);
 	return (
 		<div className="space-y-4">
-			{form.fields.map((field, i) => (
-				<FieldDispatch
-					key={`${field.name || field.kind}-${i}`}
-					field={field}
-					value={value}
-					onChange={onChange}
-					disabled={disabled}
-				/>
-			))}
+			{slots.map((slot, i) => {
+				if (slot.kind === "carousel") {
+					return (
+						<ImageCarousel
+							key={`carousel-${i}`}
+							images={slot.images}
+						/>
+					);
+				}
+				const field = slot.field;
+				return (
+					<FieldDispatch
+						key={`${field.name || field.kind}-${i}`}
+						field={field}
+						value={value}
+						onChange={onChange}
+						disabled={disabled}
+					/>
+				);
+			})}
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

- New `ImageCarousel` component + `groupImageFields` helper that collapses 2+ top-level image fields into a single carousel with prev/next, "k / N" counter, keyboard arrows, and a fit/actual zoom toggle.
- `FormRenderer` calls `groupImageFields` once and emits either a carousel slot or the existing `FieldDispatch` per slot.
- Single-image forms render unchanged (no carousel chrome).

## Why

The AwaitVerify review surface ships N document fragments as N image fields. Pre-PR, the reviewer scrolled through a long vertical stack — slow and easy to lose track of which page they're on. Post-PR, they see one page at a time with quick keyboard navigation and a zoom toggle for fine-grained verification.

## Behavior summary

| # images | Result |
|---|---|
| 0 | No carousel. Fields render as-is. |
| 1 | Inline `<img>` via the existing `ImageDisplayRenderer`. The carousel chrome would be pure noise for one page. |
| 2+ | Single carousel at the position of the FIRST image. Non-image fields between images keep their relative order, landing AFTER the carousel slot. |

## Keyboard / UX details

- ← / → cycle pages. Listener is global but suppresses when an `INPUT` / `TEXTAREA` / `contentEditable` element is focused, so typing into the reviewer's response form never shuffles pages.
- Esc resets zoom to fit (no modal; "Esc closes any zoom modal" from the brief is interpreted as zoom-reset since there's no separate modal layer).
- Counter has `aria-live="polite"` so screen readers announce page transitions.
- Boundary disable (◀ on page 1, ▶ on last page) — no wraparound, since the document is ordered and wrapping would confuse "did I get them all?".
- Zoom resets to fit when the slide changes — carrying "actual size" across slides leaves the next image scrolled to a meaningless position.
- Touch / trackpad zoom on actual-size mode works via native overflow-auto. No custom pinch handling added per the brief's "don't optimize for mobile".

## Scope

- **Top-level image fields only.** Images nested inside `section_collapse` / `subform` / `repeatable_group` still render individually. Review forms put fragments at the top level by convention; nested images are rare and the carousel UX assumes the images are the primary visual content.
- **No new dependencies.** The dashboard doesn't have React Testing Library installed; the testable logic is extracted into the pure `groupImageFields` helper so the slot-plan rules are pinned via vitest unit tests. The component itself is small glue and gets manual verification.

## Test plan

- [x] `npm test` in `packages/dashboard` — **15 passed** (8 existing + 7 new in `image-grouping.test.ts` covering no-images, 1-image, 2+ images, position, interleaved fields, image ordering, empty form)
- [x] `npx tsc --noEmit` — clean
- [ ] **Reviewer (manual):**
  - [ ] Single-image task: inline image renders, no chrome
  - [ ] Multi-image task: carousel at first image's position
  - [ ] Arrow keys cycle, suppressed in input fields
  - [ ] Fit ↔ Actual toggle scrolls a large image
  - [ ] Esc resets zoom
  - [ ] Counter increments / decrements correctly
  - [ ] Boundary buttons disable on page 1 and last page

## Independent of PR A and PR C

Pure dashboard layout change. No wire shape or server changes. Lands cleanly alongside PR #165 (initial_response backend) and whatever PR C (form rendering overhaul) ends up touching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)