### PR TITLE
ci: auto-deploy main to Azure Container Apps after image push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -80,3 +80,72 @@ jobs:
           # Cross-run cache — speeds up subsequent builds a lot.
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  deploy-container-app:
+    name: Deploy to Azure Container Apps
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    # Only auto-deploy on pushes to main and version tags. Manual
+    # workflow_dispatch runs still skip deploy unless the same
+    # condition is met, so an opt-in rebuild doesn't punt prod by
+    # accident.
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+    steps:
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Resolve image tag to deploy
+        id: tag
+        # On a push to main → deploy `:main`. On a tag push → deploy
+        # the matching `:vX.Y.Z` so the running revision is pinned to
+        # the released image, not a moving `:latest`. Tag pushes also
+        # rebuild `:main` (because the tag commit is on main), but the
+        # tag deploy happens after and wins.
+        #
+        # Security: we strictly validate the resolved tag against
+        # `^[a-zA-Z0-9._-]+$` before exporting it. Even though only
+        # repo-writers can push tags, this prevents a maliciously
+        # named tag from injecting shell metacharacters into the
+        # later `az containerapp update --image ...:<tag>` call. Any
+        # mismatch fails the job loudly instead of running attacker
+        # input.
+        env:
+          GITHUB_REF_ENV: ${{ github.ref }}
+        run: |
+          if [[ "${GITHUB_REF_ENV}" == refs/tags/v* ]]; then
+            tag="${GITHUB_REF_ENV##refs/tags/}"
+          else
+            tag="main"
+          fi
+          if ! [[ "${tag}" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+            echo "::error::Refusing to deploy: resolved image tag '${tag}' contains characters outside [a-zA-Z0-9._-]." >&2
+            exit 1
+          fi
+          echo "image_tag=${tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Update Container App image
+        uses: azure/CLI@v2
+        env:
+          # Pass all values through env so the inline script reads
+          # them as shell variables — no `${{ ... }}` interpolation
+          # inside the script body, no injection surface.
+          CONTAINER_APP_NAME: ${{ secrets.AZURE_CONTAINER_APP_NAME }}
+          RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
+          IMAGE_REPO: ghcr.io/${{ github.repository }}
+          IMAGE_TAG: ${{ steps.tag.outputs.image_tag }}
+        with:
+          # Pinned to a known-good az CLI. Container Apps extension is
+          # installed by default on this image, no `az extension add`
+          # needed.
+          azcliversion: 2.65.0
+          inlineScript: |
+            az containerapp update \
+              --name "$CONTAINER_APP_NAME" \
+              --resource-group "$RESOURCE_GROUP" \
+              --image "$IMAGE_REPO:$IMAGE_TAG"
+
+      - name: Azure logout
+        if: always()
+        run: az logout


### PR DESCRIPTION
## Summary

- Adds a `deploy-container-app` job to `docker.yml` that runs after `build-and-push` on pushes to `main` and `v*.*.*` tags.
- Logs into Azure via `AZURE_CREDENTIALS` service principal, then `az containerapp update --image` to roll a new revision against the freshly pushed GHCR image.
- Closes the gap that caused `/api/demo/start` to 404 in prod after PR #184 landed: the image had been built but no automation pulled it into Azure.

## Required repo secrets (one-time setup, already added)

- `AZURE_CREDENTIALS` — service principal JSON (`az ad sp create-for-rbac --sdk-auth`), scoped to the prod resource group only
- `AZURE_CONTAINER_APP_NAME` — `awaithumans-managed`
- `AZURE_RESOURCE_GROUP` — `awaithumans-prod`

## Security notes

- Resolved image tag is validated against `^[a-zA-Z0-9._-]+$` before being passed to `az`. A maliciously named tag (`v1.0";rm -rf /;"`) fails the job rather than running.
- Every value passed into the inline `az` script flows through `env:`, never through `${{ ... }}` inline interpolation. No workflow-injection surface even from repo secrets.
- `workflow_dispatch` alone does NOT trigger the deploy job — only `push` to `main` or a `v*.*.*` tag does. Opt-in rebuilds cannot accidentally punt prod.

## Test plan

- [ ] Merge this PR
- [ ] Confirm a new `Docker image` workflow run appears with two jobs: `build-and-push` and `Deploy to Azure Container Apps`
- [ ] Confirm the deploy job succeeds and a new revision shows up in the Container App
- [ ] Confirm `curl -i -X POST https://api.awaithumans.dev/api/demo/start` no longer returns 404 (will return 4xx with a real JSON body when missing form fields, which is the expected behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)