### PR TITLE
feat(dashboard): page-grouped carousel for multi-page documents (O10)

### DIFF
--- a/packages/dashboard/components/form-renderer/image-carousel.test.tsx
+++ b/packages/dashboard/components/form-renderer/image-carousel.test.tsx
@@ -193,3 +193,230 @@ describe("ImageCarousel — no lightbox button when only one image", () => {
 // CSS like `user-drag` while testing — they don't represent a
 // correctness issue, just happy-dom's strict-mode chatter.
 vi.spyOn(console, "warn").mockImplementation(() => {});
+
+// ── Multi-page (AwaitVerify M5) ────────────────────────────────────
+
+function pagedImage(
+	name: string,
+	url: string,
+	page: number,
+	frag: number,
+	pageCount: number,
+	fragmentsPerPage = 5,
+): ImageField {
+	return {
+		...imageField(name, url),
+		page_index: page,
+		fragment_in_page: frag,
+		page_count: pageCount,
+		fragments_per_page: fragmentsPerPage,
+	};
+}
+
+function threePagesByFive(): ImageField[] {
+	const out: ImageField[] = [];
+	for (let p = 0; p < 3; p++) {
+		for (let f = 0; f < 5; f++) {
+			out.push(pagedImage(`p${p}f${f}`, `http://x/${p}-${f}.png`, p, f, 3, 5));
+		}
+	}
+	return out;
+}
+
+describe("ImageCarousel — page selector (multi-page mode)", () => {
+	it("renders a tab strip when 2 ≤ pageCount ≤ 8", () => {
+		// The brief calls this the "compact tab strip" — preferred
+		// over a numeric input when the page count fits on one row.
+		render(<ImageCarousel images={threePagesByFive()} />);
+		const tabs = screen.getByTestId("page-selector-tabs");
+		expect(tabs).toBeTruthy();
+		// Three tabs labeled 1, 2, 3.
+		expect(tabs.textContent).toContain("1");
+		expect(tabs.textContent).toContain("2");
+		expect(tabs.textContent).toContain("3");
+	});
+
+	it("renders the numeric input variant when pageCount > 8", () => {
+		// Threshold is 8 — past that the tab strip would wrap or
+		// shrink uncomfortably on laptop widths.
+		const many: ImageField[] = [];
+		for (let p = 0; p < 12; p++) {
+			for (let f = 0; f < 5; f++) {
+				many.push(
+					pagedImage(`p${p}f${f}`, `http://x/${p}-${f}.png`, p, f, 12, 5),
+				);
+			}
+		}
+		render(<ImageCarousel images={many} />);
+		expect(screen.getByTestId("page-selector-input")).toBeTruthy();
+		expect(screen.queryByTestId("page-selector-tabs")).toBeNull();
+	});
+
+	it("does NOT render the page selector for single-page tasks", () => {
+		// Backward compat: a task with no page metadata renders
+		// today's flat carousel — no page chrome.
+		render(<ImageCarousel images={TWO_IMAGES} />);
+		expect(screen.queryByTestId("page-selector-tabs")).toBeNull();
+		expect(screen.queryByTestId("page-selector-input")).toBeNull();
+	});
+
+	it("clicking a page tab jumps to that page's first fragment", () => {
+		// Test from the brief: "Clicking tab [2] shows fragment with
+		// page_index === 1, fragment_in_page === 0 first."
+		const { container } = render(
+			<ImageCarousel images={threePagesByFive()} />,
+		);
+
+		// Tab 2 (1-indexed) maps to page_index 1 (0-indexed).
+		const tabs = screen.getByTestId("page-selector-tabs");
+		const tab2 = tabs.querySelector("button:nth-of-type(2)")!;
+		fireEvent.click(tab2);
+
+		const img = container.querySelector("img");
+		expect(img).not.toBeNull();
+		expect(img?.getAttribute("src")).toBe("http://x/1-0.png");
+	});
+});
+
+describe("ImageCarousel — keyboard nav across pages", () => {
+	it("→ on the last fragment of page 1 advances to page 2 fragment 1", () => {
+		// "→ on the last fragment of page N advances to fragment 1
+		// of the next page" — the cross-page flow that makes flat
+		// scrolling still possible.
+		const { container } = render(
+			<ImageCarousel images={threePagesByFive()} />,
+		);
+
+		// Navigate to the last fragment of page 1: tap → four times.
+		for (let i = 0; i < 4; i++) {
+			fireEvent.keyDown(window, { key: "ArrowRight" });
+		}
+		let img = container.querySelector("img");
+		expect(img?.getAttribute("src")).toBe("http://x/0-4.png");
+
+		// One more → must jump to page 2 fragment 1 (page_index=1, frag=0).
+		fireEvent.keyDown(window, { key: "ArrowRight" });
+		img = container.querySelector("img");
+		expect(img?.getAttribute("src")).toBe("http://x/1-0.png");
+	});
+
+	it("← on the first fragment of page 2 returns to last fragment of page 1", () => {
+		// Symmetric: backwards traversal also crosses boundaries.
+		const { container } = render(
+			<ImageCarousel images={threePagesByFive()} />,
+		);
+
+		// Jump to page 2 via tab.
+		const tabs = screen.getByTestId("page-selector-tabs");
+		fireEvent.click(tabs.querySelector("button:nth-of-type(2)")!);
+		let img = container.querySelector("img");
+		expect(img?.getAttribute("src")).toBe("http://x/1-0.png");
+
+		// ← must go back to page 1's last fragment.
+		fireEvent.keyDown(window, { key: "ArrowLeft" });
+		img = container.querySelector("img");
+		expect(img?.getAttribute("src")).toBe("http://x/0-4.png");
+	});
+
+	it("PageDown jumps to fragment 1 of the next page", () => {
+		// Faster than 5 × → for the reviewer who knows they want
+		// the next page, not the next fragment.
+		const { container } = render(
+			<ImageCarousel images={threePagesByFive()} />,
+		);
+
+		fireEvent.keyDown(window, { key: "PageDown" });
+		let img = container.querySelector("img");
+		expect(img?.getAttribute("src")).toBe("http://x/1-0.png");
+
+		fireEvent.keyDown(window, { key: "PageDown" });
+		img = container.querySelector("img");
+		expect(img?.getAttribute("src")).toBe("http://x/2-0.png");
+	});
+
+	it("PageUp jumps to fragment 1 of the previous page", () => {
+		const { container } = render(
+			<ImageCarousel images={threePagesByFive()} />,
+		);
+
+		// Start on page 3 via the tab.
+		const tabs = screen.getByTestId("page-selector-tabs");
+		fireEvent.click(tabs.querySelector("button:nth-of-type(3)")!);
+		let img = container.querySelector("img");
+		expect(img?.getAttribute("src")).toBe("http://x/2-0.png");
+
+		fireEvent.keyDown(window, { key: "PageUp" });
+		img = container.querySelector("img");
+		expect(img?.getAttribute("src")).toBe("http://x/1-0.png");
+	});
+
+	it("active page tab visually flips when navigation crosses pages", () => {
+		// The page selector's "active" highlight must follow the
+		// current fragment — without this the reviewer would see
+		// "I'm on tab [1]" while looking at page 2's content.
+		render(<ImageCarousel images={threePagesByFive()} />);
+
+		const tabs = screen.getByTestId("page-selector-tabs");
+		const tabButtons = tabs.querySelectorAll("button");
+		// Initial: tab 1 is selected.
+		expect(tabButtons[0].getAttribute("aria-selected")).toBe("true");
+		expect(tabButtons[1].getAttribute("aria-selected")).toBe("false");
+
+		// PageDown → page 2.
+		fireEvent.keyDown(window, { key: "PageDown" });
+
+		// Tab 2 should now be selected.
+		const updatedTabs = screen
+			.getByTestId("page-selector-tabs")
+			.querySelectorAll("button");
+		expect(updatedTabs[0].getAttribute("aria-selected")).toBe("false");
+		expect(updatedTabs[1].getAttribute("aria-selected")).toBe("true");
+	});
+
+	it("counter shows 'view K of 5' for multi-page tasks (not the flat K/N)", () => {
+		// Per the brief: the inner counter is per-page, not global.
+		// Reviewer expectation: "I'm on view 3 of 5 of this page"
+		// — far more useful than "I'm on 8 of 25" for grok.
+		render(<ImageCarousel images={threePagesByFive()} />);
+
+		expect(screen.getByText("view 1 of 5")).toBeTruthy();
+
+		// One → → "view 2 of 5".
+		fireEvent.keyDown(window, { key: "ArrowRight" });
+		expect(screen.getByText("view 2 of 5")).toBeTruthy();
+	});
+});
+
+describe("ImageLightbox — page header (multi-page mode)", () => {
+	it("shows 'Page N of M, view K of 5' when the current image carries metadata", () => {
+		// Brief: when active, the lightbox header should show
+		// "Page N of M, view K of 5". The lightbox is mounted on
+		// click via the Full screen button.
+		render(<ImageCarousel images={threePagesByFive()} />);
+
+		// Navigate to page 2 fragment 3 so the header isn't trivially
+		// "Page 1 of 3, view 1 of 5".
+		const tabs = screen.getByTestId("page-selector-tabs");
+		fireEvent.click(tabs.querySelector("button:nth-of-type(2)")!);
+		fireEvent.keyDown(window, { key: "ArrowRight" });
+		fireEvent.keyDown(window, { key: "ArrowRight" });
+
+		fireEvent.click(
+			screen.getByRole("button", { name: /full[- ]?screen/i }),
+		);
+
+		const header = screen.getByTestId("lightbox-page-header");
+		expect(header.textContent).toContain("Page 2 of 3");
+		expect(header.textContent).toContain("view 3 of 5");
+	});
+
+	it("does NOT show the lightbox page header for legacy single-page tasks", () => {
+		// Backward compat: image fields without page metadata don't
+		// produce a header — the bottom "K / N" counter is sufficient.
+		render(<ImageCarousel images={TWO_IMAGES} />);
+		fireEvent.click(
+			screen.getByRole("button", { name: /full[- ]?screen/i }),
+		);
+		expect(screen.queryByTestId("lightbox-page-header")).toBeNull();
+	});
+});

--- a/packages/dashboard/components/form-renderer/image-carousel.tsx
+++ b/packages/dashboard/components/form-renderer/image-carousel.tsx
@@ -2,39 +2,77 @@
 
 /**
  * ImageCarousel — single-image-at-a-time viewer with prev/next, a
- * "k / N" counter, keyboard arrow navigation, and a fit/actual zoom
- * toggle. Rendered by the FormRenderer when a form has 2+ top-level
- * image fields (typical AwaitVerify review surface: N document
- * fragments).
+ * "k / N" counter, keyboard arrow navigation, a fit/actual zoom
+ * toggle, and a full-screen lightbox. Rendered by the FormRenderer
+ * when a form has 2+ top-level image fields (typical AwaitVerify
+ * review surface: N document fragments).
+ *
+ * Page-grouped mode (AwaitVerify M5)
+ * ----------------------------------
+ * When the image fields carry per-page metadata (``page_index``,
+ * ``fragment_in_page``, ``page_count``, ``fragments_per_page``), the
+ * carousel renders a two-level navigation:
+ *
+ *   - Top: a page selector — tab strip for ≤ 8 pages, numeric input
+ *     + arrows otherwise.
+ *   - Inner: today's prev/next carousel scoped to one page's
+ *     fragments. Counter changes to "view K of 5" (this page)
+ *     rather than "K / 25" (all fragments).
+ *
+ * Internally we still track a single flat index across all fragments
+ * — that lets ← / → flow across page boundaries naturally, and lets
+ * us swap the entire flat list to the lightbox without translating
+ * coordinates. The active page is derived from the current
+ * fragment's ``page_index``.
  *
  * Reviewers work on laptops — we don't optimize for mobile, but the
- * `<img>` container is overflow-auto in actual-size mode so native
+ * ``<img>`` container is overflow-auto in actual-size mode so native
  * touchpad / pinch-zoom gestures work on the natural-size view
  * without us reimplementing them.
  *
- * Keyboard:
- *   ← / →   navigate. Suppressed when an INPUT / TEXTAREA /
- *           contentEditable element is focused, so typing into the
- *           reviewer's response form doesn't shuffle pages.
- *   Esc     reset zoom to fit.
+ * Keyboard
+ * --------
+ * ← / →           navigate fragments. Wraps across page boundaries:
+ *                 → on the last fragment of page N advances to
+ *                 fragment 1 of page N+1. Suppressed when an INPUT /
+ *                 TEXTAREA / contentEditable has focus.
+ * PageDown / PageUp  jump to fragment 1 of the next/previous page.
+ *                    Faster than tapping → repeatedly for
+ *                    multi-page documents.
+ * Esc             reset zoom to fit (when lightbox is closed).
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Eyebrow } from "@/components/eyebrow";
 import type { ImageField } from "@/lib/form-types";
+import {
+	derivePageLayout,
+	flattenLayout,
+	pageStartIndices,
+	type PagedLayout,
+} from "./image-grouping";
 import { ImageLightbox } from "./image-lightbox";
 import { ProtectedImage } from "./protected-image";
 
 type Zoom = "fit" | "actual";
 
+// Threshold from the brief: tab strip up to 8 pages, numeric
+// input + arrows beyond that. 9+ tabs gets too tight visually on
+// laptop-width screens.
+const PAGE_TAB_THRESHOLD = 8;
+
 export function ImageCarousel({ images }: { images: ImageField[] }) {
+	const layout = useMemo(() => derivePageLayout(images), [images]);
+	const flatImages = useMemo(() => flattenLayout(layout), [layout]);
+	const pageStarts = useMemo(() => pageStartIndices(layout), [layout]);
+
 	const [index, setIndex] = useState(0);
 	const [zoom, setZoom] = useState<Zoom>("fit");
 	const [lightboxOpen, setLightboxOpen] = useState(false);
 	const containerRef = useRef<HTMLDivElement>(null);
 
-	const count = images.length;
-	const current = images[index];
+	const count = flatImages.length;
+	const current = flatImages[index];
 
 	const goPrev = useCallback(
 		() => setIndex((i) => (i > 0 ? i - 1 : i)),
@@ -45,13 +83,42 @@ export function ImageCarousel({ images }: { images: ImageField[] }) {
 		[count],
 	);
 
+	// Page-level jumps. No-op when the layout is flat (pageStarts ==
+	// [0] and the bounds check below evaluates to "stay at 0").
+	const goPrevPage = useCallback(() => {
+		setIndex((cur) => {
+			// Find the page index containing the current flat index.
+			// pageStarts is monotonically increasing, so this is a
+			// straight linear scan.
+			let p = 0;
+			for (let i = 0; i < pageStarts.length; i++) {
+				if (pageStarts[i] <= cur) p = i;
+			}
+			return pageStarts[Math.max(0, p - 1)] ?? cur;
+		});
+	}, [pageStarts]);
+	const goNextPage = useCallback(() => {
+		setIndex((cur) => {
+			let p = 0;
+			for (let i = 0; i < pageStarts.length; i++) {
+				if (pageStarts[i] <= cur) p = i;
+			}
+			return pageStarts[Math.min(pageStarts.length - 1, p + 1)] ?? cur;
+		});
+	}, [pageStarts]);
+	const setActivePage = useCallback(
+		(p: number) => {
+			const clamped = Math.max(0, Math.min(pageStarts.length - 1, p));
+			setIndex(pageStarts[clamped] ?? 0);
+		},
+		[pageStarts],
+	);
+
 	// Keyboard navigation. Global listener, but skip when a text input
 	// has focus — the reviewer typing into the form's response fields
 	// should not shuffle pages. Reset zoom on Esc. While the lightbox
-	// is open, the lightbox owns keyboard handling (it has its own
-	// listener for ← / → / Esc) — bail out here so we don't dispatch
-	// twice or have the carousel react to Esc and dismiss zoom while
-	// the lightbox is also reacting to Esc to close.
+	// is open, the lightbox owns keyboard handling — bail out here so
+	// we don't dispatch twice.
 	useEffect(() => {
 		if (lightboxOpen) return;
 		function onKey(e: KeyboardEvent) {
@@ -70,13 +137,19 @@ export function ImageCarousel({ images }: { images: ImageField[] }) {
 			} else if (e.key === "ArrowRight") {
 				e.preventDefault();
 				goNext();
+			} else if (e.key === "PageDown") {
+				e.preventDefault();
+				goNextPage();
+			} else if (e.key === "PageUp") {
+				e.preventDefault();
+				goPrevPage();
 			} else if (e.key === "Escape") {
 				setZoom("fit");
 			}
 		}
 		window.addEventListener("keydown", onKey);
 		return () => window.removeEventListener("keydown", onKey);
-	}, [goPrev, goNext, lightboxOpen]);
+	}, [goPrev, goNext, goPrevPage, goNextPage, lightboxOpen]);
 
 	// Reset zoom when the slide changes — operators expect a fresh
 	// view per page; carrying "actual" across slides leaves the next
@@ -85,13 +158,27 @@ export function ImageCarousel({ images }: { images: ImageField[] }) {
 		setZoom("fit");
 	}, []);
 
+	// Page-derived values for the counter / page selector / etc.
+	const activePage = current?.page_index ?? 0;
+	const fragmentInPage = current?.fragment_in_page ?? index;
+	const isPaged = layout.kind === "paged";
+
 	return (
 		<div
 			ref={containerRef}
 			className="space-y-2"
 			data-testid="image-carousel"
 		>
-			{current.label && (
+			{/* Page selector — only when multi-page. */}
+			{isPaged && (
+				<PageSelector
+					layout={layout}
+					activePage={activePage}
+					onChange={setActivePage}
+				/>
+			)}
+
+			{current?.label && (
 				<Eyebrow weight="semibold" className="block text-white/50">
 					{current.label}
 				</Eyebrow>
@@ -104,16 +191,22 @@ export function ImageCarousel({ images }: { images: ImageField[] }) {
 						: "rounded-md border border-white/10 bg-black/20 max-h-[640px] overflow-auto"
 				}
 			>
-				<ProtectedImage
-					key={current.url}
-					src={current.url}
-					alt={current.alt ?? current.label ?? `Image ${index + 1} of ${count}`}
-					className={
-						zoom === "fit"
-							? "max-w-full max-h-[640px] object-contain"
-							: "block"
-					}
-				/>
+				{current && (
+					<ProtectedImage
+						key={current.url}
+						src={current.url}
+						alt={
+							current.alt ??
+							current.label ??
+							`Image ${index + 1} of ${count}`
+						}
+						className={
+							zoom === "fit"
+								? "max-w-full max-h-[640px] object-contain"
+								: "block"
+						}
+					/>
+				)}
 			</div>
 
 			<div className="flex items-center justify-between gap-2 text-sm">
@@ -140,7 +233,12 @@ export function ImageCarousel({ images }: { images: ImageField[] }) {
 						className="ml-2 tabular-nums text-white/50"
 						aria-live="polite"
 					>
-						{index + 1} / {count}
+						{isPaged
+							? `view ${fragmentInPage + 1} of ${
+									layout.pages[activePage]?.length ??
+									layout.fragmentsPerPage
+								}`
+							: `${index + 1} / ${count}`}
 					</span>
 				</div>
 
@@ -172,12 +270,149 @@ export function ImageCarousel({ images }: { images: ImageField[] }) {
 
 			{lightboxOpen && (
 				<ImageLightbox
-					images={images}
+					images={flatImages}
 					index={index}
 					onClose={() => setLightboxOpen(false)}
 					onIndexChange={setIndex}
 				/>
 			)}
+		</div>
+	);
+}
+
+// ── Page selector ──────────────────────────────────────────────────
+//
+// Two flavors, switched on ``pageCount``:
+//   ≤ 8 pages: tab strip `[1] [2] [3] ...`
+//   > 8 pages: `< Page N of M >` with a numeric input + arrows
+//
+// Threshold is set so the tab strip stays single-line on a typical
+// laptop width without horizontal scrolling. Numeric input wins
+// when there are too many tabs to fit comfortably.
+
+function PageSelector({
+	layout,
+	activePage,
+	onChange,
+}: {
+	layout: PagedLayout;
+	activePage: number;
+	onChange: (next: number) => void;
+}) {
+	if (layout.pageCount <= PAGE_TAB_THRESHOLD) {
+		return (
+			<div
+				className="flex items-center gap-1 flex-wrap"
+				role="tablist"
+				aria-label="Document pages"
+				data-testid="page-selector-tabs"
+			>
+				<span className="text-xs text-white/40 mr-1">Pages:</span>
+				{Array.from({ length: layout.pageCount }).map((_, i) => {
+					const isActive = i === activePage;
+					return (
+						<button
+							key={i}
+							type="button"
+							onClick={() => onChange(i)}
+							role="tab"
+							aria-selected={isActive}
+							className={
+								isActive
+									? "px-3 py-1 text-sm rounded-md bg-brand/20 border border-brand text-brand"
+									: "px-3 py-1 text-sm rounded-md border border-white/10 text-white/60 hover:text-white hover:border-white/30"
+							}
+						>
+							{i + 1}
+						</button>
+					);
+				})}
+			</div>
+		);
+	}
+	return (
+		<NumericPageInput
+			pageCount={layout.pageCount}
+			activePage={activePage}
+			onChange={onChange}
+		/>
+	);
+}
+
+function NumericPageInput({
+	pageCount,
+	activePage,
+	onChange,
+}: {
+	pageCount: number;
+	activePage: number;
+	onChange: (next: number) => void;
+}) {
+	// Local input value so the reviewer can type while the formatted
+	// "Page N of M" caption stays accurate. Commit on blur or Enter
+	// — typing in real-time would re-render and reset focus on every
+	// keystroke.
+	const [draft, setDraft] = useState<string>(String(activePage + 1));
+
+	// Keep the draft in sync when the active page changes from
+	// elsewhere (← / → / PageUp / PageDown crossed a boundary).
+	useEffect(() => {
+		setDraft(String(activePage + 1));
+	}, [activePage]);
+
+	const commit = () => {
+		const n = Number.parseInt(draft, 10);
+		if (Number.isFinite(n) && n >= 1 && n <= pageCount) {
+			onChange(n - 1);
+		} else {
+			// Reset to current — operator typed something invalid.
+			setDraft(String(activePage + 1));
+		}
+	};
+
+	return (
+		<div
+			className="flex items-center gap-2 text-sm"
+			data-testid="page-selector-input"
+		>
+			<button
+				type="button"
+				onClick={() => onChange(Math.max(0, activePage - 1))}
+				disabled={activePage === 0}
+				className="px-2 py-1 rounded-md border border-white/10 text-white/70 hover:text-white hover:border-white/30 disabled:opacity-30 disabled:cursor-not-allowed"
+				aria-label="Previous page"
+			>
+				◀
+			</button>
+			<span className="text-white/60">Page</span>
+			<input
+				type="text"
+				inputMode="numeric"
+				value={draft}
+				onChange={(e) => setDraft(e.target.value)}
+				onBlur={commit}
+				onKeyDown={(e) => {
+					if (e.key === "Enter") {
+						e.preventDefault();
+						commit();
+						(e.target as HTMLInputElement).blur();
+					}
+				}}
+				aria-label="Page number"
+				className="w-12 px-2 py-1 text-center rounded-md bg-white/5 border border-white/10 text-white tabular-nums focus:outline-none focus:border-brand/40"
+			/>
+			<span className="text-white/60">of {pageCount}</span>
+			<button
+				type="button"
+				onClick={() =>
+					onChange(Math.min(pageCount - 1, activePage + 1))
+				}
+				disabled={activePage === pageCount - 1}
+				className="px-2 py-1 rounded-md border border-white/10 text-white/70 hover:text-white hover:border-white/30 disabled:opacity-30 disabled:cursor-not-allowed"
+				aria-label="Next page"
+			>
+				▶
+			</button>
 		</div>
 	);
 }

--- a/packages/dashboard/components/form-renderer/image-grouping.test.ts
+++ b/packages/dashboard/components/form-renderer/image-grouping.test.ts
@@ -167,3 +167,197 @@ describe("groupImageFields", () => {
 		expect(groupImageFields([])).toEqual([]);
 	});
 });
+
+// ── derivePageLayout (AwaitVerify M5) ──────────────────────────────
+
+import {
+	derivePageLayout,
+	flattenLayout,
+	pageStartIndices,
+} from "./image-grouping";
+
+function pagedImage(
+	name: string,
+	url: string,
+	page: number,
+	frag: number,
+	pageCount: number,
+	fragmentsPerPage: number,
+): ImageField {
+	return {
+		...imageField(name, url),
+		page_index: page,
+		fragment_in_page: frag,
+		page_count: pageCount,
+		fragments_per_page: fragmentsPerPage,
+	};
+}
+
+describe("derivePageLayout", () => {
+	it("returns flat for legacy fields without page metadata", () => {
+		// Pre-M5 tasks: image fields carry no page_index. Render as
+		// the original flat carousel — page selector chrome would
+		// be noise.
+		const images = [
+			imageField("doc_0", "http://x/0.png"),
+			imageField("doc_1", "http://x/1.png"),
+			imageField("doc_2", "http://x/2.png"),
+		];
+		const layout = derivePageLayout(images);
+		expect(layout.kind).toBe("flat");
+		if (layout.kind === "flat") {
+			expect(layout.images).toEqual(images);
+		}
+	});
+
+	it("returns flat for empty input", () => {
+		// Degenerate: no images at all. Must not throw.
+		const layout = derivePageLayout([]);
+		expect(layout.kind).toBe("flat");
+		if (layout.kind === "flat") expect(layout.images).toEqual([]);
+	});
+
+	it("returns flat when metadata resolves to a single page", () => {
+		// Defensive: managed shouldn't emit page_count: 1 (it would
+		// just leave metadata off entirely), but a tools-side mistake
+		// shouldn't break the dashboard.
+		const images = [
+			pagedImage("a", "http://x/0.png", 0, 0, 1, 5),
+			pagedImage("b", "http://x/1.png", 0, 1, 1, 5),
+		];
+		const layout = derivePageLayout(images);
+		expect(layout.kind).toBe("flat");
+	});
+
+	it("groups fragments by page_index when metadata is present", () => {
+		// Canonical M5 surface: 3 pages × 5 fragments. Each page's
+		// fragments live in the same bucket, sorted by
+		// fragment_in_page.
+		const images: ImageField[] = [];
+		for (let p = 0; p < 3; p++) {
+			for (let f = 0; f < 5; f++) {
+				images.push(pagedImage(`p${p}f${f}`, `http://x/${p}-${f}.png`, p, f, 3, 5));
+			}
+		}
+		const layout = derivePageLayout(images);
+		expect(layout.kind).toBe("paged");
+		if (layout.kind !== "paged") return;
+		expect(layout.pageCount).toBe(3);
+		expect(layout.fragmentsPerPage).toBe(5);
+		expect(layout.pages.length).toBe(3);
+		for (let p = 0; p < 3; p++) {
+			expect(layout.pages[p].length).toBe(5);
+			expect(layout.pages[p][0].name).toBe(`p${p}f0`);
+			expect(layout.pages[p][4].name).toBe(`p${p}f4`);
+		}
+	});
+
+	it("sorts within a page by fragment_in_page (defensive)", () => {
+		// Managed emits fragments in order, but if the wire ever
+		// arrives shuffled (proxy reorders, etc.) the carousel
+		// nav must still see page 0 in the right order.
+		const images = [
+			pagedImage("frag4", "http://x/4.png", 0, 4, 1, 5),
+			pagedImage("frag0", "http://x/0.png", 0, 0, 1, 5),
+			pagedImage("frag2", "http://x/2.png", 0, 2, 1, 5),
+			// Plus enough images on page 1 to keep it from collapsing
+			// to flat.
+			pagedImage("p1f0", "http://x/p1f0.png", 1, 0, 2, 5),
+		];
+		const layout = derivePageLayout(images);
+		expect(layout.kind).toBe("paged");
+		if (layout.kind !== "paged") return;
+		// Page 0's fragments should be in 0, 2, 4 order — not their
+		// original arrival order.
+		const namesOnPage0 = layout.pages[0].map((i) => i.name);
+		expect(namesOnPage0).toEqual(["frag0", "frag2", "frag4"]);
+	});
+
+	it("sorts pages by page_index ascending", () => {
+		// Same as fragments within a page, but for the page list.
+		// Reviewer expectation: page 1, page 2, page 3 — not the
+		// order managed happened to emit them in.
+		const images = [
+			pagedImage("p2", "http://x/p2.png", 2, 0, 3, 5),
+			pagedImage("p2b", "http://x/p2b.png", 2, 1, 3, 5),
+			pagedImage("p0", "http://x/p0.png", 0, 0, 3, 5),
+			pagedImage("p0b", "http://x/p0b.png", 0, 1, 3, 5),
+			pagedImage("p1", "http://x/p1.png", 1, 0, 3, 5),
+			pagedImage("p1b", "http://x/p1b.png", 1, 1, 3, 5),
+		];
+		const layout = derivePageLayout(images);
+		expect(layout.kind).toBe("paged");
+		if (layout.kind !== "paged") return;
+		expect(layout.pages[0][0].name).toBe("p0");
+		expect(layout.pages[1][0].name).toBe("p1");
+		expect(layout.pages[2][0].name).toBe("p2");
+	});
+
+	it("uses max actual page length as fallback for fragmentsPerPage", () => {
+		// Defensive: when fragments_per_page is missing from the
+		// wire (it shouldn't be, but) the reported value should
+		// at least match the biggest page seen.
+		const images = [
+			{
+				...imageField("a", "http://x/0.png"),
+				page_index: 0,
+				fragment_in_page: 0,
+				page_count: 2,
+			},
+			{
+				...imageField("b", "http://x/1.png"),
+				page_index: 0,
+				fragment_in_page: 1,
+				page_count: 2,
+			},
+			{
+				...imageField("c", "http://x/2.png"),
+				page_index: 1,
+				fragment_in_page: 0,
+				page_count: 2,
+			},
+		];
+		const layout = derivePageLayout(images);
+		expect(layout.kind).toBe("paged");
+		if (layout.kind !== "paged") return;
+		expect(layout.fragmentsPerPage).toBe(2);
+	});
+});
+
+describe("flattenLayout + pageStartIndices", () => {
+	it("flattens a paged layout to a single ordered list", () => {
+		// The carousel uses a flat index across all fragments so
+		// ← / → can step across page boundaries.
+		const images: ImageField[] = [];
+		for (let p = 0; p < 2; p++) {
+			for (let f = 0; f < 3; f++) {
+				images.push(pagedImage(`p${p}f${f}`, `http://x/${p}-${f}.png`, p, f, 2, 3));
+			}
+		}
+		const layout = derivePageLayout(images);
+		const flat = flattenLayout(layout);
+		expect(flat.map((i) => i.name)).toEqual([
+			"p0f0",
+			"p0f1",
+			"p0f2",
+			"p1f0",
+			"p1f1",
+			"p1f2",
+		]);
+	});
+
+	it("pageStartIndices returns the flat-index of each page's first fragment", () => {
+		// pages of length [5, 5, 3] → start indices [0, 5, 10].
+		const images: ImageField[] = [];
+		for (let f = 0; f < 5; f++) images.push(pagedImage(`p0f${f}`, `http://x/0-${f}.png`, 0, f, 3, 5));
+		for (let f = 0; f < 5; f++) images.push(pagedImage(`p1f${f}`, `http://x/1-${f}.png`, 1, f, 3, 5));
+		for (let f = 0; f < 3; f++) images.push(pagedImage(`p2f${f}`, `http://x/2-${f}.png`, 2, f, 3, 5));
+		const layout = derivePageLayout(images);
+		expect(pageStartIndices(layout)).toEqual([0, 5, 10]);
+	});
+
+	it("pageStartIndices returns [0] for a flat layout", () => {
+		const layout = derivePageLayout([imageField("a", "http://x/0.png")]);
+		expect(pageStartIndices(layout)).toEqual([0]);
+	});
+});

--- a/packages/dashboard/components/form-renderer/image-grouping.ts
+++ b/packages/dashboard/components/form-renderer/image-grouping.ts
@@ -72,3 +72,137 @@ export function groupImageFields(fields: FormField[]): RenderSlot[] {
 	}
 	return slots;
 }
+
+// ── Page layout (AwaitVerify M5) ───────────────────────────────────
+//
+// When managed includes per-fragment page metadata (PR #M5), the
+// carousel renders a two-level navigation: a page selector at the
+// top, and the existing carousel scoped to one page's fragments
+// inside it. ``derivePageLayout`` decides which layout to use and,
+// for the paged case, returns the fragments grouped by page in a
+// stable order.
+
+export type FlatLayout = {
+	kind: "flat";
+	images: ImageField[];
+};
+
+export type PagedLayout = {
+	kind: "paged";
+	// Outer index is page (0-indexed). Inner array is the fragments
+	// for that page, sorted by `fragment_in_page` ascending.
+	pages: ImageField[][];
+	pageCount: number;
+	// Most-common case: every page has the same fragment count
+	// (5 at v1). When pages have varying counts (e.g. a final page
+	// with fewer fragments) this is the max; per-page actual count
+	// is `pages[i].length`.
+	fragmentsPerPage: number;
+};
+
+export type CarouselLayout = FlatLayout | PagedLayout;
+
+/**
+ * Decide the carousel layout for a set of image fields.
+ *
+ * Falls back to flat when:
+ *   - No image carries page metadata (legacy task created before M5)
+ *   - All images report ``page_count: 1`` (single-page document)
+ *   - All images resolve to the same page (defensive — managed should
+ *     not emit ``page_count > 1`` when only one page is present, but
+ *     a tools-side mistake shouldn't break the dashboard)
+ *
+ * The metadata fields are optional on the wire (M5 is additive over
+ * older tasks). Missing keys are treated as their pre-M5 defaults
+ * (page_index=0, fragment_in_page=index, page_count=1) — pre-M5
+ * tasks render in today's flat carousel without crashing on the
+ * absent keys.
+ */
+export function derivePageLayout(images: ImageField[]): CarouselLayout {
+	if (images.length === 0) {
+		return { kind: "flat", images: [] };
+	}
+	// "Has page metadata" means at least one image carries page_index.
+	// We could also key off page_count, but page_index is what drives
+	// the grouping — defaulting to that signal keeps the logic crisp.
+	const hasMetadata = images.some((img) => img.page_index !== undefined);
+	if (!hasMetadata) {
+		return { kind: "flat", images };
+	}
+
+	// Group images by their page_index. Missing page_index defaults
+	// to 0 — partial metadata is unusual but we'd rather merge into
+	// page 0 than crash.
+	const buckets = new Map<number, ImageField[]>();
+	for (const img of images) {
+		const p = img.page_index ?? 0;
+		const list = buckets.get(p) ?? [];
+		list.push(img);
+		buckets.set(p, list);
+	}
+
+	// Sort within each bucket by fragment_in_page (defensive — managed
+	// emits in order, but client-side resilience is cheap).
+	for (const list of buckets.values()) {
+		list.sort(
+			(a, b) => (a.fragment_in_page ?? 0) - (b.fragment_in_page ?? 0),
+		);
+	}
+
+	// Materialize pages in ascending page_index order.
+	const sortedPageIndices = [...buckets.keys()].sort((a, b) => a - b);
+	const pages = sortedPageIndices.map((p) => buckets.get(p) ?? []);
+
+	if (pages.length <= 1) {
+		// Defensive: page metadata present but everything resolved to
+		// page 0. Render as flat — the page selector would only show
+		// "Page 1 of 1" which is noise.
+		return { kind: "flat", images };
+	}
+
+	// fragments_per_page comes from any image that carries it; fall
+	// back to the largest actual page length so the layout's reported
+	// "expected" count matches reality even when the wire metadata
+	// is stale.
+	const declaredPerPage = images.find(
+		(img) => img.fragments_per_page !== undefined,
+	)?.fragments_per_page;
+	const maxActualPerPage = Math.max(...pages.map((p) => p.length));
+	const fragmentsPerPage = declaredPerPage ?? maxActualPerPage;
+
+	return {
+		kind: "paged",
+		pages,
+		pageCount: pages.length,
+		fragmentsPerPage,
+	};
+}
+
+/**
+ * Flatten a layout to a single ordered list of images. The carousel
+ * stores its navigation as a single flat index; this helper produces
+ * the matching array so ← / → can step across page boundaries by
+ * just incrementing the index.
+ */
+export function flattenLayout(layout: CarouselLayout): ImageField[] {
+	return layout.kind === "paged" ? layout.pages.flat() : layout.images;
+}
+
+/**
+ * Compute the flat-index of the FIRST fragment of each page. Used by
+ * the page selector / PageDown / PageUp navigation: clicking page N
+ * jumps the carousel's flat index to ``pageStarts[N]``.
+ *
+ * For a layout with pages of length [5, 5, 3], returns [0, 5, 10].
+ * Always returns ``[0]`` for a flat layout.
+ */
+export function pageStartIndices(layout: CarouselLayout): number[] {
+	if (layout.kind !== "paged") return [0];
+	const starts: number[] = [0];
+	let acc = 0;
+	for (let i = 0; i < layout.pages.length - 1; i++) {
+		acc += layout.pages[i].length;
+		starts.push(acc);
+	}
+	return starts;
+}

--- a/packages/dashboard/components/form-renderer/image-lightbox.tsx
+++ b/packages/dashboard/components/form-renderer/image-lightbox.tsx
@@ -105,6 +105,23 @@ export function ImageLightbox({
 				className="max-w-[95vw] max-h-[95vh] object-contain"
 			/>
 
+			{/* Top header — shows "Page N of M, view K of 5" when the
+			    current image carries page metadata (AwaitVerify M5).
+			    Without metadata, no header is shown — the bottom
+			    "K / N" counter is sufficient for a flat document. */}
+			{current?.page_index !== undefined &&
+				current?.page_count !== undefined && (
+					<div
+						className="absolute top-4 left-1/2 -translate-x-1/2 bg-white/10 backdrop-blur-sm rounded-full px-4 py-2 text-sm text-white/90 tabular-nums"
+						data-testid="lightbox-page-header"
+					>
+						Page {current.page_index + 1} of {current.page_count}
+						{current.fragment_in_page !== undefined &&
+							current.fragments_per_page !== undefined &&
+							`, view ${current.fragment_in_page + 1} of ${current.fragments_per_page}`}
+					</div>
+				)}
+
 			<button
 				type="button"
 				onClick={(e) => {

--- a/packages/dashboard/lib/form-types.ts
+++ b/packages/dashboard/lib/form-types.ts
@@ -192,6 +192,14 @@ export type ImageField = BaseField & {
 	alt: string | null;
 	width: number | null;
 	height: number | null;
+	// Per-page metadata (AwaitVerify M5, optional). When present the
+	// carousel renders a two-level page selector + per-page nav. When
+	// absent (legacy tasks created before M5) the field renders in
+	// today's flat carousel — DO NOT crash on missing keys.
+	page_index?: number; // 0-indexed
+	fragment_in_page?: number; // 0-indexed within page
+	page_count?: number; // total pages
+	fragments_per_page?: number; // always 5 at v1
 };
 
 export type VideoField = BaseField & {


### PR DESCRIPTION
## Summary

When an AwaitVerify task's image fields carry per-page metadata (M5), the carousel now renders a two-level navigation: page selector on top, scoped carousel inside. Legacy / single-page tasks render exactly as today — no chrome change, no regression.

- **Top:** Compact tab strip `[1] [2] [3] ...` for ≤ 8 pages, numeric input `< Page N of M >` for > 8.
- **Inner:** Existing prev/next carousel scoped to one page's fragments. Counter changes from `K / 25` (flat) to `view K of 5` (this page).
- **Keyboard:** ← / → flow across page boundaries (→ on last fragment of page 1 lands on fragment 1 of page 2). PageDown / PageUp jump pages directly.
- **Lightbox:** Top header shows `Page N of M, view K of 5` when metadata is present.

## Design — pure helper + single flat index

The decision-making lives in a pure helper, `derivePageLayout(images: ImageField[])`, which returns either `{ kind: "flat", images }` or `{ kind: "paged", pages, pageCount, fragmentsPerPage }`. The carousel keeps a single flat `index` into `flattenLayout(layout)` — same shape as pre-PR. That's what lets ← / → step across page boundaries by just incrementing, and lets us pass the entire flat list to the lightbox without coordinate translation. The active page is derived from the current fragment's `page_index`.

Fallback to flat happens when:
- No image carries `page_index` (legacy task)
- `pages.length === 1` after grouping (defensive — managed shouldn't emit `page_count: 1` with metadata but the dashboard handles it)
- Empty input (renders nothing, no crash)

The grouping helper sorts both pages (by `page_index` ascending) and fragments within each page (by `fragment_in_page` ascending). Managed emits in order today, but client-side resilience is cheap.

## Backward compatibility

`ImageField`'s four new fields are all `?: number` — optional. Legacy tasks created before M5 omit them and continue through the flat-layout branch unchanged. No null checks needed downstream because `derivePageLayout` does the routing once at the top.

## Test plan

- [x] `npm test` in `packages/dashboard` — **89 passed** (22 new + 67 existing)
- [x] `npx tsc --noEmit` — clean
- [x] Pure-helper tests pin: empty input, legacy fields without metadata, single-page metadata collapses to flat, multi-page groups & sorts correctly, `fragmentsPerPage` fallback when declared count is missing.
- [x] Component tests pin: tab strip vs numeric input by page count, clicking tab N jumps to page N fragment 1, ← / → flows across boundaries, PageDown / PageUp jumps pages, active tab visually flips, per-page counter, lightbox header.
- [ ] **Reviewer (manual):**
  - [ ] Submit an AwaitVerify task with 3 pages × 5 fragments via the smoke — `[1] [2] [3]` tabs appear above the carousel.
  - [ ] Click `[2]` → fragment with `page_index=1, fragment_in_page=0` shows.
  - [ ] On last fragment of page 1, press → → page 2 fragment 1 appears AND active tab flips to `[2]`.
  - [ ] Press PageDown → page 3 fragment 1 directly.
  - [ ] Open the full-screen lightbox on page 2 fragment 3 → top header reads `Page 2 of 3, view 3 of 5`.
  - [ ] Open a legacy task (no page metadata) → page selector NOT present, carousel renders as today.
  - [ ] Submit a 12-page task → numeric `< Page 1 of 12 >` input appears instead of tabs.

## What's NOT in this PR

- No response-side rendering changes — only the image-section carousel grew page awareness. The submitted-response view (PR #171 / #172) is unaffected.
- No per-page response field grouping — the customer's `response_schema` is one Pydantic shape across the document. Page-keyed schemas are a customer modeling decision.
- No proxy URL or DEK changes — those are wire-level invariants the dashboard doesn't touch (M1 / M4 invariants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)