### PR TITLE
fix(dashboard): render submitted nested response without [object Object]

### DIFF
--- a/packages/dashboard/app/(dashboard)/task/page.tsx
+++ b/packages/dashboard/app/(dashboard)/task/page.tsx
@@ -33,6 +33,7 @@ import {
 	initialValueFor,
 	type FormValue,
 } from "@/components/form-renderer";
+import { SubmittedResponse } from "@/components/submitted-response";
 
 /**
  * Route is query-param (`/task?id=...`) rather than dynamic segment
@@ -427,28 +428,18 @@ function TaskDetailPageInner() {
 							<Eyebrow as="h2" size="md" tone="bright" weight="semibold" className="block mb-4">
 								Response
 							</Eyebrow>
-							<div className="space-y-3">
-								{Object.entries(task.response).map(([key, value]) => (
-									<div key={key} className="flex items-start gap-3">
-										<span className="text-white/40 text-sm min-w-[120px] font-mono">
-											{key}
-										</span>
-										<span className="text-sm">
-											{typeof value === "boolean" ? (
-												<span
-													className={
-														value ? "text-brand" : "text-red-400"
-													}
-												>
-													{value ? "Yes" : "No"}
-												</span>
-											) : (
-												String(value)
-											)}
-										</span>
-									</div>
-								))}
-							</div>
+							{/* Read-back uses the same FormRenderer the
+							    reviewer filled in, in disabled mode, so
+							    nested fields (object_group,
+							    repeatable_group) render with the right
+							    shape instead of the previous
+							    `String(value)` coercion that produced
+							    "[object Object]" for any nested value.
+							    See components/submitted-response.tsx. */}
+							<SubmittedResponse
+								response={task.response}
+								formDefinition={task.form_definition}
+							/>
 							{completedByLabel(task) && (
 								<div className="mt-4 text-white/30 text-xs">
 									Completed by {completedByLabel(task)} via{" "}

--- a/packages/dashboard/components/submitted-response.test.tsx
+++ b/packages/dashboard/components/submitted-response.test.tsx
@@ -1,0 +1,233 @@
+/**
+ * Regression: the submitted-response view must never show
+ * "[object Object]".
+ *
+ * Pre-PR, `task/page.tsx` ran `String(value)` on each entry in
+ * `task.response`. JavaScript coerces nested objects and arrays to
+ * the literal string "[object Object]", which is what a reviewer
+ * saw immediately after clicking Submit on any task with a
+ * list[BaseModel] or nested-object response.
+ *
+ * These tests pin both render paths:
+ *   1. With form_definition → FormRenderer in disabled mode, no
+ *      "[object Object]" anywhere.
+ *   2. Without form_definition (fallback) → recursive primitive
+ *      renderer, also no "[object Object]".
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { FormDefinition, FormField } from "@/lib/form-types";
+
+import { SubmittedResponse } from "./submitted-response";
+
+afterEach(() => {
+	cleanup();
+});
+
+// Compact field factories for fixture forms.
+function shortText(name: string, label = name): FormField {
+	return {
+		kind: "short_text",
+		name,
+		label,
+		required: false,
+		hint: null,
+		placeholder: null,
+		max_length: null,
+		min_length: null,
+		pattern: null,
+		currency_code: null,
+		subtype: "plain",
+	} as unknown as FormField;
+}
+
+function objectGroup(name: string, fields: FormField[]): FormField {
+	return {
+		kind: "object_group",
+		name,
+		label: name,
+		required: false,
+		hint: null,
+		fields,
+	} as unknown as FormField;
+}
+
+function repeatableGroup(name: string, itemFields: FormField[]): FormField {
+	return {
+		kind: "repeatable_group",
+		name,
+		label: name,
+		required: false,
+		hint: null,
+		item_fields: itemFields,
+		min_items: null,
+		max_items: null,
+	} as unknown as FormField;
+}
+
+function form(fields: FormField[]): FormDefinition {
+	return { version: 1, fields };
+}
+
+describe("SubmittedResponse — with form_definition (Option A path)", () => {
+	it("does not render '[object Object]' for a nested object response", () => {
+		// Canonical bug case: response has a nested address object.
+		// Pre-fix this rendered as `[object Object]` next to the
+		// "address" key.
+		render(
+			<SubmittedResponse
+				response={{
+					vendor: "Acme Corp",
+					address: { city: "Brooklyn", zip: "11201" },
+				}}
+				formDefinition={form([
+					shortText("vendor"),
+					objectGroup("address", [
+						shortText("city"),
+						shortText("zip"),
+					]),
+				])}
+			/>,
+		);
+		expect(screen.queryByText("[object Object]")).toBeNull();
+		// The flat primitive lands as plain text via the form input.
+		expect(screen.getAllByDisplayValue("Acme Corp").length).toBeGreaterThan(0);
+		expect(screen.getAllByDisplayValue("Brooklyn").length).toBeGreaterThan(0);
+		expect(screen.getAllByDisplayValue("11201").length).toBeGreaterThan(0);
+	});
+
+	it("does not render '[object Object]' for a list[BaseModel] response", () => {
+		// The other canonical case: a repeatable_group response
+		// where each row is itself an object. Pre-fix each row
+		// rendered as "[object Object]".
+		render(
+			<SubmittedResponse
+				response={{
+					line_items: [
+						{ sku: "A-1", qty: "2" },
+						{ sku: "B-9", qty: "1" },
+					],
+				}}
+				formDefinition={form([
+					repeatableGroup("line_items", [
+						shortText("sku"),
+						shortText("qty"),
+					]),
+				])}
+			/>,
+		);
+		expect(screen.queryByText("[object Object]")).toBeNull();
+		// Each cell renders the value via the form input.
+		expect(screen.getAllByDisplayValue("A-1").length).toBeGreaterThan(0);
+		expect(screen.getAllByDisplayValue("B-9").length).toBeGreaterThan(0);
+	});
+
+	it("renders all primitive inputs in disabled mode", () => {
+		// The "read-only" promise — inputs must not be editable
+		// after the task is submitted.
+		const { container } = render(
+			<SubmittedResponse
+				response={{ vendor: "Acme Corp" }}
+				formDefinition={form([shortText("vendor")])}
+			/>,
+		);
+		const inputs = container.querySelectorAll("input");
+		expect(inputs.length).toBeGreaterThan(0);
+		for (const input of inputs) {
+			expect(input.disabled).toBe(true);
+		}
+	});
+});
+
+describe("SubmittedResponse — without form_definition (fallback path)", () => {
+	it("does not render '[object Object]' for a nested object response", () => {
+		// Task created without a form_definition (programmatic
+		// await_human without a Pydantic schema). The recursive
+		// renderer must handle nesting cleanly.
+		render(
+			<SubmittedResponse
+				response={{
+					vendor: "Acme Corp",
+					address: { city: "Brooklyn", zip: "11201" },
+				}}
+				formDefinition={null}
+			/>,
+		);
+		expect(screen.queryByText("[object Object]")).toBeNull();
+		// Primitives are still readable in the fallback renderer.
+		expect(screen.getByText("Acme Corp")).toBeTruthy();
+		expect(screen.getByText("Brooklyn")).toBeTruthy();
+	});
+
+	it("does not render '[object Object]' for an array of objects", () => {
+		render(
+			<SubmittedResponse
+				response={{
+					line_items: [
+						{ sku: "A-1", qty: "2" },
+						{ sku: "B-9", qty: "1" },
+					],
+				}}
+				formDefinition={null}
+			/>,
+		);
+		expect(screen.queryByText("[object Object]")).toBeNull();
+		expect(screen.getByText("A-1")).toBeTruthy();
+		expect(screen.getByText("B-9")).toBeTruthy();
+	});
+
+	it("renders booleans as Yes/No in the fallback", () => {
+		// The original code had a special boolean case that produced
+		// "Yes" / "No"; the new recursive renderer preserves that
+		// rather than emitting raw "true" / "false".
+		render(
+			<SubmittedResponse
+				response={{ approved: true, rejected: false }}
+				formDefinition={null}
+			/>,
+		);
+		expect(screen.getByText("Yes")).toBeTruthy();
+		expect(screen.getByText("No")).toBeTruthy();
+	});
+
+	it("renders null and empty values with a visible placeholder", () => {
+		// A reviewer who cleared a field should see something other
+		// than blank space — "empty" makes it clear the field was
+		// touched but left empty, distinct from "the key wasn't
+		// present at all" (which the response wouldn't carry).
+		render(
+			<SubmittedResponse
+				response={{ note: null, optional_text: "" }}
+				formDefinition={null}
+			/>,
+		);
+		expect(screen.getAllByText("empty").length).toBe(2);
+	});
+
+	it("renders deeply-nested values without '[object Object]'", () => {
+		// Defensive: a response with three levels of nesting (object
+		// → array → object) was the worst-case for the old
+		// String(value) coercion. Make sure the recursive renderer
+		// walks all the way down.
+		render(
+			<SubmittedResponse
+				response={{
+					vendor: {
+						name: "Acme",
+						previous_orders: [
+							{ order_id: "O-1", total: 100 },
+							{ order_id: "O-2", total: 250 },
+						],
+					},
+				}}
+				formDefinition={null}
+			/>,
+		);
+		expect(screen.queryByText("[object Object]")).toBeNull();
+		expect(screen.getByText("Acme")).toBeTruthy();
+		expect(screen.getByText("O-1")).toBeTruthy();
+		expect(screen.getByText("O-2")).toBeTruthy();
+	});
+});

--- a/packages/dashboard/components/submitted-response.tsx
+++ b/packages/dashboard/components/submitted-response.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+/**
+ * Read-only view of a task's submitted response.
+ *
+ * Pre-PR, the task page rendered the response as `Object.entries`
+ * with `String(value)` per value, which JavaScript happily coerces
+ * to "[object Object]" for any nested object or array. Reviewers
+ * submitting a nested response (a list[BaseModel], an object_group)
+ * saw broken text immediately after clicking Submit.
+ *
+ * Two render paths:
+ *
+ *   1. **With form_definition (primary).** Mount the same
+ *      ``FormRenderer`` the reviewer used to fill the form, with
+ *      ``disabled={true}`` so every input is read-only. This stays
+ *      in sync with the write side automatically — new field kinds
+ *      land in one place and the read-back gets them for free.
+ *
+ *   2. **Without form_definition (fallback).** Some tasks predate
+ *      form_definition (programmatic tasks created via raw
+ *      ``await_human`` without a Pydantic response_schema) so a
+ *      ``FormDefinition`` may be null on the wire. In that case we
+ *      walk the response JSON recursively and render primitives
+ *      inline, arrays as numbered groups, and objects as nested
+ *      key/value pairs. The fallback path never emits
+ *      "[object Object]" — that string should not appear anywhere
+ *      a reviewer can see.
+ */
+
+import { FormRenderer } from "@/components/form-renderer";
+import type { FormDefinition } from "@/lib/form-types";
+
+type Props = {
+	response: Record<string, unknown>;
+	formDefinition: FormDefinition | null;
+};
+
+export function SubmittedResponse({ response, formDefinition }: Props) {
+	if (formDefinition) {
+		// Disabled mode: FormRenderer threads the prop to every
+		// primitive's <input disabled />, producing a faithful
+		// read-back of exactly what the reviewer saw + filled in.
+		return (
+			<FormRenderer
+				form={formDefinition}
+				value={response}
+				onChange={noop}
+				disabled
+			/>
+		);
+	}
+	return <RecursiveValue value={response} />;
+}
+
+function noop() {
+	// FormRenderer requires an onChange but in disabled mode every
+	// primitive renderer suppresses user interaction, so this is a
+	// pure type-shim. Inlined rather than imported so a future move
+	// of this component doesn't drag a "utils" file.
+}
+
+// ── Fallback: recursive primitive renderer ─────────────────────────
+
+/**
+ * Walks a JSON value and renders it inline. Three real cases plus
+ * a defensive last branch:
+ *   - primitive (string / number / boolean / null) → readable text
+ *   - array → indexed entries with the same recursive renderer
+ *   - object → key/value pairs, recursing into the values
+ *   - anything else (defensive: BigInt, etc., never present in
+ *     server-parsed JSON) → JSON.stringify in a <pre> so the
+ *     reviewer at least sees the raw shape rather than
+ *     "[object Object]"
+ */
+function RecursiveValue({ value }: { value: unknown }) {
+	if (value === null || value === undefined) {
+		return <span className="text-white/30 italic">empty</span>;
+	}
+	if (typeof value === "boolean") {
+		return (
+			<span className={value ? "text-brand" : "text-red-400"}>
+				{value ? "Yes" : "No"}
+			</span>
+		);
+	}
+	if (typeof value === "number" || typeof value === "string") {
+		// Empty string is a meaningful value (reviewer explicitly
+		// cleared the field); rendering it as a thin placeholder
+		// makes it visible.
+		if (value === "") return <span className="text-white/30 italic">empty</span>;
+		return <span className="text-sm">{value}</span>;
+	}
+	if (Array.isArray(value)) {
+		if (value.length === 0) {
+			return <span className="text-white/30 italic">no items</span>;
+		}
+		return (
+			<ol className="list-decimal list-inside space-y-1 pl-3 border-l-2 border-white/10">
+				{value.map((item, i) => (
+					<li key={i} className="text-sm">
+						<RecursiveValue value={item} />
+					</li>
+				))}
+			</ol>
+		);
+	}
+	if (typeof value === "object") {
+		const entries = Object.entries(value as Record<string, unknown>);
+		if (entries.length === 0) {
+			return <span className="text-white/30 italic">empty</span>;
+		}
+		return (
+			<div className="space-y-2 pl-3 border-l-2 border-white/10">
+				{entries.map(([key, v]) => (
+					<div key={key} className="flex items-start gap-3">
+						<span className="text-white/40 text-sm min-w-[120px] font-mono">
+							{key}
+						</span>
+						<div className="text-sm flex-1">
+							<RecursiveValue value={v} />
+						</div>
+					</div>
+				))}
+			</div>
+		);
+	}
+	// Defensive: shapes that don't come from JSON (BigInt, Date,
+	// Symbol). Real JSON-loaded payloads can't reach this branch,
+	// but we'd rather show JSON-ish text than the literal
+	// "[object Object]".
+	return (
+		<pre className="text-xs text-white/50 bg-white/5 p-2 rounded overflow-x-auto">
+			{JSON.stringify(value, null, 2)}
+		</pre>
+	);
+}


### PR DESCRIPTION
## Summary

- New `<SubmittedResponse>` component renders the reviewer's submitted answer in two paths:
  - **With `form_definition`** (primary): mounts the same `FormRenderer` they filled in, with `disabled={true}` — faithful read-back, stays in sync with new field kinds automatically.
  - **Without `form_definition`** (fallback): recursive primitive renderer that walks objects + arrays without ever emitting `[object Object]`.
- `task/page.tsx` swaps the inline `Object.entries` + `String(value)` block for a single `<SubmittedResponse>` component.
- 8 new component tests pin the regression on both render paths.

## The bug

`task/page.tsx` line 446 (pre-fix):

```tsx
<span className="text-sm">
  {typeof value === "boolean" ? (...) : String(value)}
</span>
```

`String({sku: "A-1", qty: "2"})` → `"[object Object]"`. Most visible on `repeatable_group` responses (common after M3 + PR #167), but any nested object_group hit it too.

## Option A vs Option B

Both implemented because some tasks predate `form_definition`:

| Has form_definition? | Path | Why |
|---|---|---|
| Yes | `<FormRenderer disabled />` | Existing renderer already threads `disabled` to native `<input disabled />` for every primitive. New field kinds (object_group, repeatable_group, future ones) automatically render correctly on the read-back side with zero parallel implementation. |
| No | Recursive primitive renderer | Walks objects + arrays inline, renders booleans as Yes/No, null/empty as a visible "empty" placeholder, deeply-nested values all the way down. |

The fallback path matters because old programmatic `await_human` calls without a Pydantic schema have `form_definition: null` on the wire. The read-back must still be readable.

## Test plan

- [x] `npm test` in `packages/dashboard` — **54 passed** (8 new + 46 existing)
- [x] `npx tsc --noEmit` — clean
- [x] Tests cover both paths + explicit assertions that `queryByText("[object Object]")` is null after rendering:
  - nested object_group response
  - list[BaseModel] response
  - inputs are `disabled` in read-back mode
  - fallback path with nested objects
  - fallback path with arrays of objects
  - fallback path with booleans → Yes/No
  - fallback path with null / empty values → "empty" placeholder
  - three-levels-deep nesting (object → array → object)
- [ ] **Reviewer (manual):**
  - [ ] Submit a task with the smoke's `InvoiceExtraction` schema (`line_items: list[LineItem]`) → success screen shows the rows in a disabled table, not as `[object Object]` or JSON
  - [ ] Submit a task with a single-level object response → keys/values render, no `[object Object]`
  - [ ] Submit a task whose schema is just primitives → existing experience unchanged

## Not changed

- Wire format. The OSS server still stores and returns the same JSON dict. Pure dashboard rendering fix.
- The audit-log `TimelineEntryDetails` block (separate code path, renders `extra_data` via `JSON.stringify`) — that's not the bug the brief asked me to fix; it shows JSON which is at least readable, not `[object Object]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)