### PR TITLE
release: v0.1.10 (OpenAI Responses API + Azure DI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,40 +14,88 @@ into a versioned release when tagged.
 
 ---
 
-## [0.1.9] — 2026-06-04
+## [0.1.10] — 2026-06-04
 
-Two P0 SDK fixes surfaced during a live customer demo. Both affect any
-customer using the Python SDK without environment overrides.
+Combined release covering the work that landed between 0.1.8 and now.
+0.1.9 was bumped in source for the `managed_url` and upload-path
+fixes but never published to PyPI; those fixes are included here.
 
 ### Fixed
 
-- **`managed_url` default points at the production custom domain.** The
-  Python SDK previously defaulted `managed_url` to the raw Azure
+- **OpenAI Flow B and Flow C migrated to the Responses API.** GPT-5.x
+  Azure deployments reject the older `chat.completions` +
+  `response_format` shape with "Unsupported parameter:
+  'response_format'. In the Responses API, this parameter has moved to
+  'text.format'." Every call site that used the old shape
+  (`_extract_openai`, `_extract_azure_openai`, the structuring step,
+  and both OpenAI + Azure OpenAI verifier providers) now calls
+  `sdk.responses.create` with `text={"format": {...}}`. The same code
+  path serves gpt-4o, gpt-5, and o-series uniformly with no per-model
+  branching and no caller-facing toggle. Image content blocks also
+  declare `detail="auto"` so behavior is deterministic across
+  providers (Azure tolerated omission, OpenAI direct does not).
+- **Reducto SDK updated to the v3 upload-then-extract shape.** The old
+  signature (`extract.run(document=, schema=, model=)`) has long been
+  replaced by `upload(file=...)` then `extract.run(input=<URL>,
+  instructions={"schema": ..., "system_prompt": ...})`. Flow B with
+  `ReductoExtraction` now works against the current SDK. The upload
+  step sniffs the document's magic bytes to pick the right filename
+  extension so Reducto does not reject mislabeled documents with 415
+  DOCUMENT_CORRUPT.
+- **Gemini verifier schema converter no longer drops property names.**
+  `_to_gemini_schema` previously recursed into `properties` and
+  treated every property name as a schema keyword to be filtered.
+  With `VERIFIER_OUTPUT_SCHEMA` that meant `passed`, `reason`, and
+  `parsed_response` were stripped, leaving `required` referencing
+  properties that no longer existed and Gemini 400ing the request.
+  The converter now preserves `properties` name maps verbatim and
+  only filters inside subschemas.
+- **`managed_url` default points at the production custom domain.**
+  The Python SDK previously defaulted `managed_url` to the raw Azure
   Container Apps hostname, which does not resolve from customer
   machines. A clean `pip install awaithumans` with only
   `AWAITHUMANS_API_KEY` set now succeeds end-to-end against
   `https://api.awaithumans.dev` without any URL override. The first
   call to `verify_document` also emits an INFO log line showing the
   resolved `managed_url`, so future misconfigurations (typos, stale
-  staging URLs, forgotten overrides) surface in customer logs instead
-  of a DNS stack trace.
+  staging URLs, forgotten overrides) surface in customer logs
+  instead of a DNS stack trace.
 - **Upload path tolerates slow uplinks.** The per-PUT timeout for
-  uploading encrypted fragments to Azure Blob signed URLs is now 300s
-  (was 30s). On a normal residential uplink, a multi-page document
-  opens 20-30 parallel TLS PUTs and individual writes can legitimately
-  stall past 30s under saturation. Concurrency is now bounded at 8
-  (`AWAITVERIFY_UPLOAD_CONCURRENCY`) so a many-fragment document never
-  melts the customer's uplink. The new
+  uploading encrypted fragments to Azure Blob signed URLs is now
+  300s (was 30s). On a normal residential uplink, a multi-page
+  document opens 20-30 parallel TLS PUTs and individual writes can
+  legitimately stall past 30s under saturation. Concurrency is now
+  bounded at 8 (`AWAITVERIFY_UPLOAD_CONCURRENCY`) so a many-fragment
+  document never melts the customer's uplink. The new
   `upload_timeout_seconds: int | None = None` kwarg on
-  `verify_document` lets customers on flaky networks tune the per-PUT
-  timeout without monkey-patching.
+  `verify_document` lets customers on flaky networks tune the
+  per-PUT timeout without monkey-patching.
 
 ### Added
 
-- `AWAITVERIFY_UPLOAD_TIMEOUT_SECONDS` and
-  `AWAITVERIFY_UPLOAD_CONCURRENCY` in `awaithumans.utils.constants`.
+- **`AzureDIExtraction` runs end-to-end.** Previously raised
+  `ProviderNotSupportedError`. Calls Azure Document Intelligence's
+  analyze endpoint (default model `prebuilt-layout`) and pipes the
+  Markdown layout output through the configured structuring step.
+  Pair with `OpenAIStructuring` or `AzureOpenAIStructuring`
+  depending on which OpenAI deployment your policy allows.
+- **`AzureOpenAIStructuring` runs end-to-end.** Previously raised
+  `ProviderNotSupportedError`. Text-only Responses-API call against
+  an Azure deployment. Lets OCR pipelines (Azure DI today, future
+  Docling and PaddleOCR) close the loop using Azure rather than
+  OpenAI direct.
+- **Gemini verifier default bumped to `gemini-2.5-flash`** (was
+  `gemini-2.0-flash`, which Google has decommissioned).
+- **`AWAITVERIFY_UPLOAD_TIMEOUT_SECONDS` and
+  `AWAITVERIFY_UPLOAD_CONCURRENCY`** in `awaithumans.utils.constants`.
   The two upload tuning knobs are now named constants rather than
   magic numbers.
+- **Env-gated provider smoke tests.**
+  `tests/awaitverify/test_extraction_smoke.py` and
+  `tests/tasks/test_verifier_smoke.py` hit real vendor APIs when the
+  matching `*_API_KEY` env vars are present and skip otherwise.
+  Catches SDK-shape regressions (the Reducto fix above started as
+  one of these) before they hit a customer demo.
 
 ---
 

--- a/packages/python/awaithumans/__init__.py
+++ b/packages/python/awaithumans/__init__.py
@@ -41,7 +41,7 @@ Supported document formats:
 
 from __future__ import annotations
 
-__version__ = "0.1.9"
+__version__ = "0.1.10"
 
 from awaithumans.awaitverify.types import ManagedAssignment, Priority
 from awaithumans.client import await_human, await_human_sync

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -20,7 +20,7 @@ packages = ["awaithumans"]
 
 [project]
 name = "awaithumans"
-version = "0.1.9"
+version = "0.1.10"
 description = "HITL infrastructure for AI agents. Your agent calls await_human(), a human reviews via Slack/email/dashboard, agent resumes with a typed response."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- Bumps `awaithumans` to **v0.1.10**. Combined release rolling up #181 (managed_url default + slow-uplink upload tuning) and #182 (OpenAI Responses API migration + Azure DI + Reducto v3 + Gemini schema fix). 0.1.9 was source-bumped for #181 but never published to PyPI; its fixes are folded into 0.1.10.

## Bumps

- `packages/python/pyproject.toml`: `0.1.9` → `0.1.10`
- `packages/python/awaithumans/__init__.py`: `__version__` `0.1.9` → `0.1.10`
- `CHANGELOG.md`: 0.1.9 entry folded into a new 0.1.10 entry covering both PRs

## Test plan

- [x] Wheel + sdist build cleanly via `uv build`
- [x] Clean-venv install + import sanity check (`import awaithumans; awaithumans.__version__` => `0.1.10`)
- [x] Targeted regression suite green (`pytest tests/awaitverify/ tests/tasks/`: 123 passed, 9 skipped)
- [x] Live smoke matrix 12/12 against real vendor APIs (OpenAI gpt-4o-2024-11-20, Azure OpenAI gpt-5.4, Anthropic claude-sonnet-4-5, Reducto v3, Azure DI prebuilt-layout, Gemini gemini-2.5-flash)
- [ ] PyPI upload via `twine upload dist/*` after merge
- [ ] Tag `v0.1.10` and push

🤖 Generated with [Claude Code](https://claude.com/claude-code)