### PR TITLE
feat(dashboard): nested-form rendering + pre-fill + UX polish (O3+O4+O5)

### DIFF
--- a/packages/dashboard/app/(dashboard)/task/page.tsx
+++ b/packages/dashboard/app/(dashboard)/task/page.tsx
@@ -101,7 +101,14 @@ function TaskDetailPageInner() {
 			setMe(meData);
 
 			if (taskData.form_definition) {
-				setFormData(initialValueFor(taskData.form_definition));
+				// Pass `initial_response` so AwaitVerify Flow A / Flow B
+				// tasks mount the form with the customer's pre-computed
+				// extraction populated. The reviewer verifies/corrects
+				// rather than re-types. Non-AwaitVerify tasks have
+				// `initial_response: null` and the form starts blank.
+				setFormData(
+					initialValueFor(taskData.form_definition, taskData.initial_response),
+				);
 			}
 		} catch (err) {
 			setError(err instanceof Error ? err.message : "Failed to load task");

--- a/packages/dashboard/components/form-renderer/build-response-value.test.ts
+++ b/packages/dashboard/components/form-renderer/build-response-value.test.ts
@@ -218,4 +218,164 @@ describe("buildResponseValue", () => {
 			amounts: [{ currency: "USD" }, { currency: "EUR", memo: "" }],
 		});
 	});
+
+	// ── Nested Pydantic groups (PR C, O3) ────────────────────────────
+
+	it("assembles object_group children into a nested dict", () => {
+		const group: FormDefinition["fields"][number] = {
+			kind: "object_group",
+			name: "address",
+			label: "Address",
+			required: false,
+			hint: null,
+			fields: [shortText("city", false), shortText("zip", true)],
+		} as unknown as FormDefinition["fields"][number];
+		const f = form([group]);
+
+		const value: FormValue = {
+			address: { city: "Brooklyn", zip: "11201" },
+		};
+		expect(buildResponseValue(f, value)).toEqual({
+			address: { city: "Brooklyn", zip: "11201" },
+		});
+	});
+
+	it("object_group drops blank optional child but keeps required null", () => {
+		// Reviewer left an optional city blank and didn't fill required zip.
+		// Optional city is dropped (server applies its Pydantic default);
+		// required zip stays as null so Pydantic surfaces a clean
+		// "missing required field" error.
+		const group: FormDefinition["fields"][number] = {
+			kind: "object_group",
+			name: "address",
+			label: "Address",
+			required: false,
+			hint: null,
+			fields: [shortText("city", false), shortText("zip", true)],
+		} as unknown as FormDefinition["fields"][number];
+		const f = form([group]);
+
+		const value: FormValue = {
+			address: { city: null, zip: null },
+		};
+		expect(buildResponseValue(f, value)).toEqual({
+			address: { zip: null },
+		});
+	});
+
+	it("non-object value for object_group is treated as empty", () => {
+		// Defensive: if the renderer ever puts a non-object at the
+		// group's slot (e.g. an array via wire drift), we don't
+		// crash — we assemble from an empty sub-scope. The required
+		// city ends up with undefined in the output, which
+		// JSON.stringify drops, so the server sees `{address: {}}`
+		// and surfaces a clean "city missing" validation error.
+		const group: FormDefinition["fields"][number] = {
+			kind: "object_group",
+			name: "address",
+			label: "Address",
+			required: false,
+			hint: null,
+			fields: [shortText("city", true)],
+		} as unknown as FormDefinition["fields"][number];
+		const f = form([group]);
+
+		const value: FormValue = { address: ["unexpected"] };
+		const result = buildResponseValue(f, value);
+		// Wire shape — what the server actually receives after JSON.stringify.
+		expect(JSON.parse(JSON.stringify(result))).toEqual({
+			address: {},
+		});
+	});
+
+	it("assembles repeatable_group rows as a list of cleaned dicts", () => {
+		const group: FormDefinition["fields"][number] = {
+			kind: "repeatable_group",
+			name: "line_items",
+			label: "Line items",
+			required: false,
+			hint: null,
+			item_fields: [
+				shortText("sku", true),
+				shortText("memo", false),
+			],
+			min_items: null,
+			max_items: null,
+		} as unknown as FormDefinition["fields"][number];
+		const f = form([group]);
+
+		const value: FormValue = {
+			line_items: [
+				{ sku: "A-1", memo: null }, // optional memo dropped
+				{ sku: "B-9", memo: "fast" }, // memo kept
+				{ sku: null, memo: null }, // required sku stays null
+			],
+		};
+		expect(buildResponseValue(f, value)).toEqual({
+			line_items: [
+				{ sku: "A-1" },
+				{ sku: "B-9", memo: "fast" },
+				{ sku: null },
+			],
+		});
+	});
+
+	it("empty repeatable_group serializes as an empty array", () => {
+		// Reviewer added no rows. Distinct from "the column doesn't
+		// exist" — sending `[]` lets the Pydantic schema's `default=[]`
+		// validate cleanly when the field is non-nullable.
+		const group: FormDefinition["fields"][number] = {
+			kind: "repeatable_group",
+			name: "rows",
+			label: "Rows",
+			required: false,
+			hint: null,
+			item_fields: [shortText("name", true)],
+			min_items: null,
+			max_items: null,
+		} as unknown as FormDefinition["fields"][number];
+		const f = form([group]);
+
+		expect(buildResponseValue(f, { rows: [] })).toEqual({ rows: [] });
+	});
+
+	it("nested object_group inside repeatable_group row recurses correctly", () => {
+		// Realistic shape: each line item carries a sub-address.
+		// The walker descends both levels in one pass.
+		const group: FormDefinition["fields"][number] = {
+			kind: "repeatable_group",
+			name: "shipments",
+			label: "Shipments",
+			required: false,
+			hint: null,
+			item_fields: [
+				shortText("carrier", true),
+				{
+					kind: "object_group",
+					name: "destination",
+					label: "Destination",
+					required: false,
+					hint: null,
+					fields: [shortText("city", true), shortText("zip", false)],
+				} as unknown as FormDefinition["fields"][number],
+			],
+			min_items: null,
+			max_items: null,
+		} as unknown as FormDefinition["fields"][number];
+		const f = form([group]);
+
+		const value: FormValue = {
+			shipments: [
+				{
+					carrier: "USPS",
+					destination: { city: "Brooklyn", zip: null }, // optional zip drops
+				},
+			],
+		};
+		expect(buildResponseValue(f, value)).toEqual({
+			shipments: [
+				{ carrier: "USPS", destination: { city: "Brooklyn" } },
+			],
+		});
+	});
 });

--- a/packages/dashboard/components/form-renderer/build-response-value.ts
+++ b/packages/dashboard/components/form-renderer/build-response-value.ts
@@ -93,6 +93,31 @@ function cleanLevel(fields: FormField[], value: FormValue): FormValue {
 			continue;
 		}
 
+		// object_group: recurse into the nested sub-FormValue. The
+		// group's `name` carries an object value; children's names live
+		// inside that object. Drop-blank-optionals applies per child.
+		if (f.kind === "object_group") {
+			const sub =
+				v && typeof v === "object" && !Array.isArray(v)
+					? (v as FormValue)
+					: {};
+			out[f.name] = cleanLevel(f.fields, sub);
+			continue;
+		}
+
+		// repeatable_group: array of nested FormValues; recurse per row
+		// using the row shape (item_fields). Drop-blank-optionals
+		// applies per row, per item field — important so an unfilled
+		// optional column on row 3 doesn't fail server-side validation
+		// just because the column was added by + Add row.
+		if (f.kind === "repeatable_group") {
+			const rows = Array.isArray(v) ? v : [];
+			out[f.name] = rows.map((row) =>
+				cleanLevel(f.item_fields, (row ?? {}) as FormValue),
+			);
+			continue;
+		}
+
 		out[f.name] = v;
 	}
 	return out;

--- a/packages/dashboard/components/form-renderer/compact-context.ts
+++ b/packages/dashboard/components/form-renderer/compact-context.ts
@@ -1,0 +1,19 @@
+"use client";
+
+/**
+ * Compact context — when true, the FieldWrapper suppresses the per-field
+ * label and the required-marker asterisk. Used by the RepeatableGroup
+ * renderer to render each row's cells without duplicating the column
+ * headers (which already carry the label).
+ *
+ * Kept as a context (not a prop) so we don't have to thread a `compact`
+ * boolean through every primitive renderer's props. The cost is one
+ * React Context read per FieldWrapper render — negligible.
+ *
+ * Hints stay visible even in compact mode: they often carry the human
+ * pattern hint ("Numbers only") that the column header can't fit.
+ */
+
+import { createContext } from "react";
+
+export const CompactFieldContext = createContext<boolean>(false);

--- a/packages/dashboard/components/form-renderer/complex.tsx
+++ b/packages/dashboard/components/form-renderer/complex.tsx
@@ -1,10 +1,14 @@
 import type { ReactNode } from "react";
 import { Eyebrow } from "@/components/eyebrow";
 import type {
+	FormField,
+	ObjectGroupField,
+	RepeatableGroupField,
 	SubformField,
 	TableColumn,
 	TableField,
 } from "@/lib/form-types";
+import { CompactFieldContext } from "./compact-context";
 import { FieldWrapper } from "./field-wrapper";
 
 const cellClass =
@@ -290,4 +294,183 @@ export function SubformRenderer({
 			</div>
 		</FieldWrapper>
 	);
+}
+
+// ─── ObjectGroup (nested Pydantic object) ───────────────────────────
+//
+// Renders as an indented section with the group's label as a small
+// uppercase header. Children dispatch normally at this level — they
+// read/write a nested sub-FormValue keyed by their own `name`. The
+// FieldDispatch case in index.tsx owns the value/onChange scoping.
+
+export function ObjectGroupRenderer({
+	field,
+	children,
+}: {
+	field: ObjectGroupField;
+	children: ReactNode;
+}) {
+	const hasLabel = field.label && field.label.length > 0;
+	return (
+		<div className="space-y-2">
+			{hasLabel && (
+				<div className="pt-2 border-t border-white/10">
+					<Eyebrow weight="semibold" className="block text-white/50">
+						{field.label}
+						{field.required && (
+							<span className="text-red-400 ml-0.5" aria-hidden>
+								*
+							</span>
+						)}
+					</Eyebrow>
+					{field.hint && (
+						<p className="text-white/40 text-xs mt-0.5">{field.hint}</p>
+					)}
+				</div>
+			)}
+			<div className="pl-3 border-l-2 border-white/10 space-y-3">
+				{children}
+			</div>
+		</div>
+	);
+}
+
+// ─── RepeatableGroup (list[BaseModel] → spreadsheet) ────────────────
+//
+// Renders as an editable table. Columns come from item_fields[].label;
+// each row is a dict matching the item_fields shape. Cells dispatch
+// the actual item_field renderer (so a date column is a date picker,
+// a switch column is a switch, etc.), wrapped in CompactFieldContext
+// so the per-field label doesn't duplicate the column header.
+//
+// Reviewer can edit any cell, add new rows via "+ Add row", or remove
+// rows. Min/max constraints from the schema gate the buttons.
+
+type RepeatableRow = Record<string, unknown>;
+
+export function RepeatableGroupRenderer({
+	field,
+	rows,
+	onRowsChange,
+	disabled,
+	renderCell,
+}: {
+	field: RepeatableGroupField;
+	rows: RepeatableRow[];
+	onRowsChange: (next: RepeatableRow[]) => void;
+	disabled?: boolean;
+	renderCell: (
+		row: RepeatableRow,
+		setRow: (next: RepeatableRow) => void,
+		itemField: FormField,
+	) => ReactNode;
+}) {
+	const setRow = (idx: number) => (next: RepeatableRow) => {
+		onRowsChange(rows.map((r, i) => (i === idx ? next : r)));
+	};
+	const addRow = () => onRowsChange([...rows, {}]);
+	const removeRow = (idx: number) =>
+		onRowsChange(rows.filter((_, i) => i !== idx));
+
+	// Column-bearing item fields (the ones the reviewer actually fills).
+	// Layout-only fields (section, divider, image, etc.) don't have a
+	// row-cell shape and would render as a confusing empty cell — filter
+	// them out of the column header AND the row cell list.
+	const columns = field.item_fields.filter((f) => !LAYOUT_AND_DISPLAY_KINDS.has(f.kind));
+
+	const canAdd =
+		!disabled && (field.max_items === null || rows.length < (field.max_items ?? Infinity));
+	const canRemove =
+		!disabled && (field.min_items === null || rows.length > (field.min_items ?? 0));
+
+	return (
+		<FieldWrapper field={field}>
+			<CompactFieldContext.Provider value={true}>
+				{rows.length === 0 ? (
+					<div className="border border-dashed border-white/15 rounded-md px-4 py-6 text-sm text-white/40 text-center">
+						No rows yet — click + Add row to begin.
+					</div>
+				) : (
+					<div className="border border-white/10 rounded-md overflow-x-auto">
+						<table className="w-full">
+							<thead className="bg-white/5 text-xs text-white/60">
+								<tr>
+									{columns.map((col) => (
+										<th
+											key={col.name}
+											className="text-left px-2 py-1.5 whitespace-nowrap"
+										>
+											{col.label || humanizeName(col.name)}
+											{col.required && (
+												<span className="text-red-400 ml-0.5">*</span>
+											)}
+										</th>
+									))}
+									{canRemove && <th className="w-8" aria-label="Remove" />}
+								</tr>
+							</thead>
+							<tbody>
+								{rows.map((row, i) => (
+									<tr key={i} className="border-t border-white/5 align-top">
+										{columns.map((col) => (
+											<td key={col.name} className="p-1 min-w-[8rem]">
+												{renderCell(row, setRow(i), col)}
+											</td>
+										))}
+										{canRemove && (
+											<td className="p-1 text-center align-middle">
+												<button
+													type="button"
+													onClick={() => removeRow(i)}
+													disabled={disabled}
+													aria-label="Remove row"
+													className="text-red-400/70 hover:text-red-400 w-6 h-6"
+												>
+													×
+												</button>
+											</td>
+										)}
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				)}
+				{canAdd && (
+					<button
+						type="button"
+						onClick={addRow}
+						className="mt-2 text-sm text-brand hover:underline"
+					>
+						+ Add row
+					</button>
+				)}
+			</CompactFieldContext.Provider>
+		</FieldWrapper>
+	);
+}
+
+// Layout/display kinds that would render as an empty cell inside a
+// repeatable_group row. Mirrors the same set in `index.tsx`'s walk()
+// — duplicated rather than imported because each module owns the
+// concept of "which kinds carry a value."
+const LAYOUT_AND_DISPLAY_KINDS = new Set([
+	"display_text",
+	"image",
+	"video",
+	"pdf_viewer",
+	"html",
+	"section",
+	"divider",
+]);
+
+function humanizeName(name: string): string {
+	// Fallback when a column has no label — turn snake_case_field
+	// into "Snake Case Field" so the reviewer doesn't see a raw
+	// identifier. Managed should always supply labels but defending
+	// against drift here costs nothing.
+	if (!name) return "";
+	return name
+		.replace(/_/g, " ")
+		.replace(/\b\w/g, (c) => c.toUpperCase());
 }

--- a/packages/dashboard/components/form-renderer/field-wrapper.tsx
+++ b/packages/dashboard/components/form-renderer/field-wrapper.tsx
@@ -1,6 +1,7 @@
-import type { ReactNode } from "react";
+import { useContext, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import type { FormField } from "@/lib/form-types";
+import { CompactFieldContext } from "./compact-context";
 
 type Props = {
 	field: FormField;
@@ -12,9 +13,15 @@ type Props = {
  * Shared wrapper: renders label (with required marker), the field content,
  * and an optional hint line. Layout-only primitives render without a wrapper
  * so they shouldn't use this.
+ *
+ * Compact mode (via CompactFieldContext) suppresses the label and required
+ * marker — used by the RepeatableGroup renderer where the column header
+ * already carries that information. Hints stay visible: they often carry
+ * the human pattern hint ("Numbers only") that the header can't fit.
  */
 export function FieldWrapper({ field, children, className }: Props) {
-	const hasLabel = field.label && field.label.length > 0;
+	const compact = useContext(CompactFieldContext);
+	const hasLabel = !compact && field.label && field.label.length > 0;
 	return (
 		<div className={cn("space-y-1.5", className)}>
 			{hasLabel && (

--- a/packages/dashboard/components/form-renderer/index.tsx
+++ b/packages/dashboard/components/form-renderer/index.tsx
@@ -48,12 +48,18 @@ import {
 	SectionCollapseRenderer,
 	SectionRenderer,
 } from "./layout";
-import { SubformRenderer, TableRenderer } from "./complex";
+import {
+	ObjectGroupRenderer,
+	RepeatableGroupRenderer,
+	SubformRenderer,
+	TableRenderer,
+} from "./complex";
 import { ImageCarousel } from "./image-carousel";
 import { groupImageFields } from "./image-grouping";
 import type { FormValue } from "./types";
 
 export { buildResponseValue } from "./build-response-value";
+export { initialValueFor } from "./initial-value";
 export type { FormValue } from "./types";
 
 type Props = {
@@ -337,85 +343,81 @@ function FieldDispatch({
 					)}
 				/>
 			);
-	}
-}
 
-// ─── Initial value helper ────────────────────────────────────────────
+		// ── Nested Pydantic groups ──────────────────────────
+		// object_group: read the nested sub-FormValue at value[field.name]
+		// and dispatch children with that as their scope. Children's
+		// `setField` wraps back to set value[field.name][child.name],
+		// preserving the rest of the sub-scope.
+		case "object_group": {
+			const groupValue = isPlainObject(value[field.name])
+				? (value[field.name] as FormValue)
+				: {};
+			const setGroup = (next: FormValue) =>
+				onChange({ ...value, [field.name]: next });
+			return (
+				<ObjectGroupRenderer field={field}>
+					{field.fields.map((child, j) => (
+						<FieldDispatch
+							key={`${child.name || child.kind}-${j}`}
+							field={child}
+							value={groupValue}
+							onChange={setGroup}
+							disabled={disabled}
+						/>
+					))}
+				</ObjectGroupRenderer>
+			);
+		}
 
-/**
- * Build an initial form value (empty dict) from a FormDefinition. Picks up
- * per-field defaults where the primitive declares one.
- */
-export function initialValueFor(form: FormDefinition): FormValue {
-	const out: FormValue = {};
-	walk(form.fields, out);
-	return out;
-}
-
-// Kinds that render UI but don't contribute a value to the response.
-// Skipping them here keeps display-only primitives (text blocks, media,
-// layout) out of the submitted response payload even when they have a
-// `name`. Without this, e.g. a display_text named "intro" shows up as
-// `{"intro": null}` in the human's response — misleading and pollutes
-// the audit trail.
-const NON_INPUT_KINDS = new Set([
-	"display_text",
-	"image",
-	"video",
-	"pdf_viewer",
-	"html",
-	"section",
-	"divider",
-]);
-
-function walk(fields: FormField[], out: FormValue): void {
-	for (const f of fields) {
-		if (!f.name) continue;
-		if (NON_INPUT_KINDS.has(f.kind)) continue;
-		switch (f.kind) {
-			case "switch":
-				out[f.name] = f.default ?? null;
-				break;
-			case "single_select":
-				out[f.name] = f.default ?? null;
-				break;
-			case "multi_select":
-				out[f.name] = f.default ?? [];
-				break;
-			case "picture_choice":
-				out[f.name] = f.default ?? [];
-				break;
-			case "slider":
-				out[f.name] = f.default ?? (f.min + f.max) / 2;
-				break;
-			case "star_rating":
-				out[f.name] = f.default ?? 0;
-				break;
-			case "opinion_scale":
-				out[f.name] = f.default ?? null;
-				break;
-			case "date":
-			case "datetime":
-			case "time":
-				out[f.name] = f.default ?? null;
-				break;
-			case "ranking":
-				out[f.name] = f.options.map((o) => o.value);
-				break;
-			case "table":
-				out[f.name] = [];
-				break;
-			case "subform":
-				out[f.name] = [];
-				break;
-			case "section_collapse":
-				walk(f.fields, out);
-				break;
-			default:
-				// Plain-value input kinds (short_text, long_text, rich_text,
-				// file_upload, signature, date_range) start blank.
-				out[f.name] = null;
+		// repeatable_group: read the array at value[field.name]. Each
+		// row is itself a FormValue (dict). Cells dispatch the actual
+		// item_field renderer with the row as the value scope.
+		case "repeatable_group": {
+			const rows: FormValue[] = Array.isArray(value[field.name])
+				? (value[field.name] as FormValue[])
+				: [];
+			return (
+				<RepeatableGroupRenderer
+					field={field}
+					rows={rows}
+					onRowsChange={(next) =>
+						onChange({ ...value, [field.name]: next })
+					}
+					disabled={disabled}
+					renderCell={(row, setRow, itemField) => (
+						<FieldDispatch
+							field={itemField}
+							value={row}
+							onChange={setRow}
+							disabled={disabled}
+						/>
+					)}
+				/>
+			);
 		}
 	}
+	// Unknown field kind — version skew between this dashboard and a
+	// newer managed-side schema walker, or a malformed form_definition
+	// payload. Show a friendly message instead of dumping JSON the
+	// reviewer can't action. Never reached in normal operation.
+	return (
+		<div className="border border-yellow-500/30 bg-yellow-500/5 rounded-md px-3 py-2 text-sm text-yellow-200/80">
+			This field isn&apos;t supported by the review form yet — please
+			contact support.
+		</div>
+	);
 }
+
+function isPlainObject(v: unknown): v is FormValue {
+	// "Plain" enough for our needs: non-null object that isn't an array.
+	// Doesn't try to defend against exotic prototypes — the form value
+	// is always either a literal {} from us or whatever JSON the server
+	// round-tripped, both of which qualify.
+	return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+// initialValueFor / walk live in ./initial-value.ts so the test file
+// can import them without going through this .tsx (which the vitest
+// JSX-preserve loader can't parse). Re-exported above for callers.
 

--- a/packages/dashboard/components/form-renderer/initial-value.test.ts
+++ b/packages/dashboard/components/form-renderer/initial-value.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Tests for `initialValueFor` — the helper that builds the form's
+ * starting state from a FormDefinition plus an optional pre-fill
+ * payload (AwaitVerify Flow A / Flow B).
+ *
+ * Three properties under test:
+ *   1. Without pre-fill, defaults match the pre-PR-C behavior.
+ *   2. Flat pre-fill values seed top-level fields verbatim.
+ *   3. Nested pre-fill descends into object_group / repeatable_group.
+ *
+ * The pre-fill contract: customer-supplied values win over per-field
+ * defaults; missing keys fall back to defaults. An empty array
+ * (`prefill.rows = []`) is still a valid value — it means "no rows"
+ * which a reviewer can add to.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { FormDefinition, FormField } from "@/lib/form-types";
+
+import { initialValueFor } from "./initial-value";
+
+function form(fields: FormField[]): FormDefinition {
+	return { version: 1, fields };
+}
+
+function shortText(name: string, required = false): FormField {
+	return {
+		kind: "short_text",
+		name,
+		label: name,
+		required,
+		hint: null,
+		placeholder: null,
+		max_length: null,
+		min_length: null,
+		pattern: null,
+		currency_code: null,
+		subtype: "plain",
+	} as unknown as FormField;
+}
+
+function switchField(name: string, defaultValue: boolean | null = null): FormField {
+	return {
+		kind: "switch",
+		name,
+		label: name,
+		required: false,
+		hint: null,
+		true_label: "Yes",
+		false_label: "No",
+		default: defaultValue,
+	} as unknown as FormField;
+}
+
+function objectGroup(name: string, children: FormField[]): FormField {
+	return {
+		kind: "object_group",
+		name,
+		label: name,
+		required: false,
+		hint: null,
+		fields: children,
+	} as unknown as FormField;
+}
+
+function repeatableGroup(name: string, itemFields: FormField[]): FormField {
+	return {
+		kind: "repeatable_group",
+		name,
+		label: name,
+		required: false,
+		hint: null,
+		item_fields: itemFields,
+		min_items: null,
+		max_items: null,
+	} as unknown as FormField;
+}
+
+describe("initialValueFor — no pre-fill", () => {
+	it("starts plain-input fields blank", () => {
+		const result = initialValueFor(
+			form([shortText("vendor"), shortText("notes")]),
+		);
+		expect(result).toEqual({ vendor: null, notes: null });
+	});
+
+	it("honors per-field defaults when pre-fill is omitted", () => {
+		const result = initialValueFor(form([switchField("approved", true)]));
+		expect(result).toEqual({ approved: true });
+	});
+
+	it("seeds object_group as a nested empty dict respecting child defaults", () => {
+		const result = initialValueFor(
+			form([
+				objectGroup("address", [
+					shortText("city"),
+					shortText("zip"),
+				]),
+			]),
+		);
+		expect(result).toEqual({ address: { city: null, zip: null } });
+	});
+
+	it("seeds repeatable_group as an empty array", () => {
+		const result = initialValueFor(
+			form([repeatableGroup("rows", [shortText("sku")])]),
+		);
+		expect(result).toEqual({ rows: [] });
+	});
+});
+
+describe("initialValueFor — pre-fill (AwaitVerify Flow A / Flow B)", () => {
+	it("uses pre-fill value over the per-field default for primitives", () => {
+		const result = initialValueFor(
+			form([shortText("vendor"), switchField("approved", false)]),
+			{ vendor: "Acme Corp", approved: true },
+		);
+		expect(result).toEqual({ vendor: "Acme Corp", approved: true });
+	});
+
+	it("falls back to default when a key is missing from pre-fill", () => {
+		// Reviewer expectation: partial pre-fills don't blank out the
+		// other fields. Customer extracted some columns, left others
+		// for human judgment.
+		const result = initialValueFor(
+			form([shortText("vendor"), shortText("notes")]),
+			{ vendor: "Acme Corp" }, // `notes` missing
+		);
+		expect(result).toEqual({ vendor: "Acme Corp", notes: null });
+	});
+
+	it("descends into object_group with a nested pre-fill object", () => {
+		const result = initialValueFor(
+			form([
+				objectGroup("address", [shortText("city"), shortText("zip")]),
+			]),
+			{ address: { city: "Brooklyn", zip: "11201" } },
+		);
+		expect(result).toEqual({
+			address: { city: "Brooklyn", zip: "11201" },
+		});
+	});
+
+	it("partial object_group pre-fill leaves missing children blank", () => {
+		// Customer's extraction got the city but not the zip — common
+		// when an OCR pass partial-matches. The reviewer fills in zip.
+		const result = initialValueFor(
+			form([
+				objectGroup("address", [shortText("city"), shortText("zip")]),
+			]),
+			{ address: { city: "Brooklyn" } },
+		);
+		expect(result).toEqual({
+			address: { city: "Brooklyn", zip: null },
+		});
+	});
+
+	it("expands repeatable_group pre-fill into pre-populated rows", () => {
+		// The canonical Flow A surface: customer's extraction yields
+		// N line items, each one a partially-or-fully-filled row.
+		const result = initialValueFor(
+			form([
+				repeatableGroup("line_items", [shortText("sku"), shortText("qty")]),
+			]),
+			{
+				line_items: [
+					{ sku: "A-1", qty: "2" },
+					{ sku: "B-9", qty: "1" },
+				],
+			},
+		);
+		expect(result).toEqual({
+			line_items: [
+				{ sku: "A-1", qty: "2" },
+				{ sku: "B-9", qty: "1" },
+			],
+		});
+	});
+
+	it("repeatable_group row with missing keys falls back per-cell", () => {
+		// Row 0 missing qty: reviewer sees A-1 with qty blank,
+		// fills it in. Without this we'd render `qty: undefined`
+		// which the field renderer treats as un-touched/blank
+		// anyway, but the explicit null is the cleaner shape.
+		const result = initialValueFor(
+			form([
+				repeatableGroup("line_items", [shortText("sku"), shortText("qty")]),
+			]),
+			{ line_items: [{ sku: "A-1" }] },
+		);
+		expect(result).toEqual({ line_items: [{ sku: "A-1", qty: null }] });
+	});
+
+	it("empty repeatable_group pre-fill stays an empty array", () => {
+		// Distinct from "key missing entirely" — empty array means
+		// "extraction found nothing to enumerate." Reviewer can
+		// click + Add row.
+		const result = initialValueFor(
+			form([repeatableGroup("rows", [shortText("sku")])]),
+			{ rows: [] },
+		);
+		expect(result).toEqual({ rows: [] });
+	});
+
+	it("non-array repeatable_group pre-fill defaults to []", () => {
+		// Defensive: if the wire shape drifts (customer sent `null`
+		// or a stray object for what should be an array), don't
+		// crash — fall back to the empty-rows default. The reviewer
+		// can still add rows.
+		const result = initialValueFor(
+			form([repeatableGroup("rows", [shortText("sku")])]),
+			{ rows: null as unknown as Record<string, unknown>[] },
+		);
+		expect(result).toEqual({ rows: [] });
+	});
+
+	it("non-object object_group pre-fill defaults to child-default scope", () => {
+		// Same defensive pattern at the object level — if the
+		// customer's extraction had `address: "123 Main St"` (a
+		// plain string instead of a nested dict), we don't try to
+		// interpret it; children fall back to their own defaults.
+		const result = initialValueFor(
+			form([
+				objectGroup("address", [shortText("city")]),
+			]),
+			{ address: "123 Main St" },
+		);
+		expect(result).toEqual({ address: { city: null } });
+	});
+
+	it("nested repeatable_group inside object_group descends correctly", () => {
+		// Realistic nested shape: an invoice's `vendor` object
+		// contains a `previous_orders` list. Pre-fill must descend
+		// through both layers without losing values.
+		const result = initialValueFor(
+			form([
+				objectGroup("vendor", [
+					shortText("name"),
+					repeatableGroup("previous_orders", [shortText("order_id")]),
+				]),
+			]),
+			{
+				vendor: {
+					name: "Acme",
+					previous_orders: [{ order_id: "O-1" }, { order_id: "O-2" }],
+				},
+			},
+		);
+		expect(result).toEqual({
+			vendor: {
+				name: "Acme",
+				previous_orders: [{ order_id: "O-1" }, { order_id: "O-2" }],
+			},
+		});
+	});
+
+	it("null pre-fill behaves the same as no pre-fill at all", () => {
+		// Non-AwaitVerify tasks carry `initial_response: null`. The
+		// helper must not crash and must produce the same defaults.
+		const withNull = initialValueFor(
+			form([shortText("vendor")]),
+			null,
+		);
+		const without = initialValueFor(form([shortText("vendor")]));
+		expect(withNull).toEqual(without);
+	});
+});

--- a/packages/dashboard/components/form-renderer/initial-value.ts
+++ b/packages/dashboard/components/form-renderer/initial-value.ts
@@ -1,0 +1,156 @@
+/**
+ * Build the form's starting state from a FormDefinition.
+ *
+ * Pure data transformation — no JSX, no React — so vitest can import
+ * this directly without going through a JSX-aware loader. The
+ * renderer's `index.tsx` re-exports it for callers.
+ *
+ * When the optional `prefill` is supplied (AwaitVerify Flow A /
+ * Flow B), customer-supplied values win over per-field defaults.
+ * Missing keys fall back to defaults. Nested groups
+ * (object_group / repeatable_group / section_collapse) descend by
+ * path so an outer `prefill.address = {city: "..."}` seeds the
+ * inner `address.city` field.
+ */
+
+import type { FormDefinition, FormField } from "@/lib/form-types";
+
+import type { FormValue } from "./types";
+
+export function initialValueFor(
+	form: FormDefinition,
+	prefill?: Record<string, unknown> | null,
+): FormValue {
+	const out: FormValue = {};
+	walk(form.fields, out, prefill ?? null);
+	return out;
+}
+
+// Kinds that render UI but don't contribute a value to the response.
+// Skipping them here keeps display-only primitives (text blocks, media,
+// layout) out of the submitted response payload even when they have a
+// `name`. Without this, e.g. a display_text named "intro" shows up as
+// `{"intro": null}` in the human's response — misleading and pollutes
+// the audit trail.
+const NON_INPUT_KINDS = new Set([
+	"display_text",
+	"image",
+	"video",
+	"pdf_viewer",
+	"html",
+	"section",
+	"divider",
+]);
+
+function walk(
+	fields: FormField[],
+	out: FormValue,
+	prefill: Record<string, unknown> | null,
+): void {
+	for (const f of fields) {
+		if (!f.name) continue;
+		if (NON_INPUT_KINDS.has(f.kind)) continue;
+
+		// section_collapse flattens children into the same scope — its
+		// own name doesn't appear in the prefill object. Use the parent
+		// prefill verbatim.
+		if (f.kind === "section_collapse") {
+			walk(f.fields, out, prefill);
+			continue;
+		}
+
+		const seeded =
+			prefill !== null && f.name in prefill ? prefill[f.name] : undefined;
+
+		switch (f.kind) {
+			case "switch":
+				out[f.name] =
+					typeof seeded === "boolean" ? seeded : (f.default ?? null);
+				break;
+			case "single_select":
+				out[f.name] =
+					typeof seeded === "string" ? seeded : (f.default ?? null);
+				break;
+			case "multi_select":
+				out[f.name] = Array.isArray(seeded) ? seeded : (f.default ?? []);
+				break;
+			case "picture_choice":
+				out[f.name] = Array.isArray(seeded) ? seeded : (f.default ?? []);
+				break;
+			case "slider":
+				out[f.name] =
+					typeof seeded === "number"
+						? seeded
+						: (f.default ?? (f.min + f.max) / 2);
+				break;
+			case "star_rating":
+				out[f.name] = typeof seeded === "number" ? seeded : (f.default ?? 0);
+				break;
+			case "opinion_scale":
+				out[f.name] =
+					typeof seeded === "number" ? seeded : (f.default ?? null);
+				break;
+			case "date":
+			case "datetime":
+			case "time":
+				out[f.name] =
+					typeof seeded === "string" ? seeded : (f.default ?? null);
+				break;
+			case "ranking":
+				out[f.name] = Array.isArray(seeded)
+					? seeded
+					: f.options.map((o) => o.value);
+				break;
+			case "table":
+				// Tables aren't expected in AwaitVerify pre-fill (they
+				// use repeatable_group instead), but seed verbatim when
+				// provided — managed sends row-shaped objects.
+				out[f.name] = Array.isArray(seeded) ? seeded : [];
+				break;
+			case "subform":
+				out[f.name] = Array.isArray(seeded) ? seeded : [];
+				break;
+			case "object_group": {
+				// Recursive: seed children from a nested prefill object.
+				// If the prefill at this name isn't a plain object,
+				// children fall back to their own defaults.
+				const subPrefill =
+					seeded && typeof seeded === "object" && !Array.isArray(seeded)
+						? (seeded as Record<string, unknown>)
+						: null;
+				const groupOut: FormValue = {};
+				walk(f.fields, groupOut, subPrefill);
+				out[f.name] = groupOut;
+				break;
+			}
+			case "repeatable_group": {
+				// Each item in the seed array becomes a row. We recurse
+				// into item_fields so a row that's missing a key still
+				// gets that field's default — important when the
+				// customer's extraction filled some columns but not
+				// others.
+				if (Array.isArray(seeded)) {
+					out[f.name] = seeded.map((row) => {
+						const rowOut: FormValue = {};
+						walk(
+							f.item_fields,
+							rowOut,
+							row && typeof row === "object" && !Array.isArray(row)
+								? (row as Record<string, unknown>)
+								: null,
+						);
+						return rowOut;
+					});
+				} else {
+					out[f.name] = [];
+				}
+				break;
+			}
+			default:
+				// Plain-value input kinds (short_text, long_text, rich_text,
+				// file_upload, signature, date_range) start blank, or
+				// seed verbatim from the prefill when present.
+				out[f.name] = seeded !== undefined ? seeded : null;
+		}
+	}
+}

--- a/packages/dashboard/lib/form-types.ts
+++ b/packages/dashboard/lib/form-types.ts
@@ -277,6 +277,32 @@ export type SubformField = BaseField & {
 	remove_label: string;
 };
 
+// ─── Nested Pydantic groups ──────────────────────────────────────────
+//
+// `object_group` and `repeatable_group` are built by the managed-side
+// form-definition builder when the customer's response_schema includes
+// a nested Pydantic model or a `list[BaseModel]`. Pre-PR-C these
+// collapsed to a `long_text` holding raw JSON, which was unusable for
+// non-technical reviewers. The new kinds give the dashboard enough
+// shape to render an indented section (object) or an editable table
+// (list[BaseModel]) without exposing JSON anywhere.
+
+export type ObjectGroupField = BaseField & {
+	kind: "object_group";
+	// Children to render inside the indented section. May contain any
+	// FormField kind, including another object_group or repeatable_group.
+	fields: FormField[];
+};
+
+export type RepeatableGroupField = BaseField & {
+	kind: "repeatable_group";
+	// Shape of a single row. Reviewer adds rows by clicking + Add row;
+	// each new row is an empty {} that fills in defaults per item_field.
+	item_fields: FormField[];
+	min_items: number | null;
+	max_items: number | null;
+};
+
 // ─── Union ───────────────────────────────────────────────────────────
 
 export type FormField =
@@ -306,4 +332,6 @@ export type FormField =
 	| DividerField
 	| SectionCollapseField
 	| TableField
-	| SubformField;
+	| SubformField
+	| ObjectGroupField
+	| RepeatableGroupField;

--- a/packages/dashboard/lib/types.ts
+++ b/packages/dashboard/lib/types.ts
@@ -23,6 +23,14 @@ export interface Task {
 	 * structures are rejected at the server schema layer.
 	 */
 	task_metadata: Record<string, string> | null;
+	/**
+	 * Pre-computed extraction snapshot (AwaitVerify Flow A / Flow B).
+	 * Matches the shape of `response_schema`. The form renderer mounts
+	 * the form with these values pre-populated so the reviewer
+	 * verifies/corrects rather than re-types. Null for pure-human
+	 * review or non-AwaitVerify await_human callers.
+	 */
+	initial_response: Record<string, unknown> | null;
 	status: TaskStatus;
 	assign_to: Record<string, unknown> | null;
 	assigned_to_email: string | null;


### PR DESCRIPTION
## Summary

Third and final PR in the AwaitVerify launch reviewer-UX series. Renders nested Pydantic schemas as proper UI (was: collapsed to long_text holding raw JSON), pre-fills the form from `initial_response` for Flow A / Flow B tasks, and adds non-technical polish.

| Brief | What this PR does |
|---|---|
| **O3** Nested-Pydantic rendering | Two new field kinds (`object_group`, `repeatable_group`) in the form types + dispatcher + renderers. Cells in `repeatable_group` reuse the full FieldDispatch via a `CompactFieldContext` so labels in the column header don't duplicate. |
| **O4** Pre-fill from `initial_response` | `initialValueFor(form, prefill?)` accepts the customer's extraction. Nested groups descend by path. Reviewer can edit any pre-filled value; partial pre-fills leave the rest at field defaults. |
| **O5** Non-technical UX polish | New "unknown field kind" fallback ("This field isn't supported by the review form yet — please contact support") replaces silent render-nothing. `humanizeName` fallback when a column has no label. ObjectGroupRenderer header uses brand divider + Eyebrow styling. |

## Wire contract (matches the brief verbatim)

\`\`\`ts
// Indented section.
{ kind: \"object_group\", name: \"address\", label, hint?, required, fields: FormField[] }

// Spreadsheet-style editable table.
{ kind: \"repeatable_group\", name: \"rows\", label, hint?, required,
  item_fields: FormField[], min_items?, max_items? }
\`\`\`

Managed builds these from `list[BaseModel]` / nested `BaseModel` schema walks. The OSS dashboard renders them — no server-side schema walker changes needed.

## Rendering behavior

**object_group**: indented section with a small uppercase header, left-border indent, and a horizontal divider above the label. Children dispatch normally at a nested scope.

**repeatable_group**:
- Empty: shows `"No rows yet — click + Add row to begin."`
- Populated: table with column headers from `item_fields[].label`. Cell renderer reuses the full FieldDispatch in compact mode (label suppressed; hint preserved). Date columns get a date picker, switch columns get a switch, etc.
- "+ Add row" appends an empty row; per-row "×" removes. `min_items` / `max_items` gate the buttons.

## Pre-fill semantics

- **Flat prefill**: `prefill[name]` → field value, fallback to per-field default.
- **object_group**: `prefill.address = {city: \"...\"}` seeds `address.city`. Partial nested objects leave missing children at defaults.
- **repeatable_group**: each item in `prefill[name]` becomes a pre-populated row. Missing cells in a row fall back to per-cell defaults.
- **Defensive**: non-object prefill at an object_group scope → children fall back to defaults; non-array prefill at a repeatable_group → empty rows.
- **No prefill / null prefill**: identical to pre-PR behavior — form starts blank with field defaults.

## Test plan

- [x] `npm test` in `packages/dashboard` — **36 passed** (15 existing + 21 new across initial-value + build-response-value)
- [x] `npx tsc --noEmit` — clean
- [ ] **Reviewer (manual / Playwright):**
  - [ ] Visit a task whose schema has a `list[BaseModel]` field → table with the right columns
  - [ ] Add a row, type values, submit → values appear in audit trail
  - [ ] Visit a task with `initial_response` populated → pre-filled rows (each cell editable)
  - [ ] Clear a pre-filled value → field behaves normally (submit drops blank optional)
  - [ ] Visit a task with a nested `object_group` → indented section, recursive fields, nested submit shape

## Deferred (NOT in this PR)

- **Validation message humanization** (O5 sub-item: replace `"must match pattern ^[0-9]+$"` with `"Numbers only"`). Surfaces at submit-error time in `task/page.tsx`'s existing error display. Bigger refactor; deferred to a follow-up.
- **Component / Playwright tests**. The dashboard doesn't have RTL or Playwright today. Pure-function tests cover the state transitions; component rendering gets manual verification. Adding a test framework is its own RFC.

## With #165 + #166 + this PR, the launch UX surface is closed

- #165 (S1 + O1): SDK forwards extraction → OSS persists `initial_response` ✅
- #166 (O2): Multi-image carousel ✅
- #167 (this PR, O3 + O4 + O5): Nested rendering + pre-fill + polish ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)