### PR TITLE
feat(sdk): await_review() no-document review entry point

### DIFF
--- a/packages/python/awaithumans/__init__.py
+++ b/packages/python/awaithumans/__init__.py
@@ -99,6 +99,25 @@ awaitVerify = verify_document  # noqa: N816
 awaitVerifySync = verify_document_sync  # noqa: N816
 
 
+async def await_review(**kwargs: Any) -> Any:
+    """Module-level shim — uses the lazy default client.
+
+    No-document text/data review: route a human judgment with just a
+    task description and a response schema, no file required.
+    """
+    return await get_default_client().await_review(**kwargs)
+
+
+def await_review_sync(**kwargs: Any) -> Any:
+    """Sync shim — uses the lazy default client."""
+    return get_default_client().await_review_sync(**kwargs)
+
+
+# camelCase aliases for the review shims
+awaitReview = await_review  # noqa: N816
+awaitReviewSync = await_review_sync  # noqa: N816
+
+
 # Module-level type re-export needed by the shim's signature above
 from typing import Any  # noqa: E402
 
@@ -117,6 +136,11 @@ __all__ = [
     "verify_document_sync",
     "awaitVerify",
     "awaitVerifySync",
+    # AwaitReview — no-document text/data review (snake + camel)
+    "await_review",
+    "await_review_sync",
+    "awaitReview",
+    "awaitReviewSync",
     # AwaitVerify types
     "Priority",
     "ManagedAssignment",

--- a/packages/python/awaithumans/awaitverify/__init__.py
+++ b/packages/python/awaithumans/awaitverify/__init__.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from awaithumans.awaitverify.client import VerifyTimeoutRangeError, verify_document
+from awaithumans.awaitverify.client import (
+    VerifyTimeoutRangeError,
+    await_review,
+    verify_document,
+)
 from awaithumans.awaitverify.errors import (
     VerifyDepsMissingError,
     VerifyDocumentArgError,
@@ -19,6 +23,7 @@ from awaithumans.awaitverify.types import ManagedAssignment, Priority
 
 __all__ = [
     "verify_document",
+    "await_review",
     "ManagedAssignment",
     "Priority",
     "fragment_document",

--- a/packages/python/awaithumans/awaitverify/_managed_client.py
+++ b/packages/python/awaithumans/awaitverify/_managed_client.py
@@ -141,7 +141,7 @@ async def create_task(
     *,
     managed_url: str,
     api_key: str | None,
-    upload_session_id: str,
+    upload_session_id: str | None,
     task_description: str,
     response_schema_json: str,
     priority: str,
@@ -150,6 +150,11 @@ async def create_task(
 ) -> CreatedTask:
     """POST /api/v1/awaitverify/tasks.
 
+    ``upload_session_id`` is None for a no-document text review — the
+    managed backend mints a placeholder session and forwards the task
+    with no fragments. Pass the id from ``create_upload_session`` for a
+    normal document verification.
+
     ``initial_response`` carries the customer's prior extraction (Flow A)
     or the SDK-run extraction output (Flow B) as a JSON payload matching
     ``response_schema``. Managed validates it server-side and forwards
@@ -157,14 +162,16 @@ async def create_task(
     pre-populated. Omit (or pass None) for pure-human review.
     """
     body: dict[str, Any] = {
-        "upload_session_id": upload_session_id,
         "task_description": task_description,
         "response_schema_json": response_schema_json,
         "priority": priority,
     }
-    # Only include task_metadata / initial_response when set so the
-    # managed backend's schema validation doesn't see an ambiguous
-    # explicit null where "omitted" is the correct signal.
+    # Only include upload_session_id / task_metadata / initial_response
+    # when set so the managed backend's schema validation doesn't see an
+    # ambiguous explicit null where "omitted" is the correct signal.
+    # Omitting upload_session_id selects the no-document path.
+    if upload_session_id is not None:
+        body["upload_session_id"] = upload_session_id
     if task_metadata:
         body["task_metadata"] = task_metadata
     if initial_response is not None:

--- a/packages/python/awaithumans/awaitverify/client.py
+++ b/packages/python/awaithumans/awaitverify/client.py
@@ -345,39 +345,128 @@ async def verify_document(
         resolved_timeout,
     )
 
-    # ── 5. Poll until terminal ──────────────────────────────────────
+    # ── 5 + 6. Poll until terminal, validate, return ───────────────
+    return await _await_terminal_and_validate(
+        client=client,
+        task_id=task.task_id,
+        resolved_timeout=resolved_timeout,
+        response_schema=response_schema,
+    )
+
+
+async def await_review(
+    *,
+    client: AwaitHumans | None = None,
+    task_description: str,
+    response_schema: type[T],
+    task_metadata: dict[str, str] | None = None,
+    priority: Priority | str | None = None,
+    timeout_seconds: int | None = None,
+) -> T:
+    """Route a no-document decision to a human reviewer and await the result.
+
+    The text-review sibling of ``verify_document``: no file is uploaded.
+    The reviewer sees ``task_description`` (the instruction) plus any
+    ``task_metadata`` (free-form context/data shown verbatim in Slack
+    and the dashboard) and fills the typed form derived from
+    ``response_schema``. Billed as one standard page, the same as a
+    one-page document verification.
+
+    Use this when an agent needs a human judgment on text or structured
+    data rather than a document — an approval, a classification, a
+    free-text answer.
+
+    Args:
+        client: AwaitHumans client. If None, uses the lazy default
+            (which reads AWAITHUMANS_API_KEY / AWAITHUMANS_MANAGED_URL
+            from environment).
+        task_description: Plain-English instruction the reviewer sees.
+            Supports multi-paragraph prose — the dashboard renders it
+            as Markdown.
+        response_schema: Pydantic model the result is validated against.
+        task_metadata: Free-form key-value context shown to the human
+            verbatim in Slack and the dashboard (e.g. the data to judge:
+            ``{"customer": "Acme", "amount": "$4,000"}``). Keys/values
+            are strings; nested structures are rejected by the backend.
+        priority: "standard" (base rate) or "high" (Express SLA, 2x
+            rate). Defaults to standard.
+        timeout_seconds: Server-side task lifetime. Min 24h, max 30 days.
+            Defaults to 48h.
+    """
+    if client is None:
+        from awaithumans.instance import get_default_client  # noqa: PLC0415
+
+        client = get_default_client()
+
+    resolved_timeout = _resolve_timeout(timeout_seconds)
+    resolved_priority = _resolve_priority(priority)
+    logger.info("AwaitReview: using managed_url=%s", client.managed_url)
+
+    # No document: skip upload/fragment/encrypt entirely. Create the
+    # task with no upload_session_id — the managed backend mints a
+    # placeholder session and forwards zero fragments.
+    response_schema_json = json.dumps(response_schema.model_json_schema())
+    task = await _managed_create_task(
+        managed_url=client.managed_url,
+        api_key=client.api_key,
+        upload_session_id=None,
+        task_description=task_description,
+        response_schema_json=response_schema_json,
+        priority=resolved_priority.value,
+        task_metadata=task_metadata,
+        initial_response=None,
+    )
+    logger.info("AwaitReview task created: id=%s (timeout=%ds)", task.task_id, resolved_timeout)
+
+    return await _await_terminal_and_validate(
+        client=client,
+        task_id=task.task_id,
+        resolved_timeout=resolved_timeout,
+        response_schema=response_schema,
+    )
+
+
+async def _await_terminal_and_validate(
+    *,
+    client: AwaitHumans,
+    task_id: str,
+    resolved_timeout: int,
+    response_schema: type[T],
+) -> T:
+    """Long-poll a managed task to a terminal state, then validate the
+    reviewer's response against ``response_schema``. Shared by
+    ``verify_document`` and ``await_review``."""
     deadline = asyncio.get_event_loop().time() + resolved_timeout
     while True:
         polled = await _managed_poll_task(
             managed_url=client.managed_url,
             api_key=client.api_key,
-            task_id=task.task_id,
+            task_id=task_id,
             timeout_seconds=_POLL_STEP_SECONDS,
         )
         if polled.status == "completed":
             break
         if polled.status in ("timed_out", "cancelled"):
-            raise VerifyTaskNonTerminalError(task.task_id, polled.status)
+            raise VerifyTaskNonTerminalError(task_id, polled.status)
         # status == "awaiting_review" → loop
         if asyncio.get_event_loop().time() >= deadline:
-            raise VerifyTaskTimeoutError(task.task_id, resolved_timeout)
+            raise VerifyTaskTimeoutError(task_id, resolved_timeout)
 
     if polled.response_json is None:
         raise VerifyError(
             code="VERIFY_TASK_COMPLETED_WITHOUT_RESPONSE",
-            message=f"Task {task.task_id} is completed but has no response body.",
+            message=f"Task {task_id} is completed but has no response body.",
             hint="This indicates a managed backend bug. Please file an issue.",
             docs_url="https://docs.awaithumans.dev/awaitverify/errors",
         )
 
-    # ── 6. Validate against response_schema and return ──────────────
     try:
         parsed = json.loads(polled.response_json)
         return response_schema.model_validate(parsed)
     except Exception as exc:
         raise VerifyError(
             code="VERIFY_RESPONSE_VALIDATION_FAILED",
-            message=f"Reviewer response for task {task.task_id} failed schema validation.",
+            message=f"Reviewer response for task {task_id} failed schema validation.",
             hint=(
                 f"Validation error: {exc}\n\n"
                 "The reviewer's submission did not match response_schema. "

--- a/packages/python/awaithumans/instance.py
+++ b/packages/python/awaithumans/instance.py
@@ -184,6 +184,36 @@ class AwaitHumans:
     def verify_document_sync(self, **kwargs: Any) -> Any:
         return asyncio.run(self.verify_document(**kwargs))
 
+    async def await_review(
+        self,
+        *,
+        task_description: str,
+        response_schema: type[BaseModel],
+        task_metadata: dict[str, str] | None = None,
+        priority: Priority | str | None = None,
+        timeout_seconds: int | None = None,
+    ) -> Any:
+        """Route a no-document text/data decision to a human reviewer.
+
+        See the module-level `await_review` for the full argument
+        reference. Billed as one standard page.
+        """
+        from awaithumans.awaitverify.client import (  # noqa: PLC0415
+            await_review as _review,
+        )
+
+        return await _review(
+            client=self,
+            task_description=task_description,
+            response_schema=response_schema,
+            task_metadata=task_metadata,
+            priority=priority,
+            timeout_seconds=timeout_seconds,
+        )
+
+    def await_review_sync(self, **kwargs: Any) -> Any:
+        return asyncio.run(self.await_review(**kwargs))
+
     # ── camelCase aliases (Pillar 12 rev 3 dual-naming) ─────────────
 
     async def awaitHuman(self, **kwargs: Any) -> Any:  # noqa: N802
@@ -197,6 +227,12 @@ class AwaitHumans:
 
     def awaitVerifySync(self, **kwargs: Any) -> Any:  # noqa: N802
         return self.verify_document_sync(**kwargs)
+
+    async def awaitReview(self, **kwargs: Any) -> Any:  # noqa: N802
+        return await self.await_review(**kwargs)
+
+    def awaitReviewSync(self, **kwargs: Any) -> Any:  # noqa: N802
+        return self.await_review_sync(**kwargs)
 
 
 # ── Module-level default client (lazy) ──────────────────────────────

--- a/packages/python/tests/awaitverify/test_await_review.py
+++ b/packages/python/tests/awaitverify/test_await_review.py
@@ -1,0 +1,151 @@
+"""Tests for await_review — the no-document text/data review entry point.
+
+await_review skips the upload/fragment/encrypt path entirely: it creates
+a managed task with no upload_session_id and polls for the reviewer's
+typed response. These tests stub the two managed-client calls it uses
+(create_task + poll) so the loop runs without a backend.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from awaithumans.awaitverify import client as client_mod
+from awaithumans.instance import AwaitHumans
+
+
+class _Decision(BaseModel):
+    approved: bool
+    reason: str | None = None
+
+
+def _stub_review_calls(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    completed_response: dict[str, Any] | None = None,
+    completed_status: str = "completed",
+) -> dict[str, Any]:
+    """Stub create_task + poll. Also stub the upload helpers to FAIL so
+    a regression that reintroduces the document path is caught."""
+    captured: dict[str, Any] = {"task_request": None, "polls": 0}
+
+    async def fail_upload_session(**_: Any) -> Any:
+        raise AssertionError("await_review must not create an upload session")
+
+    async def fail_upload_fragment(**_: Any) -> Any:
+        raise AssertionError("await_review must not upload fragments")
+
+    async def fake_create_task(
+        *,
+        managed_url: str,
+        api_key: str | None,
+        upload_session_id: str | None,
+        task_description: str,
+        response_schema_json: str,
+        priority: str,
+        task_metadata: dict[str, str] | None = None,
+        initial_response: dict[str, Any] | None = None,
+    ) -> Any:
+        from awaithumans.awaitverify._managed_client import CreatedTask
+
+        captured["task_request"] = {
+            "upload_session_id": upload_session_id,
+            "task_description": task_description,
+            "response_schema_json": response_schema_json,
+            "priority": priority,
+            "task_metadata": task_metadata,
+            "initial_response": initial_response,
+        }
+        # The managed backend returns the placeholder session id.
+        return CreatedTask(
+            task_id="task-id-fake",
+            upload_session_id="placeholder-sess",
+            status="awaiting_review",
+        )
+
+    async def fake_poll_task(
+        *, managed_url: str, api_key: str | None, task_id: str, timeout_seconds: int
+    ) -> Any:
+        from awaithumans.awaitverify._managed_client import PolledTask
+
+        captured["polls"] += 1
+        response_json = (
+            json.dumps(completed_response)
+            if completed_response is not None and completed_status == "completed"
+            else None
+        )
+        return PolledTask(task_id=task_id, status=completed_status, response_json=response_json)
+
+    monkeypatch.setattr(client_mod, "_managed_create_upload_session", fail_upload_session)
+    monkeypatch.setattr(client_mod, "_managed_upload_fragment", fail_upload_fragment)
+    monkeypatch.setattr(client_mod, "_managed_create_task", fake_create_task)
+    monkeypatch.setattr(client_mod, "_managed_poll_task", fake_poll_task)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_await_review_creates_task_with_no_upload_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _stub_review_calls(
+        monkeypatch, completed_response={"approved": True, "reason": "looks fine"}
+    )
+    client = AwaitHumans(api_key="ah_sk_test", managed_url="http://localhost:8000")
+
+    result = await client.await_review(
+        task_description="Approve this $4,000 refund?",
+        response_schema=_Decision,
+        task_metadata={"customer": "Acme", "amount": "$4,000"},
+    )
+
+    # No document: the task was created with no upload session.
+    assert captured["task_request"]["upload_session_id"] is None
+    # The instruction + context flowed through.
+    assert captured["task_request"]["task_description"] == "Approve this $4,000 refund?"
+    assert captured["task_request"]["task_metadata"] == {
+        "customer": "Acme",
+        "amount": "$4,000",
+    }
+    # No prefilled response on a pure review.
+    assert captured["task_request"]["initial_response"] is None
+    # The reviewer's typed response is validated against the schema.
+    assert isinstance(result, _Decision)
+    assert result.approved is True
+    assert result.reason == "looks fine"
+
+
+@pytest.mark.asyncio
+async def test_await_review_module_shim_uses_default_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import awaithumans
+
+    awaithumans.set_default_client(
+        AwaitHumans(api_key="ah_sk_default", managed_url="http://localhost:8000")
+    )
+    captured = _stub_review_calls(monkeypatch, completed_response={"approved": False})
+
+    result = await awaithumans.await_review(
+        task_description="Is this spam?", response_schema=_Decision
+    )
+
+    assert captured["task_request"]["upload_session_id"] is None
+    assert isinstance(result, _Decision)
+    assert result.approved is False
+
+
+@pytest.mark.asyncio
+async def test_await_review_propagates_timed_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from awaithumans.awaitverify.client import VerifyTaskNonTerminalError
+
+    _stub_review_calls(monkeypatch, completed_status="timed_out")
+    client = AwaitHumans(api_key="ah_sk_test")
+
+    with pytest.raises(VerifyTaskNonTerminalError):
+        await client.await_review(task_description="Approve?", response_schema=_Decision)


### PR DESCRIPTION
Adds `await_review()`, the no-document sibling of `verify_document()`, so an agent can route a pure text/data decision to a human reviewer with no file.

```python
from awaithumans import await_review
from pydantic import BaseModel

class Decision(BaseModel):
    approved: bool
    reason: str | None = None

result = await await_review(
    task_description="Approve this $4,000 refund? Yes/No + reason.",
    response_schema=Decision,
    task_metadata={"customer": "Acme", "amount": "$4,000"},
)
```

### What changes
- `_managed_client.create_task`: `upload_session_id` is now optional and omitted from the request body when None, which selects the backend's no-document path (mints a placeholder session, zero fragments, billed as one standard page).
- `client.py`: new `await_review()` that skips upload/fragment/encrypt entirely and creates the task with no upload session. The poll-until-terminal + schema-validate loop is extracted into `_await_terminal_and_validate`, now shared by `verify_document` and `await_review` (no behaviour change to `verify_document`).
- Surfaced consistently: `client.await_review` / `await_review_sync`, the `awaithumans.awaitverify` package, and the top-level `awaithumans.await_review`, each with the camelCase aliases used elsewhere.

### Tests
`tests/awaitverify/test_await_review.py` (3): asserts the task is created with no upload session, that the description + metadata flow through, that the typed response is validated, and that the upload helpers are never called (a regression guard against reintroducing the document path). The existing 30-test client suite still passes after the refactor. Ruff + mypy clean.

### Depends on
Backend no-document support (awaithumans-managed#16). Until that deploys, `await_review` calls will 422 against the live backend; the SDK contract and tests are independent of deploy timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
