### PR TITLE
docs: add AwaitVerify Mintlify section (8 pages)

### DIFF
--- a/docs/awaitverify/errors.mdx
+++ b/docs/awaitverify/errors.mdx
@@ -1,0 +1,238 @@
+---
+title: "Errors"
+description: "Every exception verify_document() can raise, what triggers it, and the right fix."
+---
+
+`verify_document()` raises typed exceptions for every failure mode. Each one carries an `error_code` and a `docs_path` so you can pattern-match in code and route users to the right help page from your own UI.
+
+```python
+from awaithumans.awaitverify import (
+    VerifyDocumentArgError,
+    VerifyDocumentLoadError,
+    VerifyDocumentTooLargeError,
+    InsufficientBalanceError,
+    ExtractionFailedError,
+    ManagedBackendError,
+    OSSServerError,
+    OSSServerUnreachableError,
+    VerifyTimeoutError,
+    VerifyDepsMissingError,
+)
+```
+
+## At a glance
+
+| Exception | When it raises | Recoverable by code? |
+|---|---|---|
+| `VerifyDocumentArgError` | You passed conflicting arguments (e.g. both `prior_extraction` and `extraction`). | No: fix the call |
+| `VerifyDocumentLoadError` | The document can't be opened (corrupt PDF, unsupported format, LibreOffice missing). | Sometimes (retry with a different file) |
+| `VerifyDocumentTooLargeError` | Document exceeds 100 pages. | No: split the document |
+| `InsufficientBalanceError` | Account balance can't cover the page-count cost. | Yes (top up + retry) |
+| `ExtractionFailedError` | Flow B provider returned malformed output. | Sometimes (try a different prompt / model) |
+| `VerifyDepsMissingError` | A required package isn't installed (Pillow, pdf2image, provider SDK). | Yes: install the extra |
+| `ManagedBackendError` | Managed API rejected the request (auth, validation, schema mismatch). | Depends on error_code |
+| `OSSServerError` | OSS reviewer service returned a 4xx (auth or payload issue). | No: managed-side config bug, contact support |
+| `OSSServerUnreachableError` | OSS reviewer service unreachable (network blip, downtime). | Yes: retry |
+| `VerifyTimeoutError` | No reviewer submitted before `timeout_seconds`. | Yes: retry or extend timeout |
+
+## Detail per exception
+
+### `VerifyDocumentArgError`
+
+Conflicting or missing arguments to `verify_document()`. The most common triggers:
+
+- Passing both `prior_extraction=` and `extraction=` (pick one: Flow A or Flow B).
+- Passing neither `document_path=` nor `document_bytes=`.
+- Passing both `document_path=` and `document_bytes=`.
+- `response_schema` isn't a Pydantic `BaseModel` subclass.
+
+**Fix**: read the message; it tells you exactly which argument combination it rejected.
+
+### `VerifyDocumentLoadError`
+
+The SDK couldn't decode the document.
+
+```python
+try:
+    result = await verify_document(document_path="page.tiff", ...)
+except VerifyDocumentLoadError as exc:
+    print(f"Could not load: {exc}")
+    # Common causes:
+    # - The file isn't actually a supported format
+    # - PDF is encrypted or password-protected
+    # - Office document and LibreOffice isn't installed (install per the message)
+```
+
+For Office documents (DOCX, XLSX, PPTX), this often means LibreOffice isn't on PATH. Install it:
+
+```bash
+# macOS
+brew install --cask libreoffice
+
+# Debian / Ubuntu
+sudo apt-get install libreoffice
+```
+
+Override the binary location with `AWAITHUMANS_LIBREOFFICE_BIN`.
+
+### `VerifyDocumentTooLargeError`
+
+You hit the 100-page cap.
+
+```python
+try:
+    result = await verify_document(document_path="500-pages.pdf", ...)
+except VerifyDocumentTooLargeError as exc:
+    print(f"{exc.page_count} pages: limit is 100. Split the document.")
+```
+
+Workflow: extract pages 1-100, call verify_document, then 101-200, etc. The page split is on the customer side; we don't auto-split.
+
+### `InsufficientBalanceError`
+
+Pre-flight balance check failed.
+
+```python
+try:
+    result = await verify_document(...)
+except InsufficientBalanceError as exc:
+    print(f"Need ${exc.required_cents / 100:.2f}, have ${exc.balance_cents / 100:.2f}")
+    print("Top up at app.awaithumans.dev/billing")
+```
+
+Fields:
+
+- `balance_cents: int`: current balance
+- `required_cents: int`: what the call needed (`page_count × rate`)
+- `error_code: str`: `"INSUFFICIENT_BALANCE"` (stable for pattern-matching)
+- `docs_path: str`: `"insufficient-balance"` (deep-link helper)
+
+### `ExtractionFailedError`
+
+Flow B: the provider returned output that doesn't validate against your `response_schema`, or the provider call itself failed (timeout, rate limit, etc.).
+
+```python
+try:
+    result = await verify_document(
+        ...,
+        extraction=OpenAIExtraction(model="gpt-4o", prompt="..."),
+    )
+except ExtractionFailedError as exc:
+    print(f"Extraction failed: {exc}")
+    print("Available providers:")
+    print("  - OpenAIExtraction")
+    print("  - AnthropicExtraction")
+    print("  - ReductoExtraction")
+    print("  - ...")
+```
+
+You're not billed when this fires. The failure happens before the managed task is created.
+
+Common causes:
+- Prompt is too vague; the model didn't return all required fields. Tighten the prompt or simplify the schema.
+- Provider rate limit or transient outage. Retry with backoff.
+- Vision model picked a model name without vision support (e.g. `gpt-3.5-turbo`). Use a vision-capable model.
+
+### `VerifyDepsMissingError`
+
+A required package isn't installed.
+
+```python
+# Likely fix is one of:
+pip install "awaithumans[awaitverify]"               # base (Pillow, pdf2image, cryptography)
+pip install "awaithumans[awaitverify-openai]"        # Flow B with OpenAI
+pip install "awaithumans[awaitverify-anthropic]"     # Flow B with Anthropic
+# ...
+```
+
+The exception message names exactly which package is missing.
+
+### `ManagedBackendError`
+
+The managed API returned a 4xx or 5xx response. The exception carries:
+
+- `status_code: int`: HTTP status
+- `body: str`: raw response body (truncated to 500 chars)
+- `endpoint: str`: which managed endpoint was called
+- `error_code: str | None`: managed's `error_code` if it was a structured error
+- `docs_path: str | None`: managed's `docs_path` if provided
+
+Common status codes:
+
+- `401`: `AWAITHUMANS_API_KEY` is missing or invalid. Check the env var.
+- `402`: `InsufficientBalanceError` is the typed subclass; you shouldn't see plain `ManagedBackendError` here.
+- `422`: request body failed validation. The error message will name the field.
+- `5xx`: managed-side issue. Retry; if persistent, check status.awaithumans.dev.
+
+### `OSSServerError` / `OSSServerUnreachableError`
+
+The managed service couldn't reach or got a 4xx from the reviewer dashboard backend.
+
+- `OSSServerUnreachableError`: transient network issue between managed and OSS. Safe to retry; the original task is rolled back, so retry creates a fresh one.
+- `OSSServerError`: non-transient (auth misconfiguration, schema mismatch). Indicates a managed-side bug. Contact support. Your retry won't help.
+
+### `VerifyTimeoutError`
+
+No reviewer submitted before `timeout_seconds` elapsed.
+
+```python
+try:
+    result = await verify_document(
+        ...,
+        timeout_seconds=4 * 3600,  # 4 hours
+    )
+except VerifyTimeoutError as exc:
+    print(f"No reviewer in {exc.timeout_seconds}s. Retry with priority='high'?")
+```
+
+You're not billed for timed-out tasks. You can call `verify_document()` again with the same arguments to re-submit; the new task is independent.
+
+The default `timeout_seconds` is 48 hours, with a maximum of 30 days. Configure shorter timeouts for tasks that have business deadlines.
+
+## Pattern-matching by error_code
+
+For UI that surfaces our errors to your users, use the stable `error_code` strings rather than parsing exception messages:
+
+```python
+from awaithumans.awaitverify import ManagedBackendError, InsufficientBalanceError
+
+try:
+    result = await verify_document(...)
+except InsufficientBalanceError as exc:
+    show_top_up_prompt(exc.required_cents - exc.balance_cents)
+except ManagedBackendError as exc:
+    if exc.error_code == "RATE_LIMIT_EXCEEDED":
+        retry_with_backoff()
+    elif exc.error_code == "INVALID_SCHEMA":
+        log_schema_mismatch(exc.body)
+    else:
+        raise
+```
+
+## Debugging without leaking content
+
+When you log a `verify_document()` failure, log:
+
+- `error_code`
+- `task_id` (if the exception carries one)
+- `status_code` (for `ManagedBackendError`)
+- The exception class name
+
+Don't log:
+
+- The `document_bytes`
+- The `prior_extraction` (it may contain PII before the human review even ran)
+- The full exception `__str__()` if you're not sure what's in the body field
+
+Our error classes are careful not to embed document content in messages, but your wrapper code might.
+
+## Where to go next
+
+<CardGroup cols={2}>
+  <Card title="Pricing" icon="credit-card" href="/awaitverify/pricing">
+    How balance + the InsufficientBalanceError prevent surprise charges.
+  </Card>
+  <Card title="Security" icon="lock" href="/awaitverify/security">
+    Why our exception messages and our audit log never carry response content.
+  </Card>
+</CardGroup>

--- a/docs/awaitverify/flows.mdx
+++ b/docs/awaitverify/flows.mdx
@@ -1,0 +1,172 @@
+---
+title: "The three flows"
+description: "Flow A (human only), Flow B (model then human), Flow C (human then model). When to use each, with code."
+---
+
+`verify_document()` supports three flows. Most customers use Flow A or B; Flow C is the quality loop on top.
+
+## Decision table
+
+| Your situation | Use | Why |
+|---|---|---|
+| You already have an extractor (your code, your model, your OCR). You want a human to verify the output. | **Flow A** | Reviewer sees your extraction and corrects the cells the model got wrong. |
+| You don't have an extractor pipeline but you have an OpenAI / Anthropic / Reducto / Azure DI key. | **Flow B** | The SDK runs the model on your machine using your credentials. Reviewer sees the model output and corrects it. |
+| You want an AI verifier to recheck what the human typed. | **Flow C** (compose with A or B) | If the verifier disagrees with the human, the task re-routes back to a human. |
+
+## Flow A: Human only
+
+You provide the data. The reviewer confirms or corrects it against the document.
+
+```python
+import asyncio
+from pydantic import BaseModel
+from awaithumans import verify_document
+
+
+class Invoice(BaseModel):
+    invoice_number: str
+    total_cents: int
+
+
+async def main() -> None:
+    # Whatever you got out of your OCR / scraper / earlier pipeline step.
+    my_extraction = Invoice(invoice_number="INV-0042", total_cents=12500)
+
+    result = await verify_document(
+        document_path="invoice.pdf",
+        task_description="Confirm or correct the invoice number and total.",
+        response_schema=Invoice,
+        prior_extraction=my_extraction,    # Flow A signal
+    )
+
+    print(f"Reviewer returned: {result}")
+
+
+asyncio.run(main())
+```
+
+What the reviewer sees:
+
+- The document fragments (five masked views per page).
+- A response form pre-filled with `my_extraction`.
+- They edit, then submit.
+
+Best for: KYC pipelines where your model already runs in production but compliance requires a human spot-check on edge cases.
+
+## Flow B: Model then human
+
+You don't have your own extractor yet. The SDK runs one on your machine using your provider credentials, then sends both the document and the extracted result to the reviewer.
+
+```python
+import asyncio
+from pydantic import BaseModel
+from awaithumans import verify_document
+from awaithumans.providers import OpenAIExtraction
+
+
+class Receipt(BaseModel):
+    vendor: str
+    total_cents: int
+    purchase_date: str   # ISO 8601
+
+
+async def main() -> None:
+    result = await verify_document(
+        document_path="receipt.png",
+        task_description="Extract vendor, total in cents, and purchase date.",
+        response_schema=Receipt,
+        extraction=OpenAIExtraction(             # Flow B signal
+            model="gpt-4o",
+            prompt=(
+                "Read this receipt. Return vendor name, total in cents "
+                "(integer), and purchase date in ISO 8601."
+            ),
+        ),
+    )
+
+    print(result.vendor, result.total_cents, result.purchase_date)
+
+
+asyncio.run(main())
+```
+
+Providers we ship out of the box: OpenAI, Anthropic, Azure OpenAI, Reducto, Azure Document Intelligence, Docling (local), PaddleOCR (local). [Full provider list →](/awaitverify/providers)
+
+<Note>
+Your provider credentials never leave your machine. The SDK calls OpenAI / Anthropic / etc. directly from your process; only the extracted result + the encrypted fragments go to AwaitVerify.
+</Note>
+
+Best for: smaller teams who want one library to handle "OCR + human-in-the-loop" rather than wiring two separate vendors.
+
+## Flow C: Human then model (AI verifier loop)
+
+After the human submits, an AI verifier rechecks the response. If it flags a problem, the task re-routes to another human.
+
+```python
+import asyncio
+from pydantic import BaseModel
+from awaithumans import verify_document, VerifierConfig
+
+
+class ContractClause(BaseModel):
+    parties: list[str]
+    effective_date: str
+    auto_renew: bool
+
+
+async def main() -> None:
+    result = await verify_document(
+        document_path="contract.pdf",
+        task_description="Extract parties, effective date, and the auto-renew flag.",
+        response_schema=ContractClause,
+        verifier=VerifierConfig(                  # Flow C signal
+            provider="claude",
+            model="claude-3-5-sonnet-20241022",
+            criteria=(
+                "Verify that auto_renew is True only if the document "
+                "contains 'auto-renew' or 'automatic renewal' near the "
+                "termination clause."
+            ),
+        ),
+    )
+
+    print(result)
+
+
+asyncio.run(main())
+```
+
+Flow C can compose with either Flow A or Flow B. Pass both `prior_extraction=` (or `extraction=`) and `verifier=`; the SDK runs the extraction, the human verifies, then the AI verifier rechecks.
+
+Best for: high-stakes review where a single human reviewer is not enough (regulated compliance, fraud detection).
+
+## What happens between Submit and your return value
+
+The SDK long-polls the managed backend. When the reviewer submits:
+
+1. OSS server records the response, fires the callback to managed.
+2. Managed marks the task `completed`, destroys the wrapped DEK, deletes the encrypted fragments from blob storage.
+3. Your next `poll` call returns the typed response.
+4. Managed nulls its copy of the response in the same transaction.
+
+Net effect: after `verify_document()` returns, the response content lives only inside your Python process. [Security details →](/awaitverify/security)
+
+## Timeouts and retries
+
+`timeout_seconds` defaults to 48 hours and caps at 30 days. If no human submits before the timeout:
+
+- Standard priority: task times out, your `verify_document()` raises `VerifyTimeoutError`. You're not billed.
+- Express priority: same behavior but with a faster (configurable) SLA target. [Pricing →](/awaitverify/pricing)
+
+You can retry by calling `verify_document()` again with the same arguments. The SDK doesn't dedupe automatically; if you need idempotency, pass a stable `idempotency_key=` (the managed backend supports this on the `/tasks` endpoint).
+
+## Where to go next
+
+<CardGroup cols={2}>
+  <Card title="Response schemas" icon="brackets-curly" href="/awaitverify/response-schemas">
+    What Pydantic shapes the reviewer can edit comfortably (and what falls back to JSON).
+  </Card>
+  <Card title="Providers" icon="plug" href="/awaitverify/providers">
+    Flow B providers: OpenAI, Anthropic, Azure, Reducto, Docling, PaddleOCR.
+  </Card>
+</CardGroup>

--- a/docs/awaitverify/overview.mdx
+++ b/docs/awaitverify/overview.mdx
@@ -1,0 +1,98 @@
+---
+title: "AwaitVerify"
+description: "Managed human verification of automated document extraction. API in, typed Pydantic out."
+---
+
+AwaitVerify is the paid managed product on top of `awaithumans`. You call one function, we route the document through a human reviewer (or your AI extractor, then a human), and your agent gets back a typed Pydantic instance.
+
+```python
+result = await verify_document(
+    document_path="invoice.pdf",
+    task_description="Extract line items and totals.",
+    response_schema=Invoice,
+    prior_extraction=Invoice(...),    # optional: your initial guess
+)
+# result is an Invoice instance with the fields the reviewer confirmed/corrected.
+```
+
+## Who AwaitVerify is for
+
+Engineers building agents that have to read paper forms, handwritten tables, scanned IDs, multi-page contracts, claim PDFs, or any other document where an LLM alone is not safe enough yet. You wire `verify_document(...)` into your pipeline; the human review happens out-of-band; you get the typed result back as if it were a synchronous function call.
+
+The three flows we support, in one table:
+
+| Flow | When to use it | How it works |
+|---|---|---|
+| **A. Human only** | You already extracted the data (your code, your model, your OCR). | Pass `prior_extraction=YourModel(...)`. Reviewer verifies it against the document, corrects in place. |
+| **B. Model then human** | You don't have an extractor yet but you have an OpenAI / Anthropic / Reducto / Azure DI key. | Pass `extraction=OpenAIExtraction(model=..., prompt=...)`. SDK runs the model on your machine, sends both the document and the extraction to the reviewer. |
+| **C. Human then model** | You want an AI verifier loop on what the human typed. | Pass `verifier=VerifierConfig(...)`. After the human submits, the verifier rechecks the response. If it disagrees, the task re-routes back to a human. |
+
+[Flow details with code samples →](/awaitverify/flows)
+
+## What makes it different from "just call an LLM"
+
+1. **A real human is in the loop.** Founder pool today, then platform reviewers as we scale. The human sees the document and the extraction side by side and corrects the cells that the model got wrong.
+2. **Typed end-to-end.** You hand us a Pydantic model. You get back an instance of that model. No JSON twiddling, no string parsing, no "did GPT hallucinate this field" doubt.
+3. **Document never leaves your machine intact.** The SDK fragments the document into masked views client-side and encrypts each fragment with AES-256-GCM before upload. The reviewer sees five partial views per page; the full document is reconstructable only inside your Python process. [Security details →](/awaitverify/security)
+4. **You pay per page reviewed, not per request.** $0.80 standard, $1.60 Express. Failed tasks aren't billed. [Pricing →](/awaitverify/pricing)
+
+## Quickstart
+
+Install the extras, set your API key, call `verify_document`. [Five-minute walkthrough →](/awaitverify/quickstart)
+
+```bash
+pip install "awaithumans[awaitverify]"
+```
+
+```python
+import os
+from awaithumans import verify_document
+from pydantic import BaseModel
+
+os.environ["AWAITHUMANS_API_KEY"] = "ah_sk_live_..."
+
+class Receipt(BaseModel):
+    vendor: str
+    total_cents: int
+
+result = await verify_document(
+    document_path="receipt.png",
+    task_description="Confirm vendor name and total in cents.",
+    response_schema=Receipt,
+)
+print(result.vendor, result.total_cents)
+```
+
+## Multi-page documents
+
+PDFs, multi-page TIFFs, and DOCX files with multiple pages all work. The SDK rasterizes each page at 300 DPI, fragments each page into five masked views, and uploads. The reviewer sees a per-page carousel and verifies the extraction across pages.
+
+Cap at v1: 100 pages per call. Billing is per page reviewed (page count after rasterization).
+
+## API key
+
+Get your key from `app.awaithumans.dev/keys`. Set it as `AWAITHUMANS_API_KEY`, or pass an `AwaitHumans` client explicitly:
+
+```python
+from awaithumans import AwaitHumans
+
+client = AwaitHumans(api_key="ah_sk_live_...")
+result = await client.verify_document(...)
+```
+
+## Where to go next
+
+<CardGroup cols={2}>
+  <Card title="Quickstart" icon="rocket" href="/awaitverify/quickstart">
+    Install, first call, get a typed result back in five minutes.
+  </Card>
+  <Card title="The three flows" icon="route" href="/awaitverify/flows">
+    Flow A (human only), Flow B (model then human), Flow C (human then model).
+  </Card>
+  <Card title="Response schemas" icon="brackets-curly" href="/awaitverify/response-schemas">
+    Pydantic patterns including nested models and lists of objects.
+  </Card>
+  <Card title="Security model" icon="lock" href="/awaitverify/security">
+    Fragmentation, AES-256-GCM, the decrypt proxy, post-submit redaction.
+  </Card>
+</CardGroup>

--- a/docs/awaitverify/pricing.mdx
+++ b/docs/awaitverify/pricing.mdx
@@ -1,0 +1,98 @@
+---
+title: "Pricing"
+description: "Per page billing. Standard and Express priority. Top-up via Stripe. No charge for failed tasks."
+---
+
+AwaitVerify bills per page reviewed. No subscriptions, no minimums, no markup on the AI verifier in Flow C.
+
+## Rates
+
+| Priority | Per page | When to use |
+|---|---|---|
+| **Standard** | $0.80 | Default. Reviewer SLA target: under 24 hours, typically under 4 hours during business hours. |
+| **Express** | $1.60 (2×) | When you need a faster turnaround. Reviewer SLA target: under 1 hour, with priority routing. |
+
+Selected per call:
+
+```python
+result = await verify_document(
+    document_path="urgent-contract.pdf",
+    response_schema=Summary,
+    task_description="...",
+    priority="high",   # "high" = Express; default is "standard"
+)
+```
+
+## What counts as a page
+
+After we rasterize the document, one rendered page = one billed page. So:
+
+| Input | Page count |
+|---|---|
+| Single PNG / JPEG / single-page PDF | 1 |
+| Multi-page PDF (N pages) | N |
+| Multi-page TIFF (N frames) | N |
+| DOCX / XLSX / PPTX | The page count of the LibreOffice-rendered PDF |
+
+We cap at 100 pages per call. If you have a 500-page document, split it.
+
+## What doesn't get billed
+
+- **Failed tasks.** If the SDK can't load the document, if the OSS reviewer service is unreachable, or if the reviewer cancels the task before submitting, you're not billed. The pre-check happens before the debit.
+- **AI verifier loops in Flow C.** If the verifier disagrees and the task re-routes to a second human, the second review is included in the original page-count charge.
+- **Tasks that time out.** If no reviewer submits before `timeout_seconds`, the task expires and you're not billed.
+- **Provider calls in Flow B.** Your OpenAI / Reducto / Azure calls run on your machine with your credentials. We don't see them, we don't pass them through.
+
+## How balance works
+
+Sign up gives you a small free credit so you can run your first few smoke tests. After that you top up.
+
+- Open [app.awaithumans.dev/billing](https://app.awaithumans.dev/billing).
+- Pick an amount, pay with a card via Stripe.
+- The credit lands within seconds.
+
+Balance is checked at task creation time. If you don't have enough to cover the estimated cost of the call (`page_count × rate`), the call fails with `InsufficientBalanceError` before any work happens.
+
+## Low-balance warnings
+
+Configure a threshold from the billing page. When a debit takes your balance below the threshold for the first time, we send one email warning. The email contains a top-up link. No spam, one shot, you re-arm the warning by topping up.
+
+For programmatic monitoring, the `verify_document()` response includes a `low_balance_crossed` flag on the underlying managed task (read it from the `AwaitHumans` client if you need it):
+
+```python
+# Coming in v0.2: track the flag via the client.audit() API.
+# For v0.1 use the email threshold.
+```
+
+## Errors related to billing
+
+`InsufficientBalanceError` is raised when the pre-flight check fails:
+
+```python
+from awaithumans.awaitverify import InsufficientBalanceError
+
+try:
+    result = await verify_document(...)
+except InsufficientBalanceError as exc:
+    # exc.balance_cents: current balance
+    # exc.required_cents: what the call needed
+    # exc.docs_path: points back to this page
+    print(f"Add ${(exc.required_cents - exc.balance_cents) / 100:.2f} of credit at app.awaithumans.dev/billing")
+```
+
+The exception's `docs_path` field is `"insufficient-balance"`, so you can route users to the right help page from your own UI.
+
+## Enterprise / volume
+
+Above $5,000/month or specific compliance terms (BAA, SCC, audit-log retention beyond 30 days), email `enterprise@awaithumans.dev`. We do prepaid credits with custom invoicing and operator-grant transactions for the test sandbox.
+
+## Where to go next
+
+<CardGroup cols={2}>
+  <Card title="Errors" icon="circle-exclamation" href="/awaitverify/errors">
+    Every error class including InsufficientBalanceError + how to recover.
+  </Card>
+  <Card title="Security" icon="lock" href="/awaitverify/security">
+    What we retain about your billing (timestamps + amounts) vs. what we don't (response content).
+  </Card>
+</CardGroup>

--- a/docs/awaitverify/providers.mdx
+++ b/docs/awaitverify/providers.mdx
@@ -1,0 +1,206 @@
+---
+title: "Flow B providers"
+description: "Providers the SDK can run on your machine to produce an initial extraction. Your credentials never leave your process."
+---
+
+Flow B runs an extractor on your machine before the human review. The SDK calls the provider with your credentials, gets a structured extraction back, and ships both the document and the extraction to the reviewer.
+
+This page covers the providers we ship out of the box, the extras you install for each, and the minimum config to use them.
+
+## The contract
+
+Every provider type plugs into the same `extraction=` parameter:
+
+```python
+from awaithumans import verify_document
+from awaithumans.providers import OpenAIExtraction   # or whichever
+
+result = await verify_document(
+    document_path="invoice.pdf",
+    response_schema=Invoice,
+    extraction=OpenAIExtraction(
+        model="gpt-4o",
+        prompt="Extract invoice number and total in cents.",
+    ),
+    task_description="...",
+)
+```
+
+The SDK validates the provider output against your `response_schema` locally before sending. If the provider returns malformed JSON or fields that don't match, you get an `ExtractionFailedError` and nothing is sent to the reviewer (no charge).
+
+## LLM providers (vision capable)
+
+These read the document image directly and return structured output matching your schema.
+
+### OpenAI
+
+```bash
+pip install "awaithumans[awaitverify,awaitverify-openai]"
+```
+
+```python
+from awaithumans.providers import OpenAIExtraction
+
+extraction = OpenAIExtraction(
+    model="gpt-4o",                # or any vision-capable model
+    prompt="Extract X, Y, Z. Return JSON matching the schema.",
+    api_key=None,                  # defaults to OPENAI_API_KEY env var
+)
+```
+
+Reads `OPENAI_API_KEY` from your environment if `api_key=` isn't passed. Uses OpenAI's structured-output mode (response_format=json_schema) to guarantee the output matches your Pydantic schema.
+
+### Anthropic (Claude)
+
+```bash
+pip install "awaithumans[awaitverify,awaitverify-anthropic]"
+```
+
+```python
+from awaithumans.providers import AnthropicExtraction
+
+extraction = AnthropicExtraction(
+    model="claude-3-5-sonnet-20241022",
+    prompt="Extract X, Y, Z.",
+    api_key=None,                  # defaults to ANTHROPIC_API_KEY
+)
+```
+
+Uses Claude's tool-use API with your `response_schema` as the tool schema; the tool call response gets validated against Pydantic.
+
+### Azure OpenAI
+
+```bash
+pip install "awaithumans[awaitverify,awaitverify-azure-openai]"
+```
+
+```python
+from awaithumans.providers import AzureOpenAIExtraction
+
+extraction = AzureOpenAIExtraction(
+    deployment="gpt-4o-deployment-name",
+    endpoint="https://your-resource.openai.azure.com/",
+    api_version="2024-08-01-preview",
+    prompt="Extract X, Y, Z.",
+    api_key=None,                  # defaults to AZURE_OPENAI_API_KEY
+)
+```
+
+Same code path as OpenAI but pointed at your Azure deployment. Useful for customers on Azure-only data-residency requirements.
+
+## Document extraction providers (SaaS)
+
+These do OCR + layout analysis and return structured JSON. Pair them with a `StructuringConfig` to map the raw extraction to your Pydantic schema.
+
+### Reducto
+
+```bash
+pip install "awaithumans[awaitverify,awaitverify-reducto]"
+```
+
+```python
+from awaithumans.providers import ReductoExtraction, OpenAIStructuring
+
+extraction = ReductoExtraction(
+    api_key=None,                  # defaults to REDUCTO_API_KEY
+    structuring=OpenAIStructuring(
+        model="gpt-4o-mini",       # used to map Reducto output to your schema
+        api_key=None,
+    ),
+)
+```
+
+Reducto's `/extract` endpoint returns structured data; the `StructuringConfig` is the LLM that maps it to your specific Pydantic shape. Best for documents with complex layouts (multi-column, mixed text + tables).
+
+### Azure Document Intelligence
+
+```bash
+pip install "awaithumans[awaitverify,awaitverify-azure-di]"
+```
+
+```python
+from awaithumans.providers import AzureDIExtraction, OpenAIStructuring
+
+extraction = AzureDIExtraction(
+    endpoint="https://your-resource.cognitiveservices.azure.com/",
+    api_key=None,                  # defaults to AZURE_DI_API_KEY
+    model_id="prebuilt-invoice",   # or prebuilt-document, prebuilt-receipt, etc.
+    structuring=OpenAIStructuring(model="gpt-4o-mini"),
+)
+```
+
+Best for documents that match one of Azure's prebuilt extraction models (invoices, receipts, IDs).
+
+## Local providers (no API calls)
+
+Run entirely on your machine. No credentials, no per-request cost. Slower, depending on your hardware.
+
+### Docling
+
+```bash
+pip install "awaithumans[awaitverify,awaitverify-docling]"
+```
+
+```python
+from awaithumans.providers import DoclingExtraction, OpenAIStructuring
+
+extraction = DoclingExtraction(
+    structuring=OpenAIStructuring(model="gpt-4o-mini"),
+)
+```
+
+Open-source OCR + layout analysis from IBM. Runs locally. The structuring step still uses an LLM unless you swap in a deterministic mapper.
+
+### PaddleOCR
+
+```bash
+pip install "awaithumans[awaitverify,awaitverify-paddleocr]"
+```
+
+```python
+from awaithumans.providers import PaddleOCRExtraction, OpenAIStructuring
+
+extraction = PaddleOCRExtraction(
+    structuring=OpenAIStructuring(model="gpt-4o-mini"),
+)
+```
+
+Open-source OCR. Best for plain-text documents where you only need text extraction (then structure with an LLM).
+
+## Comparison
+
+| Provider | What it does | Best for | Cost model |
+|---|---|---|---|
+| OpenAI | Vision LLM, structured output | Anything text or table | Per token |
+| Anthropic | Vision LLM, tool use | Anything text or table | Per token |
+| Azure OpenAI | Vision LLM via Azure | Azure-only deployments | Per token |
+| Reducto | SaaS OCR + layout | Complex layouts, multi-column | Per page |
+| Azure DI | SaaS OCR + prebuilt models | Invoices, receipts, IDs | Per page |
+| Docling | Local OCR + layout | Air-gapped envs, batch jobs | Compute only |
+| PaddleOCR | Local OCR | Plain text, batch jobs | Compute only |
+
+## Credentials never leave your machine
+
+The SDK calls every provider from your Python process. Your `OPENAI_API_KEY`, `REDUCTO_API_KEY`, etc. are read from your environment (or passed to the constructor) and used to make the provider request directly. AwaitVerify's managed backend never sees provider credentials. We only receive:
+
+- The encrypted document fragments
+- The extracted result (after your provider returned it)
+- The task metadata you attach
+
+## What if my provider isn't on the list?
+
+Two options:
+
+1. **Use Flow A.** Run your provider on your machine, then pass the result as `prior_extraction=YourModel(...)`. We don't need to support your provider directly; we just need the Pydantic instance.
+2. **Open an issue.** New providers land based on real demand. PR welcome too. The provider interface is in `awaithumans.providers.base`.
+
+## Where to go next
+
+<CardGroup cols={2}>
+  <Card title="The three flows" icon="route" href="/awaitverify/flows">
+    Flow A (you bring the extraction) vs Flow B (SDK runs the provider).
+  </Card>
+  <Card title="Response schemas" icon="brackets-curly" href="/awaitverify/response-schemas">
+    The Pydantic shape determines the provider's output schema too.
+  </Card>
+</CardGroup>

--- a/docs/awaitverify/quickstart.mdx
+++ b/docs/awaitverify/quickstart.mdx
@@ -1,0 +1,144 @@
+---
+title: "AwaitVerify quickstart"
+description: "Install, make your first verify_document() call, and get a typed result back in five minutes."
+---
+
+By the end of this page you'll have:
+
+- An AwaitVerify API key.
+- A Python script that uploads a document and waits for a human to verify the extraction.
+- That extraction flowing back into your code as a typed Pydantic instance.
+
+## 1. Install the extras
+
+```bash
+pip install "awaithumans[awaitverify]"
+```
+
+The `awaitverify` extra adds Pillow (raster image handling), pdf2image (PDF rasterization), and cryptography (client-side AES-256-GCM encryption). The base `awaithumans` package stays lightweight; you only opt into these when you use AwaitVerify.
+
+<Note>
+For Flow B (the SDK runs an extractor on your machine first), add the provider extra too:
+
+```bash
+pip install "awaithumans[awaitverify,awaitverify-openai]"      # OpenAI
+pip install "awaithumans[awaitverify,awaitverify-anthropic]"   # Anthropic
+pip install "awaithumans[awaitverify,awaitverify-reducto]"     # Reducto
+pip install "awaithumans[awaitverify,awaitverify-azure-di]"    # Azure Document Intelligence
+```
+
+[Full provider list →](/awaitverify/providers)
+</Note>
+
+## 2. Get an API key
+
+Sign in at [app.awaithumans.dev](https://app.awaithumans.dev), open the **API keys** page, click **Create key**. Copy the `ah_sk_live_...` value once; you can't see it again.
+
+Set it as an environment variable:
+
+```bash
+export AWAITHUMANS_API_KEY="ah_sk_live_..."
+```
+
+The dashboard also shows your current balance. New accounts start with a free trial credit. [Pricing →](/awaitverify/pricing)
+
+## 3. Define your response shape
+
+The reviewer is going to fill out a form that matches your Pydantic schema. Define what you want back:
+
+```python
+from pydantic import BaseModel, Field
+
+
+class LineItem(BaseModel):
+    description: str = Field(description="What the line is for")
+    amount_cents: int = Field(description="Price in cents")
+
+
+class Invoice(BaseModel):
+    invoice_number: str
+    total_cents: int
+    line_items: list[LineItem]
+```
+
+Anything that's a `BaseModel` becomes a section. Anything that's a `list[BaseModel]` becomes a spreadsheet-style editable table on the reviewer's dashboard. [Schema patterns →](/awaitverify/response-schemas)
+
+## 4. Call verify_document
+
+```python
+import asyncio
+from awaithumans import verify_document
+
+async def main() -> None:
+    result = await verify_document(
+        document_path="invoice.pdf",
+        task_description=(
+            "Extract the invoice number, total in cents, and every "
+            "line item. If a line item amount is illegible, leave the "
+            "row in but flag the description with [unclear]."
+        ),
+        response_schema=Invoice,
+        timeout_seconds=24 * 3600,
+    )
+
+    print(f"Invoice {result.invoice_number} totals ${result.total_cents / 100:.2f}")
+    for item in result.line_items:
+        print(f"  {item.description}: ${item.amount_cents / 100:.2f}")
+
+asyncio.run(main())
+```
+
+`verify_document()` is async; the SDK long-polls the managed backend until the reviewer submits. For a synchronous flow, wrap the call:
+
+```python
+from awaithumans import verify_document_sync
+
+result = verify_document_sync(
+    document_path="invoice.pdf",
+    task_description="...",
+    response_schema=Invoice,
+    timeout_seconds=24 * 3600,
+)
+```
+
+## 5. The reviewer's side
+
+The moment your script hits the managed backend, the task lands in our reviewer dashboard:
+
+1. A reviewer opens the task.
+2. They see the document fragments (five masked views per page, decrypted and streamed through our proxy on demand).
+3. The form is pre-filled if you supplied `prior_extraction=` or `extraction=`; otherwise it's blank.
+4. They edit cells, add rows, correct what the model got wrong, and click **Submit**.
+
+Your `verify_document()` call returns the typed `Invoice` instance with the reviewer's corrections.
+
+## 6. Multi-page documents
+
+PDFs, multi-page TIFF, and Office docs (DOCX, XLSX, PPTX via LibreOffice) all work without extra config. The SDK detects the page count, rasterizes at 300 DPI, and uploads each page's fragments. The reviewer's dashboard shows a per-page carousel.
+
+```python
+result = await verify_document(
+    document_path="five-page-contract.pdf",   # any page count up to 100
+    task_description="Extract the parties, dates, and signed amounts.",
+    response_schema=ContractSummary,
+)
+```
+
+Billing scales linearly: `$0.80 × page_count` for standard priority.
+
+## Where to go next
+
+<CardGroup cols={2}>
+  <Card title="The three flows" icon="route" href="/awaitverify/flows">
+    Skip blind human review with Flow A or Flow B. Add an AI verifier with Flow C.
+  </Card>
+  <Card title="Response schemas" icon="brackets-curly" href="/awaitverify/response-schemas">
+    Patterns for nested models, tables, optionals, and multi-page response shapes.
+  </Card>
+  <Card title="Security" icon="lock" href="/awaitverify/security">
+    What the reviewer sees, what they don't, how the document stays encrypted.
+  </Card>
+  <Card title="Errors" icon="circle-exclamation" href="/awaitverify/errors">
+    Every exception, what triggers it, and the right fix.
+  </Card>
+</CardGroup>

--- a/docs/awaitverify/response-schemas.mdx
+++ b/docs/awaitverify/response-schemas.mdx
@@ -1,0 +1,199 @@
+---
+title: "Response schemas"
+description: "What Pydantic shapes the reviewer can edit comfortably. Primitives, nested models, lists of objects, multi-page patterns."
+---
+
+The reviewer's form is generated from your `response_schema` automatically. The shape you pass determines what they type into. This page lists every shape that renders well, and what falls back to a JSON textarea.
+
+## Primitives
+
+Map cleanly to form fields.
+
+```python
+from enum import Enum
+from pydantic import BaseModel, Field
+
+
+class Priority(str, Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class TicketSummary(BaseModel):
+    subject: str = Field(max_length=120)         # short_text
+    description: str                             # long_text (no max_length)
+    customer_count: int                          # number input
+    refund_amount: float                         # number input (decimals)
+    has_attachments: bool                        # switch (Yes/No)
+    priority: Priority                           # single_select dropdown
+```
+
+| Pydantic type | Reviewer sees |
+|---|---|
+| `str` with `max_length <= 200` | Single-line text input |
+| `str` with no max or `max_length > 200` | Multi-line textarea |
+| `int`, `float` | Number input (with decimal support for floats) |
+| `bool` | Yes/No toggle |
+| `Enum` of strings | Dropdown of the enum values |
+
+## Optional fields
+
+`Optional[X]` flattens to the underlying type. The form field is unrequired but renders as the inner kind, not as a generic JSON textarea.
+
+```python
+from typing import Optional
+
+
+class Receipt(BaseModel):
+    vendor: str                                  # required short_text
+    tip_cents: Optional[int] = None              # optional number input
+    notes: Optional[str] = Field(                # optional multi-line
+        default=None,
+        description="Anything that wouldn't fit the structured fields above"
+    )
+```
+
+## Nested objects
+
+Render as an indented section with the inner fields stacked vertically. Useful for grouping related data.
+
+```python
+class Address(BaseModel):
+    street: str = Field(max_length=120)
+    city: str = Field(max_length=80)
+    postal_code: str = Field(max_length=20)
+
+
+class Person(BaseModel):
+    full_name: str = Field(max_length=80)
+    date_of_birth: str                           # ISO 8601 date
+    address: Address                             # nested → object_group
+```
+
+## Lists of objects (the killer feature)
+
+`list[BaseModel]` becomes a **spreadsheet-style editable table** on the reviewer's dashboard. One column per property of the element model. The reviewer adds rows, edits cells inline, removes rows.
+
+```python
+class LineItem(BaseModel):
+    description: str = Field(max_length=120)
+    quantity: int
+    unit_price_cents: int
+    total_cents: int
+
+
+class Invoice(BaseModel):
+    invoice_number: str = Field(max_length=64)
+    issued_at: str                               # ISO 8601 date
+    total_cents: int
+    line_items: list[LineItem]                   # → spreadsheet table
+```
+
+What the reviewer sees for `line_items`:
+
+```
+description           | quantity | unit_price_cents | total_cents
+----------------------|----------|------------------|------------
+Widget A              | 2        | 2500             | 5000
+Widget B              | 3        | 2500             | 7500
+[+ Add row]
+```
+
+This is the right shape for invoices, receipts, claim line items, table rows from scanned forms, any data that's intrinsically tabular.
+
+## Multi-page response patterns
+
+Three common ways to structure a response for a multi-page document. Pick the one that matches your downstream code; the SDK doesn't enforce any particular pattern.
+
+### Pattern 1: Flat list across all pages (simplest)
+
+```python
+class Invoice(BaseModel):
+    invoice_number: str
+    line_items: list[LineItem]   # reviewer aggregates from every page
+```
+
+The reviewer sees one spreadsheet table with all line items. Easy to consume downstream. Loses per-page provenance.
+
+### Pattern 2: Page-keyed structure
+
+```python
+class PageData(BaseModel):
+    page_title: str
+    rows: list[LineItem]
+
+
+class Document(BaseModel):
+    pages: list[PageData]         # one entry per page
+```
+
+Renders as a `repeatable_group` (spreadsheet) where each row is itself a section (the per-page object). The reviewer adds one row per page and fills in the section per row. Useful when your downstream code reasons about pages explicitly.
+
+### Pattern 3: Top-level totals + nested table
+
+```python
+class Invoice(BaseModel):
+    invoice_number: str
+    total_cents: int                  # roll-up across pages
+    line_items: list[LineItem]        # flat table, reviewer aggregates
+
+
+class Submission(BaseModel):
+    documents: list[Invoice]          # one invoice per document if you batch
+```
+
+Use when one customer call submits a batch of related documents.
+
+## Fields and constraints we recognize
+
+| Pydantic feature | Effect on the form |
+|---|---|
+| `Field(description="...")` | Becomes the hint text under the field |
+| `Field(title="...")` | Becomes the field label (overrides the property name) |
+| `Field(max_length=N)` | Short vs long text rendering (≤200 → short) |
+| `Field(min_length=N)` | Validation hint, shown on submit if violated |
+| `Field(default=...)` | Used as the field's initial value if no `prior_extraction` is supplied |
+
+## What doesn't render well (yet)
+
+Some shapes fall back to a long_text JSON textarea. The reviewer can still submit (by typing JSON), but the UX isn't ideal. v1 limitations:
+
+- `Union[str, int]` and similar multi-variant unions
+- Discriminated unions
+- Self-referential schemas (a model that references itself)
+- Schemas nested deeper than 6 levels
+
+For these, restructure your schema (often flattening one level is enough) or open an issue describing your case. We add coverage based on real usage.
+
+## Examples
+
+The smoke test we use in CI is a real reference for what works:
+
+```python
+from pydantic import BaseModel, Field
+
+
+class LineItem(BaseModel):
+    description: str = Field(description="What the line is for")
+    amount_cents: int = Field(description="Price in cents")
+
+
+class InvoiceExtraction(BaseModel):
+    invoice_number: str
+    total_cents: int
+    line_items: list[LineItem]
+```
+
+A reviewer takes ~30 seconds to verify a 5-line invoice with this shape.
+
+## Where to go next
+
+<CardGroup cols={2}>
+  <Card title="The three flows" icon="route" href="/awaitverify/flows">
+    Combine schemas with Flow A (prior_extraction) for pre-filled forms.
+  </Card>
+  <Card title="Providers" icon="plug" href="/awaitverify/providers">
+    Flow B: which provider you pick affects how the extraction maps to your schema.
+  </Card>
+</CardGroup>

--- a/docs/awaitverify/security.mdx
+++ b/docs/awaitverify/security.mdx
@@ -1,0 +1,138 @@
+---
+title: "Security model"
+description: "Client-side AES-256-GCM fragmentation, decrypt proxy, post-submit redaction, DEK destruction. What we keep, what we don't."
+---
+
+This page is the full story of what happens to the bytes of your document between `verify_document()` and the typed result your code receives back. The short version:
+
+> The full document never reaches AwaitVerify infrastructure intact. The SDK fragments and encrypts client-side; the reviewer sees masked views through a managed decrypt proxy; the response content is destroyed everywhere except your Python process after the round-trip completes.
+
+## What lives where, at every stage
+
+| Stage | What we have | Encrypted? | Survives the round-trip? |
+|---|---|---|---|
+| 1. SDK loads + rasterizes | Raw document (plaintext) | n/a (your machine) | Your process only |
+| 2. SDK fragments + encrypts | Five masked views per page, encrypted | AES-256-GCM, key generated in your process | Ciphertext uploads to Azure Blob |
+| 3. Managed receives upload | Wrapped DEK (only) | KEK-wrapped, KEK derived from PAYLOAD_KEY | Yes, in managed DB |
+| 4. Task POSTed to OSS reviewer | Signed proxy URLs (one per fragment) | URLs are HMAC-signed, content is still ciphertext | URLs expire with the task |
+| 5. Reviewer browser fetches | Plaintext fragment (streamed) | Decrypted server-side, streamed over TLS | Browser memory only |
+| 6. Reviewer submits | Response JSON (plaintext) | TLS in transit | Briefly in OSS DB, briefly in managed DB |
+| 7. Callback delivered to managed | Response forwarded | TLS, HMAC-signed | Yes |
+| 8. SDK polls + gets response | Typed Pydantic instance | TLS | Your process only |
+| 9. **After the round-trip** | Metadata + timestamps + reviewer attribution | n/a | We retain metadata; response content is gone |
+
+## Layer 1: Client-side fragmentation
+
+The SDK runs entirely on your machine. It:
+
+1. Loads the document (PDF, image, or office doc via LibreOffice).
+2. Rasterizes each page at 300 DPI.
+3. For each page, creates five masked views. Each one blacks out approximately 50% of the page using a different mask geometry. No single fragment shows more than half the page.
+4. Encrypts each fragment with a per-task data-encryption key (DEK).
+
+The full document image never leaves your process intact. A reviewer who saw all five fragments still wouldn't reconstruct the original without piecing them together visually, and they only see one at a time in the dashboard carousel.
+
+## Layer 2: Envelope encryption (AES-256-GCM)
+
+Two keys, two layers:
+
+- **DEK (Data Encryption Key)**. 32 bytes, generated fresh per task with `os.urandom(32)` in your SDK process.
+  - Used to encrypt each fragment via AES-256-GCM (`encrypt_fragment(plaintext, dek)`).
+  - Sent to managed wrapped under the KEK (see below). The plaintext DEK never reaches our servers.
+- **KEK (Key Encryption Key)**. HKDF-SHA256 derivation off `PAYLOAD_KEY` (a managed-server-only secret stored in Infisical).
+  - Used to wrap the DEK. The wrapped DEK lives in our database.
+  - Never transmitted, never persisted unwrapped.
+
+This is the standard envelope-encryption pattern. A breach of our database leaks wrapped DEKs that an attacker can't unwrap without `PAYLOAD_KEY`. A breach of `PAYLOAD_KEY` (e.g. our Infisical credentials) leaks the ability to unwrap DEKs but requires also exfiltrating the encrypted fragments from Azure Blob.
+
+## Layer 3: The decrypt proxy
+
+The reviewer's browser doesn't decrypt anything. It can't. The wrapped DEK is in our database, not in the dashboard. Instead, the dashboard renders `<img src="...">` with a URL that points at the managed decrypt proxy:
+
+```
+https://api.awaithumans.dev/api/v1/awaitverify/tasks/{task_id}/fragments/{i}/view?token={hmac_signed}
+```
+
+The proxy:
+
+1. Verifies the HMAC token (bound to `task_id` + `fragment_index` + `expires_at`).
+2. Looks up the wrapped DEK from the upload session.
+3. Unwraps it with the KEK.
+4. Fetches the encrypted blob from Azure Storage.
+5. Decrypts in memory.
+6. Streams plaintext PNG bytes to the reviewer's browser with `Cache-Control: private` and `X-Content-Type-Options: nosniff`.
+
+The wrapped DEK never leaves the managed process; the plaintext DEK exists only in the duration of one decrypt call.
+
+Token failures (signature, expiry, path mismatch) all collapse to HTTP 403 with no body so an attacker can't tell which check failed.
+
+## Layer 4: Post-submit redaction
+
+When the reviewer hits Submit:
+
+1. **Wrapped DEK destruction.** Managed nulls `upload_sessions.wrapped_dek`. After this, fragments stored against this task are **cryptographically unrecoverable** even with full filesystem access to our database and storage.
+2. **Fragment blob deletion.** Managed deletes each encrypted fragment from Azure Blob. The ciphertext bytes are gone from storage entirely.
+3. **OSS-side response redaction.** OSS dispatches the callback to managed; on 2xx, OSS nulls its own copy of `response_json` and stamps `response_redacted_at`. The dashboard's submitted-response view renders a "delivered, content redacted" panel from that point onward.
+4. **Managed-side claim-and-null.** The SDK's poll endpoint returns the response in the same SQL transaction that nulls `verification_tasks.response_json`. Subsequent polls see the completed-but-empty state.
+
+Net effect: after `verify_document()` returns, the response content lives only inside your Python process. Our audit trail keeps timestamps, customer/task IDs, reviewer attribution, and billing. Nothing about the response **content**.
+
+## What we retain
+
+For each task, we keep indefinitely:
+
+- Task ID, customer ID, task description (the prompt you sent, not the document)
+- Status transitions (created → awaiting_review → completed) with timestamps
+- Reviewer attribution (which operator submitted), method (dashboard / Slack), submission time
+- Billing entries (amount, source, balance after)
+- Failed-task error logs (which exception triggered, no response content)
+
+We do **not** keep, after the round-trip:
+
+- The document plaintext
+- The response content
+- The wrapped DEK
+- The encrypted fragments in Azure
+
+## In transit
+
+- TLS 1.2+ on every API call. SDK to managed, managed to OSS, OSS to reviewer browser, reviewer to OSS.
+- HMAC signing on:
+  - OSS → managed webhook callbacks (`X-Awaithumans-Signature`)
+  - Managed → reviewer decrypt-proxy URLs (token in URL)
+- The SDK validates the managed-server certificate as part of the standard `httpx` TLS handshake.
+
+## Operator and credential management
+
+- All managed-service runtime secrets (DB URL, OSS admin token, payload key, Stripe webhook secret, Slack tokens) are fetched from Infisical on container boot. Nothing is baked into the image.
+- Postgres uses managed-identity credentials with a rotated password. Reviewer service shares the same Postgres server but a separate database (`awaithumans_reviewers` vs `awaithumans_managed`).
+- GitHub Actions has bootstrap credentials only (Azure login + Infisical client ID/secret). No application-level secrets in repo settings.
+
+## Compliance posture
+
+- **Delaware C-corp**. Governing law for the customer contract.
+- **Audit log retention**: indefinite for task metadata, until reviewer submit for response content (which then gets destroyed per the above).
+- **BAA / SCC / per-account audit-log retention** beyond what's described above: enterprise tier. Email `compliance@awaithumans.dev`.
+
+## How to verify all this
+
+1. **The SDK fragmentation code is in your install.** `pip show -f awaithumans` lists `awaithumans/awaitverify/fragmentation.py` and `awaithumans/awaitverify/_encryption.py`. Read them. The plaintext DEK is generated in your process, the encryption happens in your process, only ciphertext is uploaded.
+2. **The proxy is the only path to plaintext fragments.** Try fetching one of our Azure Blob URLs directly with a browser. You'll see ciphertext bytes, not an image.
+3. **Post-submit, the proxy returns 404.** After a task completes, hit the same proxy URL with a valid token. You get 404 (the wrapped DEK is destroyed, the blob is gone).
+
+## What's intentionally out of scope (v1)
+
+- **Multi-tenant operator separation.** All our reviewers see all tasks. Per-customer reviewer pools land post-launch.
+- **Customer-side encryption of the response.** Today the response is plaintext over TLS to your SDK. End-to-end response encryption (you pass a public key, the reviewer's submission encrypts to it) is on the roadmap.
+- **Air-gapped on-prem reviewer.** Enterprise customers can run their own reviewer dashboard (the OSS `awaithumans` server is the same code) but Phase 1 ships only the managed reviewer pool.
+
+## Where to go next
+
+<CardGroup cols={2}>
+  <Card title="Errors" icon="circle-exclamation" href="/awaitverify/errors">
+    What goes wrong, how to debug it without leaking content into logs.
+  </Card>
+  <Card title="Pricing" icon="credit-card" href="/awaitverify/pricing">
+    What we retain about your billing vs. what we don't.
+  </Card>
+</CardGroup>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -58,6 +58,19 @@
             ]
           },
           {
+            "group": "AwaitVerify",
+            "pages": [
+              "awaitverify/overview",
+              "awaitverify/quickstart",
+              "awaitverify/flows",
+              "awaitverify/response-schemas",
+              "awaitverify/providers",
+              "awaitverify/pricing",
+              "awaitverify/security",
+              "awaitverify/errors"
+            ]
+          },
+          {
             "group": "Routing",
             "pages": [
               "routing/overview"


### PR DESCRIPTION
## Summary

Closes the docs gap blocking the AwaitVerify launch announcement. Mintlify had zero AwaitVerify entries; customers landing on docs.awaithumans.dev after the launch would find ``await_human()`` quickstart but nothing on ``verify_document()``.

Eight pages totaling ~1300 lines:

| Page | Lines | Covers |
|---|---|---|
| overview.mdx | 98 | What it is, decision table, multi-page note |
| quickstart.mdx | 144 | Install, API key, first call, typed result |
| flows.mdx | 172 | Flow A / Flow B / Flow C with code |
| response-schemas.mdx | 199 | Pydantic patterns + multi-page schema patterns |
| providers.mdx | 206 | Flow B providers + comparison table |
| pricing.mdx | 98 | Rates, page rules, what's free |
| security.mdx | 138 | Fragmentation, envelope encryption, redaction |
| errors.mdx | 238 | Every exception + pattern-matching by error_code |

``docs/docs.json`` gets a new ``AwaitVerify`` group between ``Channels`` and ``Routing``.

## Style notes

- Em dashes stripped throughout per the no-em-dash project rule.
- Every page ends with a ``CardGroup`` to keep readers moving forward.
- Code samples use real Pydantic shapes from the smoke test (``InvoiceExtraction`` with nested ``LineItem``).

## Test plan
- [x] ``python -c 'import json; json.load(open(\"docs/docs.json\"))'`` validates.
- [x] All 8 ``.mdx`` files have correct frontmatter + render without missing internal links (every cross-reference points to a page that exists in this PR).
- [ ] Mintlify preview deploy on the PR: review headings + code blocks render.
- [ ] After merge: live at ``docs.awaithumans.dev/awaitverify/overview``.

## Out of scope

- O10 (page-grouped carousel) is in flight separately; the multi-page section here describes what we *will* ship in O10. Once O10 lands and the dashboard groups fragments by page, the section is already accurate.
- Webhooks for callback delivery (Phase 4): mentioned in errors.mdx as ``coming in v0.2`` but no dedicated page yet.
- On-prem reviewer deployments: noted as enterprise-tier in security.mdx, no dedicated page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)