### PR TITLE
chore: replace awaithumans.com refs with .dev

### DIFF
--- a/packages/python/awaithumans/awaitverify/_managed_client.py
+++ b/packages/python/awaithumans/awaitverify/_managed_client.py
@@ -69,7 +69,7 @@ class ManagedBackendError(VerifyError):
                 "  - 401/403: check the api_key on your AwaitHumans client.\n"
                 "  - 404: the upload session or task id was not recognized.\n"
                 "  - 422: a request field failed validation — check the response body.\n"
-                "  - 5xx: transient — retry or check status.awaithumans.com."
+                "  - 5xx: transient — retry or check status.awaithumans.dev."
             ),
             docs_url="https://docs.awaithumans.dev/awaitverify/errors",
         )

--- a/packages/python/awaithumans/instance.py
+++ b/packages/python/awaithumans/instance.py
@@ -55,7 +55,7 @@ class AwaitHumans:
         managed_url: Base URL of the AwaitVerify managed backend, used
             by `verify_document` calls. Falls back to
             AWAITHUMANS_MANAGED_URL or the hosted default
-            (`https://api.awaithumans.com`).
+            (`https://api.awaithumans.dev`).
         openai: Optional OpenAI credentials for Flow B. The customer's
             key is used locally; it never reaches AwaitVerify.
         anthropic: Optional Anthropic (Claude) credentials.
@@ -84,7 +84,7 @@ class AwaitHumans:
         # Production managed endpoint. Customers can override per
         # instance via `managed_url=` or per process via the
         # AWAITHUMANS_MANAGED_URL env var. When we later cut over a
-        # custom domain (`api.awaithumans.com`), update this default
+        # custom domain (`api.awaithumans.dev`), update this default
         # in one place and ship a minor release.
         self.managed_url = (
             managed_url


### PR DESCRIPTION
## Summary

Three user-facing strings still pointed at \`awaithumans.com\` while the canonical brand domain is \`awaithumans.dev\`.

- \`packages/python/awaithumans/instance.py\` — \`AwaitHumans\` docstring + a code comment both referenced \`api.awaithumans.com\` as the planned hosted endpoint. Now \`.dev\`.
- \`packages/python/awaithumans/awaitverify/_managed_client.py\` — \`ManagedBackendError\` hint pointed at \`status.awaithumans.com\` for 5xx debugging. Now \`.dev\`.

No code paths change. No new dependencies. Pure string update.

## Test plan

- [ ] \`ruff check .\` and \`ruff format --check .\` pass.
- [ ] \`mypy\` is unaffected (no type changes).
- [ ] Quick \`grep -rn awaithumans.com packages/\` returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)