### PR TITLE
fix(dashboard): render long task descriptions as prose, not a giant heading

### DIFF
--- a/packages/dashboard/components/markdown.test.ts
+++ b/packages/dashboard/components/markdown.test.ts
@@ -34,4 +34,21 @@ describe("looksRich", () => {
 		expect(looksRich("Verify John's ID")).toBe(false);
 		expect(looksRich("Approve the $4,000 refund (urgent)")).toBe(false);
 	});
+
+	it("treats a long single-line description as rich (prose, not a giant heading)", () => {
+		const longPlain =
+			"Approve this refund request from the customer for their recent " +
+			"order, confirm the item was returned to the warehouse, and check " +
+			"there are no prior refunds on the account before deciding";
+		expect(longPlain.length).toBeGreaterThan(120);
+		expect(looksRich(longPlain)).toBe(true);
+	});
+
+	it("keeps a normal-length one-line title as a heading", () => {
+		// ~110 chars: a long but reasonable headline still renders as a heading.
+		const headline =
+			"Approve the $4,000 refund for order 4821 and add a short reason for the decision either way please";
+		expect(headline.length).toBeLessThanOrEqual(120);
+		expect(looksRich(headline)).toBe(false);
+	});
 });

--- a/packages/dashboard/components/markdown.tsx
+++ b/packages/dashboard/components/markdown.tsx
@@ -87,13 +87,21 @@ export function Markdown({
 	);
 }
 
+// A single-line title past this length is really a brief, not a
+// heading. Rendering it as a giant <h1> wraps into a wall of bold text,
+// so we route it through prose rendering instead. Tuned so a normal
+// one-line task title (a dozen-ish words) stays a heading.
+const TITLE_PROSE_LENGTH_THRESHOLD = 120;
+
 /**
  * Heuristic: does this string benefit from Markdown/prose rendering?
- * True when it spans multiple lines or contains common Markdown syntax.
- * Short single-line titles stay as a plain heading so existing document
- * tasks look unchanged.
+ * True when it spans multiple lines, contains common Markdown syntax,
+ * or is long enough that a heading would look messy. Short single-line
+ * titles stay as a plain heading so existing document tasks look
+ * unchanged.
  */
 export function looksRich(text: string): boolean {
+	if (text.length > TITLE_PROSE_LENGTH_THRESHOLD) return true;
 	if (text.includes("\n")) return true;
 	return /(\*\*|__|^#{1,6}\s|^[-*+]\s|\[[^\]]+\]\([^)]+\)|`)/m.test(text);
 }


### PR DESCRIPTION
Renders a long task description as prose instead of a giant heading.

### Problem
For no-document reviews the task description carries the full instruction, often a long single line. With no Markdown or newline in it, it fell through to a plain `text-2xl` `<h1>` with no size cap, so a long one wrapped into a wall of bold text.

### Fix
Extend `looksRich` to also return true when the title exceeds 120 chars, routing long descriptions through the existing prose renderer. A normal one-line title (≤120 chars, no Markdown) still renders as a heading, so document tasks are unchanged.

Frontend only: no API, schema, or DB change. The title string arrives from the API unchanged; this only changes how it's displayed.

### Tests
`components/markdown.test.ts`: a 185-char description is treated as rich; a 98-char headline stays a heading. Full dashboard suite passes; `tsc` clean; Biome clean.
