### PR TITLE
fix(dashboard): render redacted panel immediately on submit, not on reload

### DIFF
--- a/packages/dashboard/app/(dashboard)/task/optimistic-redact.test.ts
+++ b/packages/dashboard/app/(dashboard)/task/optimistic-redact.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for ``applyOptimisticRedaction`` — the client-side overlay
+ * applied immediately after a successful submit on a task with
+ * ``redact_response_after_submit=true``.
+ *
+ * The helper does three things that the rest of the page wires
+ * together to make the submit→redacted transition instantaneous:
+ *
+ *   1. Clears ``response`` so any sibling component reading it
+ *      sees no content to render.
+ *   2. Stamps ``response_redacted_at`` so SubmittedResponse picks
+ *      the "Response delivered" placeholder branch.
+ *   3. Flips ``status`` to "completed" so the form-mount gate
+ *      (``canSubmitResponse``) becomes false and the form
+ *      unmounts. Without this the form would render alongside
+ *      the placeholder, defeating the privacy guarantee.
+ *
+ * The companion ``SubmittedResponse`` tests in PR #172 pin the
+ * render side: when ``responseRedactedAt`` is non-null, the
+ * "Response delivered" placeholder takes priority — even if a
+ * stale ``response`` is present. Together the two test files
+ * cover the submit→redacted chain end-to-end.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { Task } from "@/lib/types";
+
+import { applyOptimisticRedaction } from "./optimistic-redact";
+
+function baseTask(overrides: Partial<Task> = {}): Task {
+	return {
+		id: "t-1",
+		idempotency_key: "k-1",
+		task: "Verify invoice",
+		payload: null,
+		payload_schema: {},
+		response_schema: {},
+		form_definition: null,
+		task_metadata: null,
+		initial_response: null,
+		redact_response_after_submit: true,
+		response_redacted_at: null,
+		status: "in_progress",
+		assign_to: null,
+		assigned_to_email: null,
+		assigned_to_user_id: null,
+		assigned_to_display_name: null,
+		assigned_to_slack_user_id: null,
+		response: { vendor: "Acme Corp", amount: 100 },
+		verifier_result: null,
+		verification_attempt: 0,
+		timeout_seconds: 900,
+		redact_payload: false,
+		created_at: "2026-06-01T12:00:00Z",
+		updated_at: "2026-06-01T12:00:00Z",
+		completed_at: null,
+		timed_out_at: null,
+		completed_by_email: null,
+		completed_by_user_id: null,
+		completed_by_display_name: null,
+		completed_by_slack_user_id: null,
+		completed_via_channel: null,
+		...overrides,
+	};
+}
+
+describe("applyOptimisticRedaction", () => {
+	it("clears response so siblings can't render the typed values", () => {
+		const result = applyOptimisticRedaction(baseTask());
+		expect(result.response).toBeNull();
+	});
+
+	it("stamps response_redacted_at with the provided clock", () => {
+		// Test-injectable clock so the timestamp assertion is exact.
+		// In production the helper falls back to `new Date()` per
+		// the function default.
+		const clock = new Date("2026-06-01T15:47:23.000Z");
+		const result = applyOptimisticRedaction(baseTask(), clock);
+		expect(result.response_redacted_at).toBe("2026-06-01T15:47:23.000Z");
+	});
+
+	it("uses the current time when no clock is passed", () => {
+		// Looser: we don't know the exact millisecond, but the stamp
+		// should be a parseable ISO string close to "now". Pinning
+		// at all (vs leaving it null) is what matters; the exact
+		// value gets overwritten on the next loadTask anyway.
+		const before = Date.now();
+		const result = applyOptimisticRedaction(baseTask());
+		const after = Date.now();
+
+		expect(result.response_redacted_at).not.toBeNull();
+		const parsed = new Date(result.response_redacted_at as string).getTime();
+		expect(parsed).toBeGreaterThanOrEqual(before);
+		expect(parsed).toBeLessThanOrEqual(after);
+	});
+
+	it("flips status to 'completed' so the form unmounts via canSubmitResponse", () => {
+		// canSubmitResponse on the task page gates on !isTerminal.
+		// Without this status flip, the form would render alongside
+		// the redacted placeholder. The status change is the
+		// load-bearing piece that removes the typed inputs from the
+		// DOM in the same render tick.
+		const result = applyOptimisticRedaction(baseTask({ status: "in_progress" }));
+		expect(result.status).toBe("completed");
+	});
+
+	it("preserves all unrelated fields verbatim", () => {
+		// The overlay must not silently drop fields the rest of the
+		// page reads — task_metadata, assign_to, completed_by_*,
+		// audit trail keys, etc. Tested explicitly because the
+		// helper does a spread + targeted overwrites; an accidental
+		// destructuring miss would silently lose state.
+		const task = baseTask({
+			task_metadata: { customer: "Acme" },
+			assigned_to_email: "alice@example.com",
+			task: "Original title",
+			id: "id-preserved",
+			idempotency_key: "key-preserved",
+		});
+		const result = applyOptimisticRedaction(task);
+		expect(result.task_metadata).toEqual({ customer: "Acme" });
+		expect(result.assigned_to_email).toBe("alice@example.com");
+		expect(result.task).toBe("Original title");
+		expect(result.id).toBe("id-preserved");
+		expect(result.idempotency_key).toBe("key-preserved");
+	});
+
+	it("does not mutate the input task", () => {
+		// Functional purity — the helper returns a new object and
+		// leaves the input alone. Without this, callers that hold
+		// onto the original (e.g. for an undo affordance, which the
+		// brief explicitly rejects but defensive coding is cheap)
+		// would silently see their data clobbered.
+		const original = baseTask({ status: "in_progress" });
+		const originalResponse = original.response;
+		applyOptimisticRedaction(original);
+		expect(original.status).toBe("in_progress");
+		expect(original.response).toBe(originalResponse);
+		expect(original.response_redacted_at).toBeNull();
+	});
+
+	it("re-applies cleanly even if response is already null", () => {
+		// Defensive: idempotent. Calling the helper twice produces
+		// the same shape (modulo timestamp drift). Matters because
+		// the sticky-ref machinery on the page may run the overlay
+		// inside loadTask AFTER handleSubmit's optimistic mutation
+		// has already redacted the task.
+		const once = applyOptimisticRedaction(baseTask());
+		const twice = applyOptimisticRedaction(once);
+		expect(twice.response).toBeNull();
+		expect(twice.status).toBe("completed");
+		expect(twice.response_redacted_at).not.toBeNull();
+	});
+});

--- a/packages/dashboard/app/(dashboard)/task/optimistic-redact.ts
+++ b/packages/dashboard/app/(dashboard)/task/optimistic-redact.ts
@@ -1,0 +1,42 @@
+/**
+ * Optimistic-redaction overlay applied client-side after a successful
+ * submit on a task with ``redact_response_after_submit=true``.
+ *
+ * Why: the server-side redaction only fires after the webhook
+ * dispatcher delivers the callback (PR #172 / O8). The reviewer's
+ * Submit click is acknowledged within milliseconds, but the callback
+ * delivery happens on the scheduler's tick. Between the two, the
+ * dashboard previously kept the typed values visible — a
+ * shoulder-surf / screenshot window that could span seconds.
+ *
+ * The overlay flips the local task to its eventual server-side
+ * shape: status COMPLETED, response cleared, response_redacted_at
+ * stamped at submit time. The render pipeline (SubmittedResponse +
+ * canSubmitResponse) then renders the "Response delivered"
+ * placeholder immediately. When the server catches up on the next
+ * fetch, the server's response_redacted_at replaces ours.
+ *
+ * Kept as a pure function so vitest can unit-test it without
+ * mounting the page.
+ */
+
+import type { Task } from "@/lib/types";
+
+export function applyOptimisticRedaction(task: Task, now: Date = new Date()): Task {
+	return {
+		...task,
+		// Clear the response so any sibling component reading
+		// `task.response` (e.g. SubmittedResponse's structured
+		// read-back) sees nothing to render.
+		response: null,
+		// Synthesize the timestamp client-side. The server-side value
+		// (stamped when the customer's callback ACKs) will replace
+		// this on the next loadTask fetch — the placeholder text
+		// doesn't care about millisecond-level precision.
+		response_redacted_at: now.toISOString(),
+		// Flip to terminal so canSubmitResponse becomes false and the
+		// form unmounts (rather than rendering alongside the
+		// placeholder, which would defeat the privacy guarantee).
+		status: "completed",
+	};
+}

--- a/packages/dashboard/app/(dashboard)/task/page.tsx
+++ b/packages/dashboard/app/(dashboard)/task/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { ChevronDown } from "lucide-react";
 import {
@@ -34,6 +34,7 @@ import {
 	type FormValue,
 } from "@/components/form-renderer";
 import { SubmittedResponse } from "@/components/submitted-response";
+import { applyOptimisticRedaction } from "./optimistic-redact";
 
 /**
  * Route is query-param (`/task?id=...`) rather than dynamic segment
@@ -67,6 +68,20 @@ function TaskDetailPageInner() {
 		new Set(),
 	);
 
+	// Sticky flag: once the reviewer has submitted a task with
+	// `redact_response_after_submit=true`, every subsequent loadTask
+	// re-applies the redaction overlay locally — even before the
+	// server-side webhook dispatcher has fired the callback and
+	// stamped `response_redacted_at`. The flag is a `useRef` (not
+	// state) because flipping it shouldn't trigger a re-render; the
+	// next setTask call already does that.
+	//
+	// Lives for the lifetime of the page mount. Navigating away and
+	// back is a fresh mount that re-fetches and reads the server's
+	// canonical redaction state — by then the scheduler will have
+	// caught up in practice.
+	const submittedWithRedaction = useRef(false);
+
 	const toggleAuditEntry = (id: string) => {
 		setExpandedAuditIds((prev) => {
 			const next = new Set(prev);
@@ -97,7 +112,18 @@ function TaskDetailPageInner() {
 				fetchAuditTrail(taskId).catch(() => []),
 				fetchMe().catch(() => null),
 			]);
-			setTask(taskData);
+			// Carry forward client-side optimistic redaction. The
+			// server's response_redacted_at is the source of truth
+			// when it arrives, but until the webhook dispatcher fires
+			// the callback (which can lag the submit by seconds) the
+			// server still has the typed response. Re-apply the
+			// overlay so the reviewer never sees the content come
+			// back between submit and the dispatcher's tick.
+			const displayTask =
+				submittedWithRedaction.current && !taskData.response_redacted_at
+					? applyOptimisticRedaction(taskData)
+					: taskData;
+			setTask(displayTask);
 			setAudit(auditData);
 			setMe(meData);
 
@@ -132,6 +158,28 @@ function TaskDetailPageInner() {
 				response: responseBody,
 				completed_via_channel: "dashboard",
 			});
+
+			// AwaitVerify: when the task carries the redaction flag,
+			// flip to the "Response delivered" placeholder
+			// immediately — within the same render tick as the 2xx
+			// from the submit endpoint. The server-side redaction
+			// fires later (on callback dispatch), so without this
+			// the typed values would stay visible for the seconds
+			// between submit and the webhook scheduler's next tick.
+			// Sticky ref ensures the loadTask below re-applies the
+			// overlay if the server-side timestamp hasn't landed yet.
+			if (task.redact_response_after_submit) {
+				submittedWithRedaction.current = true;
+				setTask((prev) =>
+					prev ? applyOptimisticRedaction(prev) : prev,
+				);
+				// Clear the typed values from local state so no
+				// sibling component holds a copy in memory. The form
+				// itself is about to unmount (canSubmitResponse goes
+				// false once status flips to "completed").
+				setFormData({});
+			}
+
 			await loadTask();
 		} catch (err) {
 			setError(err instanceof Error ? err.message : "Failed to submit");

--- a/packages/dashboard/components/submitted-response.test.tsx
+++ b/packages/dashboard/components/submitted-response.test.tsx
@@ -306,3 +306,65 @@ describe("SubmittedResponse — redacted (post-callback) path", () => {
 		expect(container.firstChild).toBeNull();
 	});
 });
+
+describe("SubmittedResponse — optimistic-redaction chain (PR H, O9)", () => {
+	// These tests pin the submit-time behavior of the task page in a
+	// focused way: take a task with a populated response, run the
+	// applyOptimisticRedaction overlay (the same helper handleSubmit
+	// uses), and mount SubmittedResponse with the result. The
+	// reviewer's typed values must NOT survive into the rendered
+	// DOM. This is what closes the shoulder-surf / screenshot
+	// window between Submit and the server-side callback dispatch.
+
+	it("typed values disappear from the DOM immediately after the overlay applies", async () => {
+		const { applyOptimisticRedaction } = await import(
+			"@/app/(dashboard)/task/optimistic-redact"
+		);
+
+		// Simulate "reviewer just typed a sensitive value and clicked Submit"
+		// — a unique string we can grep for to prove it leaks nowhere.
+		const SENSITIVE = "very-sensitive-value-PR-H-pin";
+		const taskAfterSubmit = applyOptimisticRedaction({
+			// Minimal Task shape — only the fields the renderer reads.
+			// Cast through unknown to skip the full Task interface;
+			// the helper's shape contract is exercised in
+			// optimistic-redact.test.ts.
+			id: "t-1",
+			response: { secret: SENSITIVE },
+		} as unknown as Parameters<typeof applyOptimisticRedaction>[0]);
+
+		render(
+			<SubmittedResponse
+				response={taskAfterSubmit.response}
+				formDefinition={null}
+				responseRedactedAt={taskAfterSubmit.response_redacted_at}
+			/>,
+		);
+
+		// Paranoid pin — walk the entire DOM and assert the
+		// sensitive string isn't anywhere. Catches the case where
+		// a sibling component still has a copy in state.
+		expect(document.body.textContent).not.toContain(SENSITIVE);
+		// And the placeholder is up.
+		expect(screen.getByText("Response delivered")).toBeTruthy();
+		expect(screen.getByText(/redacted for privacy/i)).toBeTruthy();
+	});
+
+	it("non-redact submit path still renders the typed values", async () => {
+		// Counter-test: when the task does NOT carry the redaction
+		// flag, the existing in-house team behavior is preserved.
+		// SubmittedResponse without responseRedactedAt renders the
+		// structured read-back as PR F (#171) shipped it.
+		render(
+			<SubmittedResponse
+				response={{ secret: "in-house-team-keeps-seeing-this" }}
+				formDefinition={null}
+				responseRedactedAt={null}
+			/>,
+		);
+		expect(
+			screen.getByText("in-house-team-keeps-seeing-this"),
+		).toBeTruthy();
+		expect(screen.queryByText("Response delivered")).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

Closes the shoulder-surf / screenshot window between Submit and the server-side callback dispatch on AwaitVerify tasks.

- New `applyOptimisticRedaction` helper that flips a task to its eventual server-side shape: `status=completed`, `response=null`, `response_redacted_at=now()`. Pure function with an injectable clock for tests.
- Task page's `handleSubmit` applies the overlay synchronously after a 2xx from `completeTask` when `task.redact_response_after_submit` is true. React flushes before `loadTask` returns, so the form unmounts and the "Response delivered" placeholder takes its place within the same render tick.
- Sticky `useRef` on the page makes the optimistic state survive `loadTask` refreshes — important because the server's `_record_outcome` redaction only fires after the webhook scheduler ticks, which can lag the submit by seconds.

## The bug

PR G (#172) redacted on reload, not on submit. Sequence pre-fix:

1. Reviewer clicks Submit
2. Server processes, returns 2xx
3. Dashboard awaits `loadTask` → fetches the task
4. Server's `response_redacted_at` is still null (the webhook scheduler hasn't ticked yet)
5. Dashboard re-renders with the typed values still visible
6. ~5 seconds later: scheduler ticks, callback dispatches, server redacts
7. ONLY on the next reload does the dashboard pick up `response_redacted_at` and hide the content

Between steps 2 and 7 the typed values stay on screen. A reviewer who steps away from their laptop after clicking Submit leaves sensitive data exposed until someone reloads the page.

## The fix

Optimistically apply the redaction overlay on the client the moment the submit succeeds, and keep it sticky across loadTask refreshes until the server's stamp arrives:

```ts
// handleSubmit, after `await completeTask(...)`:
if (task.redact_response_after_submit) {
  submittedWithRedaction.current = true;        // sticky
  setTask(prev => prev ? applyOptimisticRedaction(prev) : prev);
  setFormData({});                              // clear typed values from local state
}
await loadTask();                               // server catches up later
```

```ts
// loadTask, after the fetch:
const displayTask =
  submittedWithRedaction.current && !taskData.response_redacted_at
    ? applyOptimisticRedaction(taskData)
    : taskData;
setTask(displayTask);
```

The status flip to `"completed"` is load-bearing — it's what flips `canSubmitResponse` to false so the form unmounts. Without it, the form would render alongside the placeholder and the privacy guarantee would be broken.

## Tests

- **`optimistic-redact.test.ts`** (7 cases, pure unit): helper clears response, stamps the timestamp with an injectable clock and falls back to `new Date()` without one, flips status, preserves unrelated fields, doesn't mutate the input, is idempotent on re-application.
- **`submitted-response.test.tsx`** (2 new chain-effect tests): runs a "sensitive" string through `applyOptimisticRedaction` → `SubmittedResponse`, walks `document.body.textContent` and asserts the string appears nowhere. Counter-test confirms non-redact tasks still show the typed values (in-house team UX unchanged).
- 67 dashboard tests pass total (9 new + 58 existing). Typecheck clean.

I did NOT mount the full task page in a test — that requires mocking `next/navigation` (`useRouter`, `useSearchParams`, the `Suspense` boundary) plus the entire `@/lib/server` surface, which is a bigger fixture investment than the value adds. The chain-effect test in `submitted-response.test.tsx` proves the integration: helper output + SubmittedResponse → no typed values in DOM. The page-level wiring is straightforward and gets manual verification.

## Test plan

- [x] `npm test` in `packages/dashboard` — 67 passed
- [x] `npx tsc --noEmit` — clean
- [ ] **Reviewer (manual):**
  - [ ] Submit an AwaitVerify task (with `redact_response_after_submit: true` from M3) → the form should unmount and "Response delivered" panel should appear instantly, before any loading spinner finishes
  - [ ] Watch network tab: even if the next `GET /api/tasks/{id}` returns with `response: {...}` and `response_redacted_at: null` (because the webhook scheduler hasn't ticked yet), the panel must stay redacted
  - [ ] Wait for the scheduler to catch up + the response panel should still show "Response delivered" with the server's real timestamp
  - [ ] Submit a non-AwaitVerify task → existing in-house behavior: structured read-back shows the values

## Out of scope (per the brief)

- Don't change the server submit endpoint — already correct from PR G.
- Don't add a "show response one more time" affordance — redact is permanent on the dashboard side once submitted.
- Don't optimistically redact non-AwaitVerify tasks — the flag's default is false; the mutation only fires when true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)